### PR TITLE
Extract EventFilter from EventQuery for clean separation of matching vs traversal concerns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,19 +74,26 @@ mvn clean install -DskipTests
 - Core to the Dynamic Consistency Boundary pattern
 - Created via `Tags.of("key", "value")` or `Tags.of(Tag.of("key", "value"))`
 
+**EventFilter:**
+- Pure matching criteria: event types, tags, and an optional "until" temporal boundary
+- Does not carry traversal semantics (direction, limit) — those belong to `EventQuery`
+- Can match all (`EventFilter.matchAll()`), none (`EventFilter.matchNone()`), or specific criteria
+- Created via `EventFilter.forEvents(eventTypesFilter, tags)`
+- Used by `AppendCriteria` for optimistic locking (where direction/limit are irrelevant)
+
 **EventQuery:**
-- Defines which events to retrieve from storage
+- Wraps an `EventFilter` together with traversal semantics (direction and limit)
+- Use `EventQuery.filter()` to extract the pure matching criteria
 - Can match all (`EventQuery.matchAll()`), none (`EventQuery.matchNone()`), or specific criteria
-- Uses `EventTypesFilter` to filter by event types and `Tags` to filter by tags
-- Supports an optional "until" reference to query up to a specific point in history
+- Supports backward direction (`.backwards()`) and result limits (`.limit(n)`)
 - Created via `EventQuery.forEvents(eventTypesFilter, tags)`
 
 **AppendCriteria:**
 - Controls optimistic locking when appending events
-- Contains an `EventQuery` and an optional `EventReference` for the expected last event
+- Contains an `EventFilter` and an optional `EventReference` for the expected last event
 - If new matching events are found after the reference, append fails with `OptimisticLockingException`
 - Use `AppendCriteria.none()` for simple appends without locking
-- Use `AppendCriteria.of(eventQuery, Optional.of(reference))` for conditional appends
+- Use `AppendCriteria.of(eventQuery, reference)` or `AppendCriteria.of(eventFilter, reference)` for conditional appends
 
 **Projection:**
 - Combines an `EventQuery` with an `EventHandler`
@@ -150,15 +157,12 @@ Stream<Event<CustomerEvent>> filtered = stream.query(
 );
 
 // 6. Conditional append with optimistic locking
