### PR TITLE
Add savepoint pattern support via Projection.initQuery()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,16 @@ mvn clean install -DskipTests
 - Combines an `EventQuery` with an `EventHandler`
 - Processes all events matching the query criteria
 - Used for building read models from event streams
+- Optionally defines an `initQuery()` for the savepoint pattern (see below)
+
+**Projection initQuery (Savepoint Pattern):**
+- Projections can define an optional `initQuery()` (default returns `null`) that runs before the main `eventQuery()`
+- Enables the savepoint pattern: a backward query with limit 1 finds the most recent savepoint event that summarizes prior state
+- The `Projector` executes `initQuery()` first, passes results to `when()`, then uses the last event's reference as the cursor for `eventQuery()`
+- Savepoint events are pure domain events — no special framework support needed
+- When no savepoint exists, the main `eventQuery()` replays from the beginning (graceful degradation)
+- When bookmarking is enabled on the `Projector`, `initQuery()` is ignored (a warning is logged at build time)
+- The `initQuery()` and `eventQuery()` should query different event types to avoid double-processing and to allow recovery from buggy savepoints
 
 ### Storage Implementations
 
@@ -165,6 +175,56 @@ stream.append(
     AppendCriteria.of(customerQuery, lastRef),
     Event.of(new CustomerNameChanged("Jane"), Tags.of("customer", "123"))
 );