-List<Event<CustomerEvent>> existingEvents = stream.query(
-    EventQuery.forEvents(EventTypesFilter.any(), Tags.of("customer", "123"))).toList();
+EventQuery customerQuery = EventQuery.forEvents(EventTypesFilter.any(), Tags.of("customer", "123"));
+List<Event<CustomerEvent>> existingEvents = stream.query(customerQuery).toList();
 EventReference lastRef = existingEvents.getLast().reference();
 
 stream.append(
-    AppendCriteria.of(
-        EventQuery.forEvents(EventTypesFilter.any(), Tags.of("customer", "123")),
-        Optional.of(lastRef)
-    ),
+    AppendCriteria.of(customerQuery, lastRef),
     Event.of(new CustomerNameChanged("Jane"), Tags.of("customer", "123"))
 );
 ```
@@ -213,8 +217,8 @@ This implementation is fully compliant with the [DCB Specification](https://dcb.
 The key insight of DCB is that business decisions are based on querying relevant historical events, and new events should only be stored if no new relevant facts have emerged since the decision was made. This is achieved through:
 1. Query events with an `EventQuery` to make a decision
 2. Note the reference of the last relevant event
-3. Append new events with `AppendCriteria` containing the same query and last reference
-4. If new events matching the query exist after the reference, the append fails
+3. Append new events with `AppendCriteria` containing the query's `EventFilter` and last reference
+4. If new events matching the filter exist after the reference, the append fails
 
 ## PostgreSQL Specific Notes
 

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventFilter.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventFilter.java
@@ -1,0 +1,230 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.query;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Pure matching criteria for selecting events from the event store.
+ *
+ * <p>EventFilter encapsulates the predicate logic for event matching: which event types and tags
+ * to match, and an optional temporal boundary ({@code until}) that limits how far into the event
+ * history to look. It does <em>not</em> carry traversal semantics such as direction or limit —
+ * those belong to {@link EventQuery}, which wraps an EventFilter.
+ *
+ * <p>EventFilter is the correct type to use wherever only matching semantics are needed,
+ * most notably in {@link org.sliceworkz.eventstore.stream.AppendCriteria} for optimistic locking,
+ * where direction and limit are irrelevant.
+ *
+ * <p><strong>Match Semantics:</strong>
+ * <ul>
+ *   <li><strong>Match All:</strong> When the items list is null, any event matches</li>
+ *   <li><strong>Match None:</strong> When the items list is empty, no event matches</li>
+ *   <li><strong>Match Specific:</strong> When the items list contains one or more {@link EventQueryItem}s,
+ *       events matching any item will match (OR condition)</li>
+ * </ul>
+ *
+ * @param items the list of query items to match against (null for match-all, empty for match-none, populated for specific criteria)
+ * @param until the reference to match up to (null for no boundary, or a specific reference to stop at that point in history)
+ *
+ * @see EventQuery
+ * @see EventQueryItem
+ * @see org.sliceworkz.eventstore.stream.AppendCriteria
+ */
+public record EventFilter ( List<EventQueryItem> items, EventReference until ) {
+
+	/**
+	 * Tests whether the given event matches this filter.
+	 *
+	 * @param event the event to test
+	 * @return true if the event matches this filter, false otherwise
+	 */
+	public boolean matches ( Event<?> event ) {
+		return matches(event.type(), event.tags(), event.reference());
+	}
+
+	/**
+	 * Tests whether the given stored event matches this filter.
+	 *
+	 * @param event the stored event to test
+	 * @return true if the stored event matches this filter, false otherwise
+	 */
+	public boolean matches ( StoredEvent event ) {
+		return matches(event.type(), event.tags(), event.reference());
+	}
+
+	/**
+	 * Tests whether an event with the given attributes matches this filter.
+	 * An event matches if:
+	 * <ul>
+	 *   <li>Its reference is before or at the "until" reference (if specified)</li>
+	 *   <li>It matches at least one of the query items (or all items if match-all)</li>
+	 * </ul>
+	 *
+	 * @param eventType the type of the event
+	 * @param tags the tags of the event
+	 * @param reference the reference of the event
+	 * @return true if the event matches this filter, false otherwise
+	 */
+	public boolean matches ( EventType eventType, Tags tags, EventReference reference ) {
+		boolean match = true;
+		if ( until == null || !reference.happenedAfter(until) ) {
+			if ( items != null ) {
+				if ( !items.isEmpty() ) { // null items = all match, empty items is none match
+					// if any query item matches the event, we keep it
+					match = items.stream().filter(i->i.matches(eventType, tags)).findAny().isPresent();
+				} else {
+					match = false; // no match since we have items (empty collection) but no criteria to adhere to
+				}
+			}
+		} else {
+			match = false;
+		}
+		return match;
+	}
+
+	/**
+	 * Checks if this filter is a match-none filter (will match no events).
+	 *
+	 * @return true if this filter has an empty items list (match-none), false otherwise
+	 */
+	@JsonIgnore
+	public boolean isMatchNone ( ) {
+		return items != null && items.isEmpty();
+	}
+
+	/**
+	 * Checks if this filter is a match-all filter (will match all events).
+	 *
+	 * @return true if this filter has null items (match-all), false otherwise
+	 */
+	@JsonIgnore
+	public boolean isMatchAll ( ) {
+		return items == null;
+	}
+
+	/**
+	 * Creates a new EventFilter with the specified "until" reference.
+	 * The resulting filter will only match events up to and including the specified reference.
+	 *
+	 * @param until the reference to match up to (events after this reference will not match)
+	 * @return a new EventFilter with the "until" reference set
+	 */
+	public EventFilter until ( EventReference until ) {
+		return new EventFilter(items, until);
+	}
+
+	/**
+	 * Creates a new EventFilter with the "until" reference set to the earlier of the current "until" and the new reference.
+	 * If the new reference is earlier than the current "until" (or if no "until" is set), the new reference is used.
+	 * Otherwise, the current "until" reference is retained.
+	 *
+	 * @param newUntil the new reference to potentially use as the "until" boundary
+	 * @return a new EventFilter with the "until" reference potentially updated
+	 */
+	public EventFilter untilIfEarlier ( EventReference newUntil ) {
+		if ( newUntil != null ) {
+			if ( this.until == null ) {
+				return new EventFilter(items, newUntil);
+			} else if ( newUntil.happenedBefore(until) ) {
+				return new EventFilter(items, newUntil);
+			} else {
+				return this;
+			}
+		} else {
+			return this;
+		}
+	}
+
+	/**
+	 * Creates a new EventFilter that combines the criteria of this filter with another (UNION operation).
+	 * The resulting filter will match events that match either this filter or the other filter.
+	 *
+	 * <p>Both filters must have the same "until" reference (or both must be unset).
+	 *
+	 * @param other the other filter to combine with this one
+	 * @return a new EventFilter representing the union of both filters
+	 * @throws IllegalArgumentException if the "until" references are incompatible
+	 */
+	public EventFilter combineWith ( EventFilter other ) {
+		List<EventQueryItem> combinedQueryItems = Stream.concat(this.items==null?Stream.empty():this.items.stream(), other.items==null?Stream.empty():other.items.stream()).toList();
+		EventReference combinedUntil = null;
+		if ( this.until == null && other.until == null ) {
+			combinedUntil = null;
+		} else if ( this.until == null || other.until == null) {
+			throw new IllegalArgumentException("can't combine two EventFilter that don't share the same until value (one was not set)");
+		} else if ( this.until.equals(other.until)) {
+			combinedUntil = this.until;
+		} else {
+			throw new IllegalArgumentException("can't combine two EventFilter that don't share the same until value (both different values)");
+		}
+
+		return new EventFilter(combinedQueryItems, combinedUntil);
+	}
+
+	/**
+	 * Creates a match-none filter that will match no events.
+	 *
+	 * @return an EventFilter that matches no events
+	 */
+	public static EventFilter matchNone ( ) {
+		return new EventFilter(new ArrayList<>(), null);
+	}
+
+	/**
+	 * Creates a match-all filter that will match all events.
+	 *
+	 * @return an EventFilter that matches all events
+	 */
+	public static EventFilter matchAll ( ) {
+		return new EventFilter(null, null);
+	}
+
+	/**
+	 * Creates a filter for events matching the specified event types and tags.
+	 *
+	 * @param eventTypes the filter specifying which event types to match
+	 * @param tags the tags that events must contain (all tags must be present)
+	 * @return an EventFilter matching the specified criteria
+	 */
+	public static EventFilter forEvents ( EventTypesFilter eventTypes, Tags tags ) {
+		return forEvents(new EventQueryItem(eventTypes, tags));
+	}
+
+	/**
+	 * Creates a filter from a single query item.
+	 *
+	 * @param queryItem the query item defining the match criteria
+	 * @return an EventFilter containing the single query item
+	 */
+	public static EventFilter forEvents ( EventQueryItem queryItem ) {
+		return new EventFilter(Collections.singletonList(queryItem), null);
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventFilter.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventFilter.java
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * <ul>
  *   <li><strong>Match All:</strong> When the items list is null, any event matches</li>
  *   <li><strong>Match None:</strong> When the items list is empty, no event matches</li>
- *   <li><strong>Match Specific:</strong> When the items list contains one or more {@link EventQueryItem}s,
+ *   <li><strong>Match Specific:</strong> When the items list contains one or more {@link EventFilterItem}s,
  *       events matching any item will match (OR condition)</li>
  * </ul>
  *
@@ -54,10 +54,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @param until the reference to match up to (null for no boundary, or a specific reference to stop at that point in history)
  *
  * @see EventQuery
- * @see EventQueryItem
+ * @see EventFilterItem
  * @see org.sliceworkz.eventstore.stream.AppendCriteria
  */
-public record EventFilter ( List<EventQueryItem> items, EventReference until ) {
+public record EventFilter ( List<EventFilterItem> items, EventReference until ) {
 
 	/**
 	 * Tests whether the given event matches this filter.
@@ -173,7 +173,7 @@ public record EventFilter ( List<EventQueryItem> items, EventReference until ) {
 	 * @throws IllegalArgumentException if the "until" references are incompatible
 	 */
 	public EventFilter combineWith ( EventFilter other ) {
-		List<EventQueryItem> combinedQueryItems = Stream.concat(this.items==null?Stream.empty():this.items.stream(), other.items==null?Stream.empty():other.items.stream()).toList();
+		List<EventFilterItem> combinedQueryItems = Stream.concat(this.items==null?Stream.empty():this.items.stream(), other.items==null?Stream.empty():other.items.stream()).toList();
 		EventReference combinedUntil = null;
 		if ( this.until == null && other.until == null ) {
 			combinedUntil = null;
@@ -214,7 +214,7 @@ public record EventFilter ( List<EventQueryItem> items, EventReference until ) {
 	 * @return an EventFilter matching the specified criteria
 	 */
 	public static EventFilter forEvents ( EventTypesFilter eventTypes, Tags tags ) {
-		return forEvents(new EventQueryItem(eventTypes, tags));
+		return forEvents(new EventFilterItem(eventTypes, tags));
 	}
 
 	/**
@@ -223,7 +223,7 @@ public record EventFilter ( List<EventQueryItem> items, EventReference until ) {
 	 * @param queryItem the query item defining the match criteria
 	 * @return an EventFilter containing the single query item
 	 */
-	public static EventFilter forEvents ( EventQueryItem queryItem ) {
+	public static EventFilter forEvents ( EventFilterItem queryItem ) {
 		return new EventFilter(Collections.singletonList(queryItem), null);
 	}
 

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventFilterItem.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventFilterItem.java
@@ -24,11 +24,11 @@ import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.Tags;
 
 /**
- * Part of an {@link EventQuery} that represents a single matching rule.
+ * Part of an {@link EventFilter} that represents a single matching rule.
  *
- * <p>An EventQueryItem defines a single criterion within an {@link EventQuery}.
- * When multiple EventQueryItems are present in a query, they represent an OR condition.
- * Within a single EventQueryItem, the event type filter and tags represent an AND condition.
+ * <p>An EventFilterItem defines a single criterion within an {@link EventFilter}.
+ * When multiple EventFilterItems are present in a filter, they represent an OR condition.
+ * Within a single EventFilterItem, the event type filter and tags represent an AND condition.
  *
  * <p><strong>Matching Logic:</strong>
  * <ul>
@@ -39,19 +39,19 @@ import org.sliceworkz.eventstore.events.Tags;
  * <p><strong>Usage Examples:</strong>
  * <pre>{@code
  * // Match CustomerRegistered OR CustomerUpdated events with "region=EU" tag
- * EventQueryItem item1 = new EventQueryItem(
+ * EventFilterItem item1 = new EventFilterItem(
  *     EventTypesFilter.of(CustomerRegistered.class, CustomerUpdated.class),
  *     Tags.of("region", "EU")
  * );
  *
  * // Match any event type with "customer=123" tag
- * EventQueryItem item2 = new EventQueryItem(
+ * EventFilterItem item2 = new EventFilterItem(
  *     EventTypesFilter.any(),
  *     Tags.of("customer", "123")
  * );
  *
  * // Match OrderPlaced events with multiple tags
- * EventQueryItem item3 = new EventQueryItem(
+ * EventFilterItem item3 = new EventFilterItem(
  *     EventTypesFilter.of(OrderPlaced.class),
  *     Tags.of("customer", "123", "status", "pending")
  * );
@@ -60,41 +60,41 @@ import org.sliceworkz.eventstore.events.Tags;
  * @param eventTypes the filter specifying which event types to match (events match if they are ANY of the listed types)
  * @param tags the tags that events must contain (events match if they contain ALL of the listed tags)
  *
- * @see EventQuery
+ * @see EventFilter
  * @see EventTypesFilter
  * @see Tags
  */
-public record EventQueryItem ( EventTypesFilter eventTypes, Tags tags ) {
-	
-	public EventQueryItem ( EventTypesFilter eventTypes, Tags tags ) {
+public record EventFilterItem ( EventTypesFilter eventTypes, Tags tags ) {
+
+	public EventFilterItem ( EventTypesFilter eventTypes, Tags tags ) {
 		if ( eventTypes == null ) {
-			throw new InvalidParameterException("eventTypes is required on query (can be 'any')");
+			throw new InvalidParameterException("eventTypes is required on filter (can be 'any')");
 		}
 		if ( tags == null ) {
-			throw new InvalidParameterException("tags is required on query (can by 'any')");
+			throw new InvalidParameterException("tags is required on filter (can be 'any')");
 		}
 		this.eventTypes = eventTypes;
 		this.tags = tags;
 	}
 
 	/**
-	 * Tests whether the given event matches this query item.
+	 * Tests whether the given event matches this filter item.
 	 * The event matches if its type matches the event types filter AND it contains all required tags.
 	 *
 	 * @param event the event to test
-	 * @return true if the event matches this query item, false otherwise
+	 * @return true if the event matches this filter item, false otherwise
 	 */
 	public boolean matches ( Event<?> event ) {
 		return eventTypes.matches(EventType.of(event.data())) && event.tags().containsAll(tags);
 	}
 
 	/**
-	 * Tests whether an event with the given type and tags matches this query item.
+	 * Tests whether an event with the given type and tags matches this filter item.
 	 * The event matches if its type matches the event types filter AND the tags contain all required tags.
 	 *
 	 * @param eventType the type of the event
 	 * @param eventTags the tags of the event
-	 * @return true if the event matches this query item, false otherwise
+	 * @return true if the event matches this filter item, false otherwise
 	 */
 	public boolean matches ( EventType eventType, Tags eventTags ) {
 		return eventTypes.matches(eventType) && eventTags.containsAll(tags);

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventQuery.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventQuery.java
@@ -72,7 +72,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @param limit the maximum number of events to return, defaults to no limit
  *
  * @see EventFilter
- * @see EventQueryItem
+ * @see EventFilterItem
  * @see EventTypesFilter
  * @see org.sliceworkz.eventstore.stream.AppendCriteria
  * @see Tags
@@ -98,14 +98,14 @@ public record EventQuery ( EventFilter filter, Direction direction, Limit limit 
 	/**
 	 * Convenience constructor from raw filter components.
 	 */
-	public EventQuery ( List<EventQueryItem> items, EventReference until, Direction direction, Limit limit ) {
+	public EventQuery ( List<EventFilterItem> items, EventReference until, Direction direction, Limit limit ) {
 		this(new EventFilter(items, until), direction, limit);
 	}
 
 	/**
 	 * Convenience constructor from raw filter components with default direction and limit.
 	 */
-	public EventQuery ( List<EventQueryItem> items, EventReference until ) {
+	public EventQuery ( List<EventFilterItem> items, EventReference until ) {
 		this(new EventFilter(items, until), Direction.FORWARD, Limit.none());
 	}
 
@@ -121,7 +121,7 @@ public record EventQuery ( EventFilter filter, Direction direction, Limit limit 
 	 *
 	 * @return the list of query items (null for match-all, empty for match-none)
 	 */
-	public List<EventQueryItem> items ( ) {
+	public List<EventFilterItem> items ( ) {
 		return filter.items();
 	}
 
@@ -278,7 +278,7 @@ public record EventQuery ( EventFilter filter, Direction direction, Limit limit 
 	 * @return an EventQuery matching the specified criteria
 	 */
 	public static final EventQuery forEvents ( EventTypesFilter eventTypes, Tags tags ) {
-		return forEvents(new EventQueryItem(eventTypes, tags));
+		return forEvents(new EventFilterItem(eventTypes, tags));
 	}
 
 	/**
@@ -287,7 +287,7 @@ public record EventQuery ( EventFilter filter, Direction direction, Limit limit 
 	 * @param queryItem the query item defining the match criteria
 	 * @return an EventQuery containing the single query item
 	 */
-	public static final EventQuery forEvents ( EventQueryItem queryItem ) {
+	public static final EventQuery forEvents ( EventFilterItem queryItem ) {
 		return new EventQuery(Collections.singletonList(queryItem), null);
 	}
 

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventQuery.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventQuery.java
@@ -17,10 +17,8 @@
  */
 package org.sliceworkz.eventstore.query;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.EventReference;
@@ -33,34 +31,24 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  * Dynamic Consistency Boundary (DCB) style query that allows to dynamically select the {@link Event}s that are of interest.
  *
- * <p>EventQuery is the core mechanism for selecting relevant facts from the event store.
- * It consists of a list of {@link EventQueryItem}s and an optional "until" {@link EventReference} to query up to a specific point in history.
- * Multiple {@link EventQueryItem}s represent an OR condition: if any item matches, the Event matches the overall EventQuery.
+ * <p>EventQuery wraps an {@link EventFilter} (which contains the pure matching criteria: event types, tags,
+ * and temporal boundary) together with traversal semantics (direction and limit) that control how results
+ * are returned.
  *
- * <p><strong>Match Semantics:</strong>
+ * <p>The separation between {@link EventFilter} and EventQuery is key:
  * <ul>
- *   <li><strong>Match All:</strong> When the items list is null, any {@link Event} will match the query</li>
- *   <li><strong>Match None:</strong> When the items list is empty, no {@link Event} will match the query</li>
- *   <li><strong>Match Specific:</strong> When the items list contains one or more {@link EventQueryItem}s, events matching any item will match</li>
+ *   <li>{@link EventFilter} defines <em>what</em> to match — event types, tags, and the "until" boundary</li>
+ *   <li>EventQuery adds <em>how</em> to return results — direction (forward/backward) and limit</li>
  * </ul>
  *
- * <p><strong>Direction and Limit:</strong>
- * EventQuery can optionally carry traversal semantics:
- * <ul>
- *   <li><strong>Direction:</strong> Controls whether events are returned forward (oldest first) or backward (newest first)</li>
- *   <li><strong>Limit:</strong> Restricts the maximum number of events returned</li>
- * </ul>
- * These are used by convenience query methods on {@link org.sliceworkz.eventstore.stream.EventSource} and do not affect
- * the {@link #matches(Event)} predicate. When used inside {@link org.sliceworkz.eventstore.stream.AppendCriteria} for
- * optimistic locking, direction and limit should be stripped via {@link #forLockingCheck()}.
+ * <p>When used for optimistic locking via {@link org.sliceworkz.eventstore.stream.AppendCriteria},
+ * only the {@link EventFilter} is needed (via {@link #filter()}), since direction and limit are
+ * presentation concerns that must not affect conflict detection.
  *
  * <p><strong>Usage Examples:</strong>
  * <pre>{@code
  * // Query all events
  * EventQuery allEvents = EventQuery.matchAll();
- *
- * // Query no events
- * EventQuery noEvents = EventQuery.matchNone();
  *
  * // Query specific event types with tags
  * EventQuery customerEvents = EventQuery.forEvents(
@@ -68,41 +56,28 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *     Tags.of("region", "EU")
  * );
  *
- * // Query up to a specific point in history
- * EventQuery historicalQuery = EventQuery.forEvents(
- *     EventTypesFilter.any(),
- *     Tags.of("customer", "123")
- * ).until(lastKnownReference);
- *
- * // Query backwards (newest first)
- * EventQuery backwardsQuery = EventQuery.matchAll().backwards();
- *
- * // Query the most recent event matching criteria
+ * // Query backwards (newest first) with limit
  * EventQuery mostRecent = EventQuery.forEvents(
  *     EventTypesFilter.of(CustomerRegistered.class),
  *     Tags.of("customer", "123")
  * ).backwards().limit(1);
  *
- * // Combine multiple queries (UNION)
- * EventQuery combined = query1.combineWith(query2);
+ * // Extract the filter for optimistic locking
+ * EventFilter filter = mostRecent.filter();
+ * AppendCriteria criteria = AppendCriteria.of(filter, lastRef);
  * }</pre>
  *
- * <p><strong>DCB Significance:</strong>
- * In the Dynamic Consistency Boundary pattern, EventQuery defines which events are considered "relevant facts" for a business decision.
- * When used with {@link org.sliceworkz.eventstore.stream.AppendCriteria}, it enables optimistic locking by ensuring no new relevant facts
- * have emerged since the decision was made.
- *
- * @param items the list of query items to match against (null for match-all, empty for match-none, populated for specific criteria)
- * @param until the reference to query up to (null for no limit, or a specific reference to stop at that point in history)
+ * @param filter the event filter containing matching criteria (event types, tags, and temporal boundary)
  * @param direction the traversal direction (FORWARD or BACKWARD), defaults to FORWARD
  * @param limit the maximum number of events to return, defaults to no limit
  *
+ * @see EventFilter
  * @see EventQueryItem
  * @see EventTypesFilter
  * @see org.sliceworkz.eventstore.stream.AppendCriteria
  * @see Tags
  */
-public record EventQuery ( List<EventQueryItem> items, EventReference until, Direction direction, Limit limit ) {
+public record EventQuery ( EventFilter filter, Direction direction, Limit limit ) {
 
 	/**
 	 * Defines the traversal direction for event queries.
@@ -114,20 +89,49 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 		BACKWARD
 	}
 
-	public EventQuery ( List<EventQueryItem> items, EventReference until, Direction direction, Limit limit ) {
-		// can be null, this means no criteria at all (match-all)
-		this.items = items;
-		this.until = until;
+	public EventQuery ( EventFilter filter, Direction direction, Limit limit ) {
+		this.filter = filter != null ? filter : EventFilter.matchNone();
 		this.direction = direction != null ? direction : Direction.FORWARD;
 		this.limit = limit != null ? limit : Limit.none();
 	}
 
-	public EventQuery ( List<EventQueryItem> items, EventReference until ) {
-		this(items, until, Direction.FORWARD, Limit.none());
+	/**
+	 * Convenience constructor from raw filter components.
+	 */
+	public EventQuery ( List<EventQueryItem> items, EventReference until, Direction direction, Limit limit ) {
+		this(new EventFilter(items, until), direction, limit);
 	}
 
-	public EventQuery (  ) {
-		this(new ArrayList<>(), null, Direction.FORWARD, Limit.none());
+	/**
+	 * Convenience constructor from raw filter components with default direction and limit.
+	 */
+	public EventQuery ( List<EventQueryItem> items, EventReference until ) {
+		this(new EventFilter(items, until), Direction.FORWARD, Limit.none());
+	}
+
+	/**
+	 * Creates a match-none EventQuery.
+	 */
+	public EventQuery ( ) {
+		this(EventFilter.matchNone(), Direction.FORWARD, Limit.none());
+	}
+
+	/**
+	 * Returns the list of query items from the underlying filter.
+	 *
+	 * @return the list of query items (null for match-all, empty for match-none)
+	 */
+	public List<EventQueryItem> items ( ) {
+		return filter.items();
+	}
+
+	/**
+	 * Returns the "until" reference from the underlying filter.
+	 *
+	 * @return the "until" reference, or null if no boundary is set
+	 */
+	public EventReference until ( ) {
+		return filter.until();
 	}
 
 	/**
@@ -137,7 +141,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return true if the event matches this query, false otherwise
 	 */
 	public boolean matches ( Event<?> event ) {
-		return matches(event.type(), event.tags(), event.reference());
+		return filter.matches(event);
 	}
 
 	/**
@@ -147,16 +151,11 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return true if the stored event matches this query, false otherwise
 	 */
 	public boolean matches ( StoredEvent event ) {
-		return matches(event.type(), event.tags(), event.reference());
+		return filter.matches(event);
 	}
 
 	/**
 	 * Tests whether an event with the given attributes matches this query.
-	 * An event matches if:
-	 * <ul>
-	 *   <li>Its reference is before or at the "until" reference (if specified)</li>
-	 *   <li>It matches at least one of the query items (or all items if match-all)</li>
-	 * </ul>
 	 *
 	 * @param eventType the type of the event
 	 * @param tags the tags of the event
@@ -164,20 +163,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return true if the event matches this query, false otherwise
 	 */
 	public boolean matches ( EventType eventType, Tags tags, EventReference reference ) {
-		boolean match = true;
-		if ( until == null || !reference.happenedAfter(until) ) {
-			if ( items != null ) {
-				if ( !items.isEmpty() ) { // null items = all match, empty items is none match
-					// if any query item matches the event, we keep it
-					match = items.stream().filter(i->i.matches(eventType, tags)).findAny().isPresent();
-				} else {
-					match = false; // no match since we have items (empty collection) but no criteria to adhere to
-				}
-			}
-		} else {
-			match = false;
-		}
-		return match;
+		return filter.matches(eventType, tags, reference);
 	}
 
 	/**
@@ -187,7 +173,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 */
 	@JsonIgnore
 	public boolean isMatchNone ( ) {
-		return items != null && items.isEmpty();
+		return filter.isMatchNone();
 	}
 
 	/**
@@ -197,7 +183,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 */
 	@JsonIgnore
 	public boolean isMatchAll ( ) {
-		return items == null;
+		return filter.isMatchAll();
 	}
 
 	/**
@@ -216,7 +202,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return a new EventQuery with direction set to BACKWARD
 	 */
 	public EventQuery backwards ( ) {
-		return new EventQuery(items, until, Direction.BACKWARD, limit);
+		return new EventQuery(filter, Direction.BACKWARD, limit);
 	}
 
 	/**
@@ -226,7 +212,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return a new EventQuery with the specified limit
 	 */
 	public EventQuery limit ( Limit limit ) {
-		return new EventQuery(items, until, direction, limit);
+		return new EventQuery(filter, direction, limit);
 	}
 
 	/**
@@ -236,45 +222,21 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return a new EventQuery with the specified limit
 	 */
 	public EventQuery limit ( long n ) {
-		return new EventQuery(items, until, direction, Limit.to(n));
-	}
-
-	/**
-	 * Returns a normalized copy of this query suitable for optimistic locking checks.
-	 * Strips direction and limit, keeping only the matching criteria (items and until).
-	 * This ensures that append checks always scan forward with no limit to detect all
-	 * potentially conflicting events.
-	 *
-	 * @return a new EventQuery with direction FORWARD and no limit
-	 */
-	public EventQuery forLockingCheck ( ) {
-		return new EventQuery(items, until, Direction.FORWARD, Limit.none());
+		return new EventQuery(filter, direction, Limit.to(n));
 	}
 
 	/**
 	 * Creates a new EventQuery that combines the criteria of this query with another (UNION operation).
 	 * The resulting query will match events that match either this query or the other query.
 	 *
-	 * <p>With regards to the "until" reference, direction, and limit, both queries must have the same
-	 * values (or both must be unset/default). If they differ, an IllegalArgumentException is thrown.
+	 * <p>The underlying filters are combined via {@link EventFilter#combineWith(EventFilter)}.
+	 * Direction and limit must be the same on both queries.
 	 *
 	 * @param other the other query to combine with this one
 	 * @return a new EventQuery representing the union of both queries
 	 * @throws IllegalArgumentException if the "until" references, directions, or limits are incompatible
 	 */
 	public EventQuery combineWith ( EventQuery other ) {
-		List<EventQueryItem> combinedQueryItems = Stream.concat(this.items==null?Stream.empty():this.items.stream(), other.items==null?Stream.empty():other.items.stream()).toList();
-		EventReference combinedUntil = null;
-		if ( this.until == null && other.until == null ) {
-			combinedUntil = null;
-		} else if ( this.until == null || other.until == null) {
-			throw new IllegalArgumentException("can't combine two EventQuery don't share the same until value (one was not set)");
-		} else if ( this.until.equals(other.until)) {
-			combinedUntil = this.until;
-		} else {
-			throw new IllegalArgumentException("can't combine two EventQuery that don't share the same until value (both different values)");
-		}
-
 		if ( this.direction != other.direction ) {
 			throw new IllegalArgumentException("can't combine two EventQuery with different directions");
 		}
@@ -283,7 +245,8 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 			throw new IllegalArgumentException("can't combine two EventQuery with different limits");
 		}
 
-		return new EventQuery(combinedQueryItems, combinedUntil, this.direction, this.limit);
+		EventFilter combinedFilter = this.filter.combineWith(other.filter);
+		return new EventQuery(combinedFilter, this.direction, this.limit);
 	}
 
 	/**
@@ -303,7 +266,7 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return an EventQuery that matches all events
 	 */
 	public static final EventQuery matchAll (  ) {
-		return new EventQuery(null, null);
+		return new EventQuery(EventFilter.matchAll(), Direction.FORWARD, Limit.none());
 	}
 
 	/**
@@ -336,29 +299,21 @@ public record EventQuery ( List<EventQueryItem> items, EventReference until, Dir
 	 * @return a new EventQuery with the "until" reference set
 	 */
 	public EventQuery until ( EventReference until ) {
-		return new EventQuery(items, until, direction, limit);
+		return new EventQuery(filter.until(until), direction, limit);
 	}
 
 	/**
 	 * Creates a new EventQuery with the "until" reference set to the earlier of the current "until" and the new reference.
-	 * If the new reference is earlier than the current "until" (or if no "until" is set), the new reference is used.
-	 * Otherwise, the current "until" reference is retained.
 	 *
 	 * @param newUntil the new reference to potentially use as the "until" boundary
 	 * @return a new EventQuery with the "until" reference potentially updated
 	 */
 	public EventQuery untilIfEarlier ( EventReference newUntil ) {
-		if ( newUntil != null  ) {
-			if (this.until == null ) { // we don't have an until value, so we just take on the new one
-				return new EventQuery(items, newUntil, direction, limit);
-			} else if ( newUntil.happenedBefore(until) ) { // newUntil asks to stop earlier in the stream
-				return new EventQuery(items, newUntil, direction, limit);
-			} else { // our until value is earlier in the stream than the new one, not expanding our query
-				return this;
-			}
-		} else {
+		EventFilter updated = filter.untilIfEarlier(newUntil);
+		if ( updated == filter ) {
 			return this;
 		}
+		return new EventQuery(updated, direction, limit);
 	}
 
 }

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventTypesFilter.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventTypesFilter.java
@@ -61,7 +61,7 @@ import org.sliceworkz.eventstore.events.EventType;
  * @param eventTypes the set of event types to match (empty set means match any type)
  *
  * @see EventQuery
- * @see EventQueryItem
+ * @see EventFilterItem
  * @see EventType
  */
 public record EventTypesFilter ( Set<EventType> eventTypes ) {

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/package-info.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/package-info.java
@@ -25,7 +25,7 @@
  * <h2>Query Components:</h2>
  * <ul>
  *   <li>{@link org.sliceworkz.eventstore.query.EventQuery} - Complete query specification combining filters and time bounds</li>
- *   <li>{@link org.sliceworkz.eventstore.query.EventQueryItem} - Single matching rule combining event types and tags</li>
+ *   <li>{@link org.sliceworkz.eventstore.query.EventFilterItem} - Single matching rule combining event types and tags</li>
  *   <li>{@link org.sliceworkz.eventstore.query.EventTypesFilter} - Filters events by their type (class)</li>
  *   <li>{@link org.sliceworkz.eventstore.query.Limit} - Limits the number of events returned</li>
  * </ul>

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/AppendCriteria.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/AppendCriteria.java
@@ -21,41 +21,56 @@ import java.util.Optional;
 
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.query.EventFilter;
 import org.sliceworkz.eventstore.query.EventQuery;
 
 /**
  * Criteria set to determine whether {@link Event}s can be added to the event store.
  * Crucial to the Dynamic Context Boundary (DCB) event store mechanism.
- * 
+ *
  * When business decisions are made, historical {@link Event}s are queried with an {@link EventQuery}, and the decision is based on all relevant facts.
  * The resulting domain {@link Event}s are only appended to the event store if by the time they are stored, no new relevant facts are found in the store.
- * In practice, this allows a dynamic optimistic locking concept, effectively checking whether no new relevant facts are known before the storage of the {@link Event}s. 
- * This is checked by including the original {@link EventQuery} which selects all historical {@link Event}s (facts), 
+ * In practice, this allows a dynamic optimistic locking concept, effectively checking whether no new relevant facts are known before the storage of the {@link Event}s.
+ * This is checked by including the {@link EventFilter} (the pure matching criteria from the original query, without direction or limit),
  * as well as an {@link EventReference} to the last relevant {@link Event} in the store on which the decision is based.
- * If any event deemed relevant by the {@link EventQuery} is found after the reference {@link Event}, no append is done.
- * Simple appends without locking (without relevant facts to consider) are possible with EventQuery.none() 
- * 
- * @param eventQuery the query to run when appending the Events
- * @param expectedLastEventReference the last known Event matching the query that our decision was based upon, or Optional.empty() for none assumed (empty EventStream)
+ * If any event deemed relevant by the {@link EventFilter} is found after the reference {@link Event}, no append is done.
+ * Simple appends without locking (without relevant facts to consider) are possible with AppendCriteria.none()
+ *
+ * @param eventFilter the filter defining which events are relevant for the consistency check
+ * @param expectedLastEventReference the last known Event matching the filter that our decision was based upon, or Optional.empty() for none assumed (empty EventStream)
  */
-public record AppendCriteria ( EventQuery eventQuery, Optional<EventReference> expectedLastEventReference ) {
+public record AppendCriteria ( EventFilter eventFilter, Optional<EventReference> expectedLastEventReference ) {
 
 	/**
-	 * Specifies that no AppedCriteria should be applied, so the append will be carried out regardless of the history.
+	 * Specifies that no AppendCriteria should be applied, so the append will be carried out regardless of the history.
 	 * @return AppendCriteria without conditional appends
 	 */
 	public static final AppendCriteria none ( ) {
-		return new AppendCriteria(EventQuery.matchNone(), null);
+		return new AppendCriteria(EventFilter.matchNone(), null);
 	}
-	
+
 	/**
-	 * Convenience method to create an AppendQuery object. 
-	 * @param eventQuery the query to run when appending the Events
+	 * Creates an AppendCriteria from an {@link EventFilter} and a reference to the last known matching event.
+	 * This is the primary factory method — use the filter extracted from your query via {@link EventQuery#filter()}.
+	 *
+	 * @param eventFilter the filter defining relevant events for the consistency check
+	 * @param reference the last known Event matching the filter that our decision was based upon (null if none)
+	 * @return AppendCriteria for conditional appends
+	 */
+	public static final AppendCriteria of ( EventFilter eventFilter, EventReference reference ) {
+		return new AppendCriteria(eventFilter, Optional.ofNullable(reference));
+	}
+
+	/**
+	 * Convenience method that creates an AppendCriteria from an {@link EventQuery}, extracting its filter.
+	 * Direction and limit from the query are discarded — only the pure matching criteria matter for optimistic locking.
+	 *
+	 * @param eventQuery the query whose filter will be used for the consistency check
 	 * @param reference the last known Event matching the query that our decision was based upon (null if none)
-	 * @return AppendCriteria without conditional appends
+	 * @return AppendCriteria for conditional appends
 	 */
 	public static final AppendCriteria of ( EventQuery eventQuery, EventReference reference ) {
-		return new AppendCriteria(eventQuery, Optional.ofNullable(reference));
+		return new AppendCriteria(eventQuery.filter(), Optional.ofNullable(reference));
 	}
 
 	/**
@@ -63,7 +78,7 @@ public record AppendCriteria ( EventQuery eventQuery, Optional<EventReference> e
 	 * @return boolean specifying whether this represents 'no criteria'
 	 */
 	public boolean isNone ( ) {
-		return eventQuery.isMatchNone ( );
+		return eventFilter.isMatchNone ( );
 	}
-	
+
 }

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/OptimisticLockingException.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/OptimisticLockingException.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sliceworkz.eventstore.events.EventReference;
-import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventFilter;
 
 /**
  * Exception thrown when an optimistic locking check fails during event append operations.
@@ -30,9 +30,9 @@ import org.sliceworkz.eventstore.query.EventQuery;
  * that the {@link AppendCriteria} specified for an append operation were violated because new relevant
  * facts (events) were found in the event store that were not present when the business decision was made.
  * <p>
- * In DCB, business decisions are based on querying relevant historical events using an {@link EventQuery}.
- * When appending the resulting events, the same query is provided along with a reference to the last
- * relevant event that was considered. If new events matching the query have been appended after that
+ * In DCB, business decisions are based on querying relevant historical events using an {@link EventFilter}.
+ * When appending the resulting events, the same filter is provided along with a reference to the last
+ * relevant event that was considered. If new events matching the filter have been appended after that
  * reference by the time the append executes, this exception is thrown.
  *
  * <h2>DCB Workflow:</h2>
@@ -81,7 +81,7 @@ import org.sliceworkz.eventstore.query.EventQuery;
  *     // New relevant events were appended concurrently
  *     System.out.println("Concurrent modification detected: " + e.getMessage());
  *     System.out.println("Expected last reference: " + e.getExpectedLastEventReference());
- *     System.out.println("Query used: " + e.getQuery());
+ *     System.out.println("Filter used: " + e.getFilter());
  *
  *     // Retry the operation with fresh data
  *     retryWithdrawal();
@@ -116,16 +116,16 @@ import org.sliceworkz.eventstore.query.EventQuery;
  *
  * @see AppendCriteria
  * @see EventSink#append(AppendCriteria, List)
- * @see EventQuery
+ * @see EventFilter
  * @see EventReference
  */
 public class OptimisticLockingException extends RuntimeException {
 
-	private final EventQuery query;
+	private final EventFilter filter;
     private final Optional<EventReference> expectedLastEventReference;
 
     /**
-     * Constructs a new OptimisticLockingException with the query and expected reference that failed.
+     * Constructs a new OptimisticLockingException with the filter and expected reference that failed.
      * <p>
      * This constructor creates an exception with a detailed message indicating why the optimistic
      * locking check failed. The message differs based on whether an event reference was expected:
@@ -134,33 +134,33 @@ public class OptimisticLockingException extends RuntimeException {
      *   <li>If reference is empty: indicates an empty stream was expected but events were found</li>
      * </ul>
      *
-     * @param query the EventQuery used in the AppendCriteria that failed, never null
+     * @param filter the EventFilter used in the AppendCriteria that failed, never null
      * @param expectedLastEventReference the expected last event reference, or Optional.empty() if an empty stream was expected
      */
-    public OptimisticLockingException(EventQuery query, Optional<EventReference> expectedLastEventReference ) {
+    public OptimisticLockingException(EventFilter filter, Optional<EventReference> expectedLastEventReference ) {
         super(
         	expectedLastEventReference != null && expectedLastEventReference.isPresent()?
-		            "Optimistic locking failed. Expected last Event with EventReference %s/%d/%d, was not last anymore for EventQuery: %s".formatted(
+		            "Optimistic locking failed. Expected last Event with EventReference %s/%d/%d, was not last anymore for EventFilter: %s".formatted(
 		            expectedLastEventReference.get().id() != null ? expectedLastEventReference.get().id().value() : -1,
 		            expectedLastEventReference.get().position(),
 		            expectedLastEventReference.get().tx(),
-		            query):
-	    		            "Optimistic locking failed. Empty EventStream expected and Events found for EventQuery: %s".formatted(query)
+		            filter):
+	    		            "Optimistic locking failed. Empty EventStream expected and Events found for EventFilter: %s".formatted(filter)
         );
-        this.query = query;
+        this.filter = filter;
         this.expectedLastEventReference = expectedLastEventReference;
     }
 
     /**
-     * Returns the EventQuery that was used in the failed AppendCriteria.
+     * Returns the EventFilter that was used in the failed AppendCriteria.
      * <p>
-     * This query defines which events were considered relevant for the business decision.
+     * This filter defines which events were considered relevant for the business decision.
      * It can be used to re-query the stream and retry the operation with fresh data.
      *
-     * @return the EventQuery from the AppendCriteria, never null
+     * @return the EventFilter from the AppendCriteria, never null
      */
-	public EventQuery getQuery() {
-		return query;
+	public EventFilter getFilter() {
+		return filter;
 	}
 
 	/**

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/query/EventQueryTest.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/query/EventQueryTest.java
@@ -162,7 +162,7 @@ public class EventQueryTest {
 		EventQuery q2 = EventQuery.forEvents(EventTypesFilter.of(SecondDomainEvent.class), Tags.of("A", "1")).until(e3_event1TagsA1.reference());
 		
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ()-> q1.combineWith(q2) );
-		assertEquals("can't combine two EventQuery that don't share the same until value (both different values)", e.getMessage());
+		assertEquals("can't combine two EventFilter that don't share the same until value (both different values)", e.getMessage());
 	}
 	
 	@Test
@@ -171,7 +171,7 @@ public class EventQueryTest {
 		EventQuery q2 = EventQuery.forEvents(EventTypesFilter.of(SecondDomainEvent.class), Tags.of("A", "1")).until(e3_event1TagsA1.reference());
 		
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ()-> q1.combineWith(q2) );
-		assertEquals("can't combine two EventQuery don't share the same until value (one was not set)", e.getMessage());
+		assertEquals("can't combine two EventFilter that don't share the same until value (one was not set)", e.getMessage());
 	}
 
 	@Test
@@ -273,26 +273,37 @@ public class EventQueryTest {
 	}
 
 	@Test
-	void testForLockingCheck ( ) {
+	void testFilter ( ) {
 		EventQuery q = EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.of("A", "1"))
 				.until(e4_event2TagsA1.reference())
 				.backwards()
 				.limit(1);
 
-		EventQuery locking = q.forLockingCheck();
+		EventFilter filter = q.filter();
 
-		// direction and limit are stripped
-		assertEquals(EventQuery.Direction.FORWARD, locking.direction());
-		assertEquals(Limit.none(), locking.limit());
-		assertFalse(locking.isBackwards());
+		// filter contains items and until
+		assertEquals(q.items(), filter.items());
+		assertEquals(q.until(), filter.until());
 
-		// items and until are preserved
-		assertEquals(q.items(), locking.items());
-		assertEquals(q.until(), locking.until());
+		// matching behavior is identical to the query
+		assertTrue(filter.matches(e3_event1TagsA1));
+		assertFalse(filter.matches(e5_event1TagsA1B1));
+	}
 
-		// matching behavior is identical
-		assertTrue(locking.matches(e3_event1TagsA1));
-		assertFalse(locking.matches(e5_event1TagsA1B1));
+	@Test
+	void testFilterMatchAll ( ) {
+		EventFilter filter = EventQuery.matchAll().filter();
+		assertTrue(filter.isMatchAll());
+		assertFalse(filter.isMatchNone());
+		assertTrue(filter.matches(e1_event1NoTags));
+	}
+
+	@Test
+	void testFilterMatchNone ( ) {
+		EventFilter filter = EventQuery.matchNone().filter();
+		assertTrue(filter.isMatchNone());
+		assertFalse(filter.isMatchAll());
+		assertFalse(filter.matches(e1_event1NoTags));
 	}
 
 	@Test

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -42,7 +42,7 @@ import org.sliceworkz.eventstore.impl.serde.EventPayloadSerializerDeserializer.T
 import org.sliceworkz.eventstore.impl.serde.EventPayloadSerializerDeserializer.TypeAndSerializedPayload;
 import org.sliceworkz.eventstore.query.EventFilter;
 import org.sliceworkz.eventstore.query.EventQuery;
-import org.sliceworkz.eventstore.query.EventQueryItem;
+import org.sliceworkz.eventstore.query.EventFilterItem;
 import org.sliceworkz.eventstore.query.EventTypesFilter;
 import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventStorage;
@@ -367,8 +367,8 @@ public class EventStoreImpl implements EventStore {
 			}
 		}
 
-		private EventQueryItem includeLegacyEventTypes ( EventQueryItem queryItem ) {
-			return new EventQueryItem(includeLegacyEventTypes(queryItem.eventTypes()), queryItem.tags());
+		private EventFilterItem includeLegacyEventTypes ( EventFilterItem queryItem ) {
+			return new EventFilterItem(includeLegacyEventTypes(queryItem.eventTypes()), queryItem.tags());
 		}
 
 		private EventTypesFilter includeLegacyEventTypes ( EventTypesFilter typesFilter ) {

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -40,6 +40,7 @@ import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.impl.serde.EventPayloadSerializerDeserializer;
 import org.sliceworkz.eventstore.impl.serde.EventPayloadSerializerDeserializer.TypeAndPayload;
 import org.sliceworkz.eventstore.impl.serde.EventPayloadSerializerDeserializer.TypeAndSerializedPayload;
+import org.sliceworkz.eventstore.query.EventFilter;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.EventQueryItem;
 import org.sliceworkz.eventstore.query.EventTypesFilter;
@@ -359,9 +360,10 @@ public class EventStoreImpl implements EventStore {
 		 */
 		private EventQuery includeLegacyEventTypes ( EventQuery query ) {
 			if ( query.items() == null ) {
-				return new EventQuery(null, query.until(), query.direction(), query.limit());
+				return query; // match-all, nothing to modify
 			} else {
-				return new EventQuery(query.items().stream().map(this::includeLegacyEventTypes).toList(), query.until(), query.direction(), query.limit());
+				EventFilter newFilter = new EventFilter(query.items().stream().map(this::includeLegacyEventTypes).toList(), query.until());
+				return new EventQuery(newFilter, query.direction(), query.limit());
 			}
 		}
 

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -292,21 +292,22 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		// otherwise, we'll need to be aware of any optimistic locking issues
 		} else {
 			
-			// we query the stream with the same filter from the last event known as our reference
+			// we query the stream with the event filter from the last event known as our reference
 			// we only need to fetch max 1 event to prove a locking issue
-			Stream<StoredEvent> newEventStream = queryAfter(appendCriteria.eventQuery().forLockingCheck(), streamId, appendCriteria.expectedLastEventReference().orElse(null), Limit.to(1), QueryDirection.FORWARD);
-			
+			EventQuery lockingQuery = new EventQuery(appendCriteria.eventFilter(), EventQuery.Direction.FORWARD, Limit.none());
+			Stream<StoredEvent> newEventStream = queryAfter(lockingQuery, streamId, appendCriteria.expectedLastEventReference().orElse(null), Limit.to(1), QueryDirection.FORWARD);
+
 			List<StoredEvent> newEvents = newEventStream.toList();
-			
+
 			// if there are no new events in the stream ...
 			if ( newEvents.isEmpty() ) {
-				
+
 				// we can safely append to the event log
 				result = addAndNotifyListeners(events);
-				
+
 			} else {
 				// new events means an optimistic lock !
-				throw new OptimisticLockingException(appendCriteria.eventQuery(), appendCriteria.expectedLastEventReference());
+				throw new OptimisticLockingException(appendCriteria.eventFilter(), appendCriteria.expectedLastEventReference());
 			}				
 		}
 		

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -48,6 +48,7 @@ import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.Tag;
 import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventFilter;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.EventQueryItem;
 import org.sliceworkz.eventstore.query.Limit;
@@ -539,9 +540,9 @@ public class PostgresEventStorageImpl implements EventStorage {
 			}
 		}
 		
-		// Add EventQuery filtering (event types and tags)
+		// Add EventFilter filtering (event types and tags)
 		if (!query.isMatchAll()) {
-			addEventQueryFiltering(sqlBuilder, parameters, query);
+			addEventFilterFiltering(sqlBuilder, parameters, query.filter());
 		}
 		
 		// Order by position
@@ -583,15 +584,15 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 	}
 	
-	private void addEventQueryFiltering(StringBuilder sqlBuilder, List<Object> parameters, EventQuery query) {
-		if (query.items() == null || query.items().isEmpty()) {
+	private void addEventFilterFiltering(StringBuilder sqlBuilder, List<Object> parameters, EventFilter filter) {
+		if (filter.items() == null || filter.items().isEmpty()) {
 			return; // matchAll case is already handled
 		}
-		
+
 		sqlBuilder.append(" AND (");
 		boolean first = true;
-		
-		for (EventQueryItem item : query.items()) {
+
+		for (EventQueryItem item : filter.items()) {
 			if (!first) {
 				sqlBuilder.append(" OR ");
 			}
@@ -716,11 +717,10 @@ public class PostgresEventStorageImpl implements EventStorage {
 				}
 			
 			
-				// Add EventQuery filtering for the consistency boundary
-				// Use forLockingCheck() to strip direction/limit — locking always scans forward with no limit
-				EventQuery lockingQuery = appendCriteria.eventQuery().forLockingCheck();
-				if (!lockingQuery.isMatchAll()) {
-					addEventQueryFiltering(sqlBuilder, parameters, lockingQuery);
+				// Add EventFilter filtering for the consistency boundary
+				EventFilter lockingFilter = appendCriteria.eventFilter();
+				if (!lockingFilter.isMatchAll()) {
+					addEventFilterFiltering(sqlBuilder, parameters, lockingFilter);
 				}
 				
 				sqlBuilder.append(") ");
@@ -762,7 +762,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 						
 						if ( storedEvents.size() != events.size() ) {
 							// Insert failed due to optimistic locking conflict
-							throw new OptimisticLockingException(appendCriteria.eventQuery(), appendCriteria.expectedLastEventReference());
+							throw new OptimisticLockingException(appendCriteria.eventFilter(), appendCriteria.expectedLastEventReference());
 						}
 					}
 					writeConnection.commit();

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -50,7 +50,7 @@ import org.sliceworkz.eventstore.events.Tag;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventFilter;
 import org.sliceworkz.eventstore.query.EventQuery;
-import org.sliceworkz.eventstore.query.EventQueryItem;
+import org.sliceworkz.eventstore.query.EventFilterItem;
 import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.spi.EventStorageException;
@@ -592,7 +592,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 		sqlBuilder.append(" AND (");
 		boolean first = true;
 
-		for (EventQueryItem item : filter.items()) {
+		for (EventFilterItem item : filter.items()) {
 			if (!first) {
 				sqlBuilder.append(" OR ");
 			}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/OptimisticLockingTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/OptimisticLockingTest.java
@@ -234,8 +234,8 @@ public class OptimisticLockingTest {
 		assertNotNull(mostRecent, "Should find the most recent FirstDomainEvent");
 		assertEquals("e3", ((FirstDomainEvent) mostRecent.data()).value());
 
-		// Use that same backwards query for append criteria — forLockingCheck() strips direction/limit
-		// so the locking check still scans forward for any FirstDomainEvent after e3's reference
+		// Use that same backwards query for append criteria — AppendCriteria.of(EventQuery, ...) extracts
+		// the filter, discarding direction/limit so locking scans for any FirstDomainEvent after e3's reference
 		AppendCriteria criteria = AppendCriteria.of(backwardsQuery, mostRecent.reference());
 		eventStream.append(criteria, Collections.singletonList(Event.of(new FirstDomainEvent("e4"), Tags.none())));
 
@@ -262,7 +262,7 @@ public class OptimisticLockingTest {
 		// Another FirstDomainEvent sneaks in after our read
 		eventStream.append(AppendCriteria.none(), Collections.singletonList(Event.of(new FirstDomainEvent("conflict"), Tags.none())));
 
-		// Our append should fail — forLockingCheck() ensures the query scans forward for ALL
+		// Our append should fail — the extracted filter scans forward for ALL
 		// matching FirstDomainEvents after our reference, detecting the conflicting event
 		AppendCriteria criteria = AppendCriteria.of(backwardsQuery, mostRecent.reference());
 		assertThrows(OptimisticLockingException.class, () -> {
@@ -328,7 +328,7 @@ public class OptimisticLockingTest {
 		// A conflicting FirstDomainEvent sneaks in
 		eventStream.append(AppendCriteria.none(), Collections.singletonList(Event.of(new FirstDomainEvent("conflict"), Tags.none())));
 
-		// Should fail — forLockingCheck() ensures full forward scan detects "conflict"
+		// Should fail — the extracted filter ensures full forward scan detects "conflict"
 		AppendCriteria criteria = AppendCriteria.of(backwardsQuery, latestAppended);
 		assertThrows(OptimisticLockingException.class, () -> {
 			eventStream.append(criteria, Collections.singletonList(Event.of(new FirstDomainEvent("e4"), Tags.none())));


### PR DESCRIPTION
EventQuery previously mixed matching criteria (event types, tags, until) with
traversal semantics (direction, limit), requiring a forLockingCheck() method to
strip direction/limit before use in optimistic locking. This refactoring introduces
EventFilter as a first-class concept:

- EventFilter: pure matching criteria (items + until) — used wherever only
  predicate logic is needed, notably in AppendCriteria for optimistic locking
- EventQuery: wraps EventFilter + direction + limit — used for querying with
  traversal semantics
- AppendCriteria: now takes EventFilter directly (with EventQuery convenience
  overload), making it impossible to accidentally pass direction/limit into
  locking context
- OptimisticLockingException: reports EventFilter instead of EventQuery
- Removed forLockingCheck() — no longer needed since EventFilter already
  carries exactly the right fields for locking checks

https://claude.ai/code/session_017ow59zELMkZpwx992dHuh7