+```
+
+### Savepoint Pattern with initQuery
+
+```java
+// Stock keeping with savepoint optimization
+sealed interface StockEvent {
+    record StockAdded(String product, int quantity) implements StockEvent {}
+    record StockPicked(String product, int quantity) implements StockEvent {}
+    record StockCounted(String product, int counted) implements StockEvent {} // savepoint
+}
+
+class StockLevelProjection implements Projection<StockEvent> {
+    private final String product;
+    private int level = 0;
+
+    @Override
+    public EventQuery initQuery() {
+        // Find the last stock count (savepoint) — backwards, limit 1
+        return EventQuery.forEvents(
+            EventTypesFilter.of(StockCounted.class),
+            Tags.of("product", product)
+        ).backwards().limit(1);
+    }
+
+    @Override
+    public EventQuery eventQuery() {
+        // Only process movements — savepoints are handled exclusively by initQuery
+        return EventQuery.forEvents(
+            EventTypesFilter.of(StockAdded.class, StockPicked.class),
+            Tags.of("product", product)
+        );
+    }
+
+    @Override
+    public void when(Event<StockEvent> event) {
+        switch (event.data()) {
+            case StockCounted c  -> level = c.counted();
+            case StockAdded a    -> level += a.quantity();
+            case StockPicked p   -> level -= p.quantity();
+        }
+    }
+
+    public int level() { return level; }
+}
+
+// Usage
+StockLevelProjection projection = new StockLevelProjection("WIDGET-42");
+Projector.from(stream).towards(projection).build().run();
+// initQuery finds the last StockCounted, then eventQuery processes only subsequent movements
 ```
 
 ## Testing

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projection.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projection.java
@@ -31,6 +31,20 @@ import org.sliceworkz.eventstore.query.EventQuery;
  * Projections are typically processed by a {@link Projector}, which efficiently streams matching events from an
  * {@link org.sliceworkz.eventstore.stream.EventSource} and applies them to the projection handler in batches.
  *
+ * <h2>Initialization Query (Savepoint Pattern):</h2>
+ * <p>
+ * Projections can optionally define an {@link #initQuery()} that is executed before the main {@link #eventQuery()}.
+ * This enables the <em>savepoint pattern</em>: a backward query with limit 1 finds the most recent savepoint event
+ * (a domain event that summarizes all prior state), initializing the read model without replaying the entire stream.
+ * The main {@code eventQuery()} then starts from that savepoint's reference, processing only subsequent events.
+ * <p>
+ * The savepoint is a pure domain event — no special framework support needed. It is up to the developer to decide
+ * when to append savepoint events to the stream.
+ * <p>
+ * <strong>Note:</strong> When bookmarking is enabled on the {@link Projector}, the {@code initQuery()} is ignored
+ * because bookmarked projections require every event to be processed. A warning is logged at build time if both
+ * are configured.
+ *
  * <h2>Example Usage:</h2>
  * <pre>{@code
  * // Define a projection that builds a customer count by region
@@ -73,6 +87,50 @@ import org.sliceworkz.eventstore.query.EventQuery;
  * System.out.println("EU customers: " + projection.getCounts().get("EU"));
  * }</pre>
  *
+ * <h2>Example Usage with initQuery (Savepoint Pattern):</h2>
+ * <pre>{@code
+ * // Stock keeping with savepoint optimization
+ * sealed interface StockEvent {
+ *     record StockAdded(String product, int quantity) implements StockEvent {}
+ *     record StockPicked(String product, int quantity) implements StockEvent {}
+ *     record StockCounted(String product, int counted) implements StockEvent {} // savepoint
+ * }
+ *
+ * class StockLevelProjection implements Projection<StockEvent> {
+ *     private final String product;
+ *     private int level = 0;
+ *
+ *     @Override
+ *     public EventQuery initQuery() {
+ *         // Find the last stock count (savepoint) for this product
+ *         return EventQuery.forEvents(
+ *             EventTypesFilter.of(StockCounted.class),
+ *             Tags.of("product", product)
+ *         ).backwards().limit(1);
+ *     }
+ *
+ *     @Override
+ *     public EventQuery eventQuery() {
+ *         // Only process movements — savepoints are handled by initQuery
+ *         return EventQuery.forEvents(
+ *             EventTypesFilter.of(StockAdded.class, StockPicked.class),
+ *             Tags.of("product", product)
+ *         );
+ *     }
+ *
+ *     @Override
+ *     public void when(Event<StockEvent> event) {
+ *         switch (event.data()) {
+ *             case StockCounted c  -> level = c.counted();
+ *             case StockAdded a    -> level += a.quantity();
+ *             case StockPicked p   -> level -= p.quantity();
+ *         }
+ *     }
+ *
+ *     public int level() { return level; }
+ * }
+ * }</pre>
+ *
  * @param <CONSUMED_EVENT_TYPE> the type of domain events this projection processes (typically a sealed interface)
  * @see Projector
  * @see ProjectionWithoutMetaData
@@ -80,6 +138,25 @@ import org.sliceworkz.eventstore.query.EventQuery;
  * @see EventWithMetaDataHandler
  */
 public interface Projection<CONSUMED_EVENT_TYPE> extends EventWithMetaDataHandler<CONSUMED_EVENT_TYPE> {
+
+	/**
+	 * Returns an optional initialization query that is executed before the main {@link #eventQuery()}.
+	 * <p>
+	 * When defined (non-null and not match-none), the {@link Projector} will execute this query first,
+	 * pass the matching events to the {@link #when(org.sliceworkz.eventstore.events.Event)} handler,
+	 * and use the last event's reference as the starting cursor for the main {@link #eventQuery()}.
+	 * <p>
+	 * This enables the <em>savepoint pattern</em>: use a backward query with limit 1 to find the most
+	 * recent savepoint event that summarizes all prior state, avoiding a full replay of the event stream.
+	 * <p>
+	 * <strong>Note:</strong> This query is ignored when bookmarking is enabled on the {@link Projector},
+	 * because bookmarked projections require processing every event. A warning is logged at build time.
+	 *
+	 * @return the initialization EventQuery, or {@code null} / {@link EventQuery#matchNone()} to skip (default)
+	 */
+	default EventQuery initQuery ( ) {
+		return null;
+	}
 
 	/**
 	 * Returns the event query that defines which events this projection depends on.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -277,23 +277,38 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 
 		protected ProjectorRunResult execute ( EventReference until, boolean singleBatch ) {
 			boolean done = false;
-			
-			if ( ( bookmarkReadFrequency == BookmarkReadFrequency.BEFORE_EACH_EXECUTION) || 
+
+			if ( ( bookmarkReadFrequency == BookmarkReadFrequency.BEFORE_EACH_EXECUTION) ||
 				 ((bookmarkReadFrequency == BookmarkReadFrequency.BEFORE_FIRST_EXECUTION) && (lastEventReference==null) )
 				) {
 				readBookmark();
 			}
-			
+
+			// Run initQuery if present and bookmarking is not enabled.
+			// The initQuery enables the savepoint pattern: a backward query with limit 1 finds the most recent
+			// savepoint event, initializing the read model without replaying the entire stream.
+			// The main eventQuery then starts from that savepoint's reference.
+			if ( bookmarkReader == null && projection.initQuery() != null && !projection.initQuery().isMatchNone() ) {
+				EventQuery initQuery = projection.initQuery();
+				queriesDone++;
+				es.query(initQuery).forEach(e -> {
+					eventsStreamed++;
+					eventsHandled++;
+					projection.when(e);
+					lastEventReference = Optional.of(e.reference());
+				});
+			}
+
 			ProjectorException exception = null;
-			
+
 			Optional<EventReference> lastReadAtStart = lastEventReference;
-			
+
 			// in order to avoid memory issues, we'll loop in batches om MAX_EVENTS_PER_QUERY, until no more events are found in the stream
 			Limit limit =  Limit.to(maxEventsPerQuery).orIfLower(projection.eventQuery().limit());
-	
-			
+
+
 			EventQuery effectiveQuery = projection.eventQuery().untilIfEarlier ( until );
-			
+
 			EventReference lastRead = lastEventReference==null?null:lastEventReference.orElse(null);
 			
 			while ( !done ) {
@@ -629,6 +644,9 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 		 * @return a new Projector configured with the builder's settings
 		 */
 		public Projector<EVENT_TYPE> build ( ) {
+			if ( bookmarkBuilder.readerName != null && projection.initQuery() != null && !projection.initQuery().isMatchNone() ) {
+				LOGGER.warn("Projection has initQuery but bookmarking is enabled — initQuery will be ignored. Remove bookmarking for live-model use, or remove initQuery for full replay.");
+			}
 			Projector<EVENT_TYPE> projector = new Projector<>(eventSource, projection, after, maxEventsPerQuery, bookmarkBuilder.readerName, bookmarkBuilder.tags, bookmarkBuilder.bookmarkReadFrequency);
 			if ( subscribe ) {
 				// subscribe for eventually consistent updates about event appends, so the projector will automatically trigger projection updates

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -284,11 +284,12 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 				readBookmark();
 			}
 
-			// Run initQuery if present and bookmarking is not enabled.
+			// Run initQuery on first execution only, if present and bookmarking is not enabled.
 			// The initQuery enables the savepoint pattern: a backward query with limit 1 finds the most recent
 			// savepoint event, initializing the read model without replaying the entire stream.
 			// The main eventQuery then starts from that savepoint's reference.
-			if ( bookmarkReader == null && projection.initQuery() != null && !projection.initQuery().isMatchNone() ) {
+			// On subsequent run() calls, lastEventReference is already set, so initQuery is skipped.
+			if ( bookmarkReader == null && lastEventReference == null && projection.initQuery() != null && !projection.initQuery().isMatchNone() ) {
 				EventQuery initQuery = projection.initQuery();
 				queriesDone++;
 				es.query(initQuery).forEach(e -> {

--- a/sliceworkz-eventstore-examples/src/main/java/org/sliceworkz/eventstore/examples/SavepointProjectionExample.java
+++ b/sliceworkz-eventstore-examples/src/main/java/org/sliceworkz/eventstore/examples/SavepointProjectionExample.java
@@ -1,0 +1,178 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.examples;
+
+import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.examples.SavepointProjectionExample.StockEvent.StockAdded;
+import org.sliceworkz.eventstore.examples.SavepointProjectionExample.StockEvent.StockCounted;
+import org.sliceworkz.eventstore.examples.SavepointProjectionExample.StockEvent.StockPicked;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.projection.Projection;
+import org.sliceworkz.eventstore.projection.Projector;
+import org.sliceworkz.eventstore.projection.Projector.ProjectorMetrics;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+/**
+ * Demonstrates the savepoint pattern using {@link Projection#initQuery()}.
+ * <p>
+ * In this stock keeping example, {@code StockAdded} and {@code StockPicked} events represent
+ * individual stock movements. A {@code StockCounted} event is a <em>savepoint</em> that summarizes
+ * the stock level at a point in time — it is a pure domain event, not a framework construct.
+ * <p>
+ * The projection uses {@code initQuery()} to find the most recent savepoint (backward, limit 1),
+ * initializing the stock level without replaying the entire stream. The main {@code eventQuery()}
+ * then processes only the movements that occurred after that savepoint.
+ * <p>
+ * This avoids a full replay of potentially thousands of events, while keeping the projection
+ * correct and self-contained. It is up to the developer to decide when to append savepoint events.
+ * <p>
+ * <strong>Key design decisions:</strong>
+ * <ul>
+ *   <li>{@code StockCounted} is only in the {@code initQuery()}, not in the {@code eventQuery()}.
+ *       This means the main query never processes savepoint events, which protects against buggy
+ *       historical savepoints — just append a corrected {@code StockCounted} and the next run
+ *       picks it up via {@code initQuery()}.</li>
+ *   <li>When no savepoint exists (e.g., first run ever), the {@code initQuery()} returns nothing
+ *       and the main query replays from the beginning. This degrades gracefully.</li>
+ *   <li>The savepoint pattern is an alternative to bookmarking. When using {@code initQuery()},
+ *       bookmarking is typically not needed. If bookmarking is enabled, the {@code initQuery()}
+ *       is ignored and a warning is logged.</li>
+ * </ul>
+ */
+public class SavepointProjectionExample {
+
+	public static void main ( String[] args ) {
+
+		EventStore eventstore = InMemoryEventStorage.newBuilder().buildStore();
+
+		EventStreamId streamId = EventStreamId.forContext("warehouse");
+		EventStream<StockEvent> stream = eventstore.getEventStream(streamId, StockEvent.class);
+
+		String product = "WIDGET-42";
+		Tags tags = Tags.of("product", product);
+
+		// Simulate stock movements
+		stream.append(AppendCriteria.none(), Event.of(new StockAdded(product, 100), tags));
+		stream.append(AppendCriteria.none(), Event.of(new StockPicked(product, 10), tags));
+		stream.append(AppendCriteria.none(), Event.of(new StockPicked(product, 5), tags));
+		stream.append(AppendCriteria.none(), Event.of(new StockAdded(product, 50), tags));
+		stream.append(AppendCriteria.none(), Event.of(new StockPicked(product, 20), tags));
+
+		// First projection run — no savepoint exists, replays everything
+		StockLevelProjection projection = new StockLevelProjection(product);
+		ProjectorMetrics metrics = Projector.from(stream).towards(projection).build().run();
+
+		System.out.println("Stock level: " + projection.level());               // 115
+		System.out.println("Events handled: " + metrics.eventsHandled());       // 5
+
+		// Now append a savepoint summarizing the current state
+		stream.append(AppendCriteria.none(), Event.of(new StockCounted(product, 115), tags));
+
+		// More movements after the savepoint
+		stream.append(AppendCriteria.none(), Event.of(new StockAdded(product, 30), tags));
+		stream.append(AppendCriteria.none(), Event.of(new StockPicked(product, 12), tags));
+
+		// Second projection run — initQuery finds the savepoint, only processes 2 movements after it
+		StockLevelProjection projection2 = new StockLevelProjection(product);
+		ProjectorMetrics metrics2 = Projector.from(stream).towards(projection2).build().run();
+
+		System.out.println("Stock level: " + projection2.level());              // 133
+		System.out.println("Events handled: " + metrics2.eventsHandled());      // 3 (1 savepoint + 2 movements)
+		System.out.println("Queries done: " + metrics2.queriesDone());          // 2 (1 initQuery + 1 eventQuery)
+
+		// Fix a bad savepoint by appending a corrected one — next run automatically uses the latest
+		stream.append(AppendCriteria.none(), Event.of(new StockCounted(product, 133), tags));
+		stream.append(AppendCriteria.none(), Event.of(new StockPicked(product, 3), tags));
+
+		StockLevelProjection projection3 = new StockLevelProjection(product);
+		ProjectorMetrics metrics3 = Projector.from(stream).towards(projection3).build().run();
+
+		System.out.println("Stock level: " + projection3.level());              // 130
+		System.out.println("Events handled: " + metrics3.eventsHandled());      // 2 (1 savepoint + 1 movement)
+	}
+
+	/**
+	 * A projection that calculates the current stock level for a product using the savepoint pattern.
+	 * <p>
+	 * The {@code initQuery()} finds the most recent {@code StockCounted} savepoint, and the
+	 * {@code eventQuery()} processes only {@code StockAdded} and {@code StockPicked} events after it.
+	 */
+	static class StockLevelProjection implements Projection<StockEvent> {
+
+		private final String product;
+		private int level = 0;
+
+		public StockLevelProjection ( String product ) {
+			this.product = product;
+		}
+
+		@Override
+		public EventQuery initQuery ( ) {
+			// Find the last stock count (savepoint) for this product
+			return EventQuery.forEvents(
+				EventTypesFilter.of(StockCounted.class),
+				Tags.of("product", product)
+			).backwards().limit(1);
+		}
+
+		@Override
+		public EventQuery eventQuery ( ) {
+			// Only process movements — savepoints are handled exclusively by initQuery
+			return EventQuery.forEvents(
+				EventTypesFilter.of(StockAdded.class, StockPicked.class),
+				Tags.of("product", product)
+			);
+		}
+
+		@Override
+		public void when ( Event<StockEvent> event ) {
+			switch ( event.data() ) {
+				case StockCounted c  -> level = c.counted();
+				case StockAdded a    -> level += a.quantity();
+				case StockPicked p   -> level -= p.quantity();
+			}
+		}
+
+		public int level ( ) {
+			return level;
+		}
+
+	}
+
+	sealed interface StockEvent {
+
+		record StockAdded ( String product, int quantity ) implements StockEvent { }
+
+		record StockPicked ( String product, int quantity ) implements StockEvent { }
+
+		/**
+		 * Savepoint event that summarizes the stock count at a certain moment in time.
+		 * This is a pure domain event — no special framework support needed.
+		 * It is up to the developer to decide when to append this event to the stream.
+		 */
+		record StockCounted ( String product, int counted ) implements StockEvent { }
+
+	}
+
+}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorTest.java
@@ -581,6 +581,107 @@ public class ProjectorTest extends AbstractEventStoreTest {
 	}
 
 
+	@Test
+	void testProjectorWithInitQuery ( ) {
+		// Set up a stream simulating stock keeping with a savepoint
+		EventStreamId stream = EventStreamId.forContext("app").withPurpose("initquery");
+		EventStream<MockDomainEvent> initEs = eventStore().getEventStream(stream, MockDomainEvent.class);
+
+		// Append: First("10"), First("5"), Third("savepoint:15"), First("3"), First("7")
+		// Using First as "stock added", Third as "savepoint/stock counted", Second is unrelated
+		append(initEs, new FirstDomainEvent("10"), Tags.none());
+		append(initEs, new FirstDomainEvent("5"), Tags.none());
+		append(initEs, new ThirdDomainEvent("savepoint:15"), Tags.none());
+		append(initEs, new FirstDomainEvent("3"), Tags.none());
+		append(initEs, new FirstDomainEvent("7"), Tags.none());
+
+		InitQueryProjection projection = new InitQueryProjection();
+		var projector = Projector.from(initEs).towards(projection).build();
+
+		ProjectorMetrics metrics = projector.run();
+
+		// initQuery finds the savepoint (ThirdDomainEvent), then eventQuery processes the 2 FirstDomainEvents after it
+		assertEquals(3, projection.counter()); // 1 from initQuery + 2 from eventQuery
+		assertEquals("savepoint:15", projection.lastSavepoint()); // savepoint was processed
+		assertEquals(2, metrics.queriesDone()); // 1 for initQuery + 1 for eventQuery
+		assertEquals(3, metrics.eventsHandled()); // 1 savepoint + 2 movements
+	}
+
+	@Test
+	void testProjectorWithInitQueryNoSavepointExists ( ) {
+		// Set up a stream with no savepoint events
+		EventStreamId stream = EventStreamId.forContext("app").withPurpose("initquery-nosavepoint");
+		EventStream<MockDomainEvent> initEs = eventStore().getEventStream(stream, MockDomainEvent.class);
+
+		append(initEs, new FirstDomainEvent("10"), Tags.none());
+		append(initEs, new FirstDomainEvent("5"), Tags.none());
+		append(initEs, new FirstDomainEvent("3"), Tags.none());
+
+		InitQueryProjection projection = new InitQueryProjection();
+		var projector = Projector.from(initEs).towards(projection).build();
+
+		ProjectorMetrics metrics = projector.run();
+
+		// No savepoint found, so all FirstDomainEvents are processed by the main eventQuery
+		assertEquals(3, projection.counter());
+		assertNull(projection.lastSavepoint()); // no savepoint was found
+		assertEquals(2, metrics.queriesDone()); // 1 for initQuery (empty) + 1 for eventQuery
+		assertEquals(3, metrics.eventsHandled());
+	}
+
+	@Test
+	void testProjectorWithInitQueryAndBookmarkingIgnoresInitQuery ( ) {
+		// When bookmarking is enabled, initQuery should be ignored
+		EventStreamId stream = EventStreamId.forContext("app").withPurpose("initquery-bookmark");
+		EventStream<MockDomainEvent> initEs = eventStore().getEventStream(stream, MockDomainEvent.class);
+
+		append(initEs, new FirstDomainEvent("10"), Tags.none());
+		append(initEs, new FirstDomainEvent("5"), Tags.none());
+		append(initEs, new ThirdDomainEvent("savepoint:15"), Tags.none());
+		append(initEs, new FirstDomainEvent("3"), Tags.none());
+		append(initEs, new FirstDomainEvent("7"), Tags.none());
+
+		InitQueryProjection projection = new InitQueryProjection();
+		var projector = Projector.from(initEs).towards(projection)
+				.bookmarkProgress().withReader("initquery-test-reader").readBeforeEachExecution().done()
+				.build();
+
+		ProjectorMetrics metrics = projector.run();
+
+		// With bookmarking, initQuery is ignored — all FirstDomainEvents are processed from the start
+		assertEquals(4, projection.counter()); // all 4 FirstDomainEvents (Third is excluded by eventQuery)
+		assertNull(projection.lastSavepoint()); // savepoint was NOT processed (initQuery skipped, Third not in eventQuery)
+		assertEquals(1, metrics.queriesDone()); // no initQuery, just 1 eventQuery batch
+		assertEquals(4, metrics.eventsHandled());
+	}
+
+	@Test
+	void testProjectorWithInitQueryMultipleRuns ( ) {
+		// Verify initQuery only runs once (on first run), subsequent runs continue from cursor
+		EventStreamId stream = EventStreamId.forContext("app").withPurpose("initquery-multirun");
+		EventStream<MockDomainEvent> initEs = eventStore().getEventStream(stream, MockDomainEvent.class);
+
+		append(initEs, new FirstDomainEvent("10"), Tags.none());
+		append(initEs, new ThirdDomainEvent("savepoint:10"), Tags.none());
+		append(initEs, new FirstDomainEvent("5"), Tags.none());
+
+		InitQueryProjection projection = new InitQueryProjection();
+		var projector = Projector.from(initEs).towards(projection).build();
+
+		// First run: initQuery finds savepoint, then processes 1 movement after it
+		ProjectorMetrics metrics1 = projector.run();
+		assertEquals(2, projection.counter()); // savepoint + 1 movement
+		assertEquals("savepoint:10", projection.lastSavepoint());
+
+		// Add more events
+		append(initEs, new FirstDomainEvent("3"), Tags.none());
+
+		// Second run: should continue from last cursor, no initQuery
+		ProjectorMetrics metrics2 = projector.run();
+		assertEquals(3, projection.counter()); // 1 new movement added
+		assertEquals(1, metrics2.eventsHandled()); // only the new event
+	}
+
 	private List<Event<MockDomainEvent>> append ( EventStream<MockDomainEvent> es, MockDomainEvent event, Tags tags ) {
 		return es.append(AppendCriteria.none(), Collections.singletonList(Event.of(event, tags)));
 	}
@@ -707,6 +808,41 @@ public class ProjectorTest extends AbstractEventStoreTest {
 			return cancelTriggered;
 		}
 		
+	}
+
+	class InitQueryProjection implements Projection<MockDomainEvent> {
+
+		private int counter;
+		private String lastSavepoint;
+
+		@Override
+		public EventQuery initQuery() {
+			// Find the last savepoint (ThirdDomainEvent) — backwards, limit 1
+			return EventQuery.forEvents(EventTypesFilter.of(ThirdDomainEvent.class), Tags.none()).backwards().limit(1);
+		}
+
+		@Override
+		public EventQuery eventQuery() {
+			// Only process movements (FirstDomainEvent) — savepoints are handled by initQuery
+			return EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none());
+		}
+
+		@Override
+		public void when(Event<MockDomainEvent> event) {
+			counter++;
+			if ( event.data() instanceof ThirdDomainEvent t ) {
+				lastSavepoint = t.value();
+			}
+		}
+
+		public int counter ( ) {
+			return counter;
+		}
+
+		public String lastSavepoint ( ) {
+			return lastSavepoint;
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

This PR introduces the **savepoint pattern** to projections, enabling efficient read model initialization without replaying entire event streams. Projections can now define an optional `initQuery()` that executes before the main `eventQuery()`, allowing a backward query to find the most recent savepoint event and initialize state from that point forward.

## Key Changes

- **New `Projection.initQuery()` method**: Optional default method that returns `null`. When implemented, it enables the savepoint pattern by executing a query (typically backward with limit 1) before the main event query.

- **Projector execution flow**: Updated `ProjectorRun.execute()` to:
  - Execute `initQuery()` first if present and bookmarking is not enabled
  - Use the last event reference from `initQuery()` as the cursor for the main `eventQuery()`
  - Track queries and events separately in metrics

- **Bookmarking conflict detection**: Added warning in `Projector.Builder.build()` when both `initQuery()` and bookmarking are configured, since bookmarking requires processing every event and makes `initQuery()` ineffective.

- **Comprehensive documentation**: 
  - Updated `Projection` interface with detailed JavaDoc explaining the savepoint pattern, use cases, and interaction with bookmarking
  - Added code examples showing stock-keeping scenario with savepoint events
  - Updated `CLAUDE.md` with savepoint pattern explanation and usage guide

- **Full test coverage**: Added four new test cases in `ProjectorTest`:
  - `testProjectorWithInitQuery`: Verifies savepoint is found and only subsequent events are processed
  - `testProjectorWithInitQueryNoSavepointExists`: Confirms graceful degradation when no savepoint exists
  - `testProjectorWithInitQueryAndBookmarkingIgnoresInitQuery`: Validates that bookmarking takes precedence
  - `testProjectorWithInitQueryMultipleRuns`: Ensures `initQuery()` runs only on first execution

- **Example implementation**: Added `SavepointProjectionExample` demonstrating the pattern with a realistic stock-keeping scenario, showing how savepoints reduce event replay from 5 events to 3 (1 savepoint + 2 movements) on subsequent runs.

## Implementation Details

- Savepoint events are pure domain events with no special framework support — developers decide when to append them
- The `initQuery()` and `eventQuery()` should query different event types to prevent double-processing and enable recovery from buggy historical savepoints
- When no savepoint exists, the system degrades gracefully by replaying from the beginning
- Metrics now track both `queriesDone()` (separate counts for `initQuery()` and `eventQuery()`) and `eventsHandled()` to provide visibility into projection efficiency

https://claude.ai/code/session_01P6jCKyTUKgm93WmAJGnusG