### PR TITLE
Refactor database initialization to use DatabaseInitMode enum

### DIFF
--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/package-info.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/package-info.java
@@ -55,10 +55,9 @@
  *     .build();
  * EventStore eventStore = EventStoreFactory.get().eventStore(storage);
  *
- * // Using PostgreSQL storage
+ * // Using PostgreSQL storage (default mode ENSURE creates schema if missing)
  * EventStorage storage = PostgresEventStorage.newBuilder()
  *     .prefix("tenant1_")
- *     .initializeDatabase()
  *     .build();
  * EventStore eventStore = EventStoreFactory.get().eventStore(storage);
  * }</pre>

--- a/sliceworkz-eventstore-infra-postgres/README.md
+++ b/sliceworkz-eventstore-infra-postgres/README.md
@@ -1,8 +1,9 @@
 
 # Postgres Storage for Eventstore
 
-Create a database schema with the DDL scripts found in 'initialisation.sql', 
+Create a database schema with the DDL scripts found in 'ensure-schema.sql',
 removing "PREFIX_" or replacing it to manage different stores next to each other.
+Use 'drop-schema.sql' to drop existing schema objects before recreating.
  
 
 

--- a/sliceworkz-eventstore-infra-postgres/pom.xml
+++ b/sliceworkz-eventstore-infra-postgres/pom.xml
@@ -104,7 +104,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<file>${basedir}/src/main/resources/initialisation.sql</file>
+					<file>${basedir}/src/main/resources/ensure-schema.sql</file>
 					<outputFile>${basedir}/src/main/quickstart/quickstart.ddl.sql</outputFile>
 					<replacements>
 						<replacement>

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/DatabaseInitMode.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/DatabaseInitMode.java
@@ -1,0 +1,70 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres;
+
+/**
+ * Controls how the database schema is handled during {@link PostgresEventStorage} startup.
+ * <p>
+ * Each mode defines a different level of schema management, from fully hands-off to
+ * destructive re-creation. The mode is set on the {@link PostgresEventStorage.Builder}
+ * via {@link PostgresEventStorage.Builder#databaseInitMode(DatabaseInitMode)} or via
+ * the convenience methods {@link PostgresEventStorage.Builder#validateDatabase()},
+ * {@link PostgresEventStorage.Builder#ensureDatabase()}, and
+ * {@link PostgresEventStorage.Builder#initializeDatabase()}.
+ *
+ * @see PostgresEventStorage.Builder
+ */
+public enum DatabaseInitMode {
+
+	/**
+	 * Assume the database schema exists. No validation, no creation.
+	 * <p>
+	 * Use this in environments where the schema is managed externally (e.g., by a DBA
+	 * or migration tool) and startup time should be minimized.
+	 */
+	NONE,
+
+	/**
+	 * Validate that all required database objects exist and are correctly defined.
+	 * Throws {@link org.sliceworkz.eventstore.spi.EventStorageException} if anything is
+	 * missing or malformed.
+	 * <p>
+	 * No objects are created or modified. This is a read-only check.
+	 */
+	VALIDATE,
+
+	/**
+	 * Create missing database objects if they do not exist, leaving existing objects untouched.
+	 * After creation, the schema is validated.
+	 * <p>
+	 * This is the default mode. It is safe to run repeatedly — existing tables, indexes,
+	 * functions, and triggers are not modified. If an existing object has an incompatible
+	 * definition, the subsequent validation will detect and report it.
+	 */
+	ENSURE,
+
+	/**
+	 * Drop all event store objects and recreate them from scratch. After creation, the
+	 * schema is validated.
+	 * <p>
+	 * <strong>Warning:</strong> This mode is destructive — all existing event data will be lost.
+	 * Use only for test environments, fresh deployments, or when a clean slate is explicitly needed.
+	 */
+	INITIALIZE
+
+}

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
@@ -357,39 +357,6 @@ public interface PostgresEventStorage {
 		}
 
 		/**
-		 * Sets the database initialization mode to {@link DatabaseInitMode#INITIALIZE} or
-		 * {@link DatabaseInitMode#ENSURE} based on the boolean parameter.
-		 *
-		 * @param value {@code true} for {@link DatabaseInitMode#INITIALIZE}, {@code false} is ignored
-		 * @return this Builder for method chaining
-		 * @deprecated Use {@link #databaseInitMode(DatabaseInitMode)} or {@link #initializeDatabase()} instead.
-		 */
-		@Deprecated
-		public Builder initializeDatabase ( boolean value ) {
-			if ( value ) {
-				this.databaseInitMode = DatabaseInitMode.INITIALIZE;
-			}
-			return this;
-		}
-
-		/**
-		 * Controls automatic database schema validation when the storage is built.
-		 *
-		 * @param value {@code true} to validate the database schema, {@code false} to skip validation
-		 * @return this Builder for method chaining
-		 * @deprecated Use {@link #databaseInitMode(DatabaseInitMode)} or {@link #validateDatabase()} instead.
-		 *     Note: passing {@code false} sets the mode to {@link DatabaseInitMode#NONE} only if the
-		 *     current mode is {@link DatabaseInitMode#VALIDATE} or {@link DatabaseInitMode#ENSURE}.
-		 */
-		@Deprecated
-		public Builder checkDatabase ( boolean value ) {
-			if ( !value && (this.databaseInitMode == DatabaseInitMode.VALIDATE || this.databaseInitMode == DatabaseInitMode.ENSURE) ) {
-				this.databaseInitMode = DatabaseInitMode.NONE;
-			}
-			return this;
-		}
-
-		/**
 		 * Configures the Micrometer meter registry for collecting observability metrics.
 		 * <p>
 		 * The meter registry is used to track event store operations including event stream creation,

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
@@ -73,13 +73,10 @@ import io.micrometer.core.instrument.Metrics;
  *
  * <h2>Basic Usage Example:</h2>
  * <pre>{@code
- * // Using default configuration from db.properties file
- * EventStorage storage = PostgresEventStorage.newBuilder()
- *     .initializeDatabase()
- *     .build();
- * EventStore eventStore = EventStoreFactory.get().eventStore(storage);
+ * // Using default configuration from db.properties file (default mode is ENSURE)
+ * EventStore eventStore = PostgresEventStorage.newBuilder().buildStore();
  *
- * // Or use convenience method
+ * // Test environment: fresh schema every time
  * EventStore eventStore = PostgresEventStorage.newBuilder()
  *     .initializeDatabase()
  *     .buildStore();
@@ -97,7 +94,7 @@ import io.micrometer.core.instrument.Metrics;
  *     .monitoringDataSource(monitoringDataSource)
  *     .prefix("tenant1_")
  *     .resultLimit(10000)
- *     .initializeDatabase()
+ *     .databaseInitMode(DatabaseInitMode.VALIDATE)
  *     .build();
  * EventStore eventStore = EventStoreFactory.get().eventStore(storage);
  * }</pre>
@@ -131,8 +128,7 @@ public interface PostgresEventStorage {
 	 *   <li><strong>prefix</strong>: "" (no prefix)</li>
 	 *   <li><strong>dataSource</strong>: Auto-configured from db.properties if not provided</li>
 	 *   <li><strong>monitoringDataSource</strong>: Defaults to same as dataSource, or separate non-pooled from db.properties</li>
-	 *   <li><strong>initializeDatabase</strong>: false (database schema not created automatically)</li>
-	 *   <li><strong>checkDatabase</strong>: true (database schema checked upon startup, after initialization if the latter is enabled)</li>
+	 *   <li><strong>databaseInitMode</strong>: {@link DatabaseInitMode#ENSURE} (create missing objects, validate)</li>
 	 *   <li><strong>resultLimit</strong>: none (no absolute limit)</li>
 	 * </ul>
 	 * <p>
@@ -140,22 +136,22 @@ public interface PostgresEventStorage {
 	 *
 	 * @see #build()
 	 * @see #buildStore()
+	 * @see DatabaseInitMode
 	 */
 	public static class Builder {
-		
+
 		private String prefix = "";
 		private String name = "psql";
 		private DataSource dataSource;
 		private DataSource monitoringDataSource;
-		private boolean initializeDatabase = false;
-		private boolean checkDatabase = true;
+		private DatabaseInitMode databaseInitMode = DatabaseInitMode.ENSURE;
 		private Limit limit = Limit.none();
 		private MeterRegistry meterRegistry = Metrics.globalRegistry;
 
 		private Builder ( ) {
-			
+
 		}
-		
+
 		static Builder newBuilder ( ) {
 			return new Builder ( );
 		}
@@ -271,119 +267,125 @@ public interface PostgresEventStorage {
 		}
 
 		/**
-		 * Enables automatic database schema initialization when the storage is built.
+		 * Sets the database initialization mode.
 		 * <p>
-		 * Equivalent to calling {@link #initializeDatabase(boolean) initializeDatabase(true)}.
+		 * Controls how the database schema is handled during startup. See {@link DatabaseInitMode}
+		 * for a description of each mode. The default is {@link DatabaseInitMode#ENSURE}.
 		 * <p>
-		 * When enabled, the builder will execute the initialization SQL script to create all
-		 * required database tables, indexes, triggers, and functions. This should typically be
-		 * enabled on first deployment or when setting up test environments.
+		 * <strong>Example usage:</strong>
+		 * <pre>{@code
+		 * // Default: create missing objects, validate
+		 * EventStorage storage = PostgresEventStorage.newBuilder().build();
+		 *
+		 * // Production: trust the DBA, skip all checks
+		 * EventStorage storage = PostgresEventStorage.newBuilder()
+		 *     .databaseInitMode(DatabaseInitMode.NONE)
+		 *     .build();
+		 *
+		 * // Startup validation only
+		 * EventStorage storage = PostgresEventStorage.newBuilder()
+		 *     .databaseInitMode(DatabaseInitMode.VALIDATE)
+		 *     .build();
+		 *
+		 * // Test environment: fresh schema every time
+		 * EventStorage storage = PostgresEventStorage.newBuilder()
+		 *     .databaseInitMode(DatabaseInitMode.INITIALIZE)
+		 *     .build();
+		 * }</pre>
+		 *
+		 * @param mode the database initialization mode
+		 * @return this Builder for method chaining
+		 * @see DatabaseInitMode
+		 */
+		public Builder databaseInitMode ( DatabaseInitMode mode ) {
+			this.databaseInitMode = mode;
+			return this;
+		}
+
+		/**
+		 * Sets the database initialization mode to {@link DatabaseInitMode#VALIDATE}.
 		 * <p>
-		 * The initialization is idempotent and safe to run multiple times. Existing tables
-		 * and data will not be affected.
+		 * Validates that all required database objects exist and are correctly defined.
+		 * No objects are created or modified.
 		 * <p>
-		 * <strong>Note:</strong> Ensure the database user has sufficient privileges to create
-		 * tables, functions, and triggers.
+		 * This is a convenience method equivalent to
+		 * {@code databaseInitMode(DatabaseInitMode.VALIDATE)}.
 		 *
 		 * @return this Builder for method chaining
-		 * @see #initializeDatabase(boolean)
+		 * @see DatabaseInitMode#VALIDATE
+		 * @see #databaseInitMode(DatabaseInitMode)
+		 */
+		public Builder validateDatabase ( ) {
+			this.databaseInitMode = DatabaseInitMode.VALIDATE;
+			return this;
+		}
+
+		/**
+		 * Sets the database initialization mode to {@link DatabaseInitMode#ENSURE}.
+		 * <p>
+		 * Creates missing database objects if they do not exist, leaving existing objects
+		 * untouched, then validates the schema. This is the default mode.
+		 * <p>
+		 * This is a convenience method equivalent to
+		 * {@code databaseInitMode(DatabaseInitMode.ENSURE)}.
+		 *
+		 * @return this Builder for method chaining
+		 * @see DatabaseInitMode#ENSURE
+		 * @see #databaseInitMode(DatabaseInitMode)
+		 */
+		public Builder ensureDatabase ( ) {
+			this.databaseInitMode = DatabaseInitMode.ENSURE;
+			return this;
+		}
+
+		/**
+		 * Sets the database initialization mode to {@link DatabaseInitMode#INITIALIZE}.
+		 * <p>
+		 * Drops all event store objects and recreates them from scratch.
+		 * <strong>Warning:</strong> This is destructive — all existing event data will be lost.
+		 * <p>
+		 * This is a convenience method equivalent to
+		 * {@code databaseInitMode(DatabaseInitMode.INITIALIZE)}.
+		 *
+		 * @return this Builder for method chaining
+		 * @see DatabaseInitMode#INITIALIZE
+		 * @see #databaseInitMode(DatabaseInitMode)
 		 */
 		public Builder initializeDatabase ( ) {
-			return initializeDatabase(true);
+			this.databaseInitMode = DatabaseInitMode.INITIALIZE;
+			return this;
 		}
-		
+
 		/**
-		 * Controls automatic database schema initialization when the storage is built.
-		 * <p>
-		 * When set to {@code true}, the builder will execute the initialization SQL script to
-		 * create all required database tables, indexes, triggers, and functions. This should
-		 * typically be enabled on first deployment or when setting up test environments.
-		 * <p>
-		 * The initialization is idempotent and safe to run multiple times. Existing tables
-		 * and data will not be affected.
-		 * <p>
-		 * Tables and structures created include:
-		 * <ul>
-		 *   <li>{@code PREFIX_events}: Main event storage table</li>
-		 *   <li>{@code PREFIX_bookmarks}: Event consumer position tracking</li>
-		 *   <li>Indexes on frequently queried columns</li>
-		 *   <li>Triggers for NOTIFY on event appends and bookmark updates</li>
-		 * </ul>
-		 * <p>
-		 * <strong>Note:</strong> Ensure the database user has sufficient privileges to create
-		 * tables, functions, and triggers.
+		 * Sets the database initialization mode to {@link DatabaseInitMode#INITIALIZE} or
+		 * {@link DatabaseInitMode#ENSURE} based on the boolean parameter.
 		 *
-		 * @param value {@code true} to initialize the database, {@code false} to skip initialization
+		 * @param value {@code true} for {@link DatabaseInitMode#INITIALIZE}, {@code false} is ignored
 		 * @return this Builder for method chaining
+		 * @deprecated Use {@link #databaseInitMode(DatabaseInitMode)} or {@link #initializeDatabase()} instead.
 		 */
+		@Deprecated
 		public Builder initializeDatabase ( boolean value ) {
-			this.initializeDatabase = value;
+			if ( value ) {
+				this.databaseInitMode = DatabaseInitMode.INITIALIZE;
+			}
 			return this;
 		}
 
 		/**
 		 * Controls automatic database schema validation when the storage is built.
-		 * <p>
-		 * When set to {@code true} (the default), the builder will validate that all required
-		 * database objects exist and are properly formed before the storage instance is returned.
-		 * This provides early detection of schema issues and prevents runtime failures.
-		 * <p>
-		 * The validation checks include:
-		 * <ul>
-		 *   <li><strong>Tables:</strong> {@code PREFIX_events} and {@code PREFIX_bookmarks} exist</li>
-		 *   <li><strong>Columns:</strong> All required columns exist with correct types and nullability</li>
-		 *   <li><strong>Indexes:</strong> All performance-critical indexes are present</li>
-		 *   <li><strong>Functions:</strong> PostgreSQL notification functions exist</li>
-		 *   <li><strong>Triggers:</strong> Event and bookmark notification triggers are properly configured</li>
-		 *   <li><strong>Constraints:</strong> Foreign key constraints are in place</li>
-		 * </ul>
-		 * <p>
-		 * If any required database object is missing or malformed, an
-		 * {@link org.sliceworkz.eventstore.spi.EventStorageException} is thrown with a detailed
-		 * explanation of what is wrong. All validation activity is logged at DEBUG level for
-		 * troubleshooting.
-		 * <p>
-		 * <strong>When to disable:</strong><br>
-		 * Schema validation can be disabled ({@code checkDatabase(false)}) in scenarios where:
-		 * <ul>
-		 *   <li>You want to defer validation to a later time</li>
-		 *   <li>The database user lacks permissions to query information_schema tables</li>
-		 *   <li>You're using a custom schema that intentionally differs from the standard</li>
-		 *   <li>You need to minimize startup time in performance-critical scenarios</li>
-		 * </ul>
-		 * <p>
-		 * <strong>Execution order:</strong><br>
-		 * If both {@link #initializeDatabase()} and {@code checkDatabase()} are enabled, the
-		 * initialization runs first, followed immediately by validation to ensure the schema
-		 * was created correctly.
-		 * <p>
-		 * <strong>Example usage:</strong>
-		 * <pre>{@code
-		 * // Validate existing schema (default behavior)
-		 * EventStorage storage = PostgresEventStorage.newBuilder()
-		 *     .checkDatabase(true)  // explicit, but this is the default
-		 *     .build();
 		 *
-		 * // Initialize and validate in one step
-		 * EventStorage storage = PostgresEventStorage.newBuilder()
-		 *     .initializeDatabase()
-		 *     .checkDatabase(true)  // validates the newly created schema
-		 *     .build();
-		 *
-		 * // Skip validation (not recommended for production)
-		 * EventStorage storage = PostgresEventStorage.newBuilder()
-		 *     .checkDatabase(false)
-		 *     .build();
-		 * }</pre>
-		 *
-		 * @param value {@code true} to validate the database schema (default), {@code false} to skip validation
+		 * @param value {@code true} to validate the database schema, {@code false} to skip validation
 		 * @return this Builder for method chaining
-		 * @throws org.sliceworkz.eventstore.spi.EventStorageException if validation is enabled and schema is invalid
-		 * @see #initializeDatabase(boolean)
-		 * @see PostgresEventStorageImpl#checkDatabase()
+		 * @deprecated Use {@link #databaseInitMode(DatabaseInitMode)} or {@link #validateDatabase()} instead.
+		 *     Note: passing {@code false} sets the mode to {@link DatabaseInitMode#NONE} only if the
+		 *     current mode is {@link DatabaseInitMode#VALIDATE} or {@link DatabaseInitMode#ENSURE}.
 		 */
+		@Deprecated
 		public Builder checkDatabase ( boolean value ) {
-			this.checkDatabase = value;
+			if ( !value && (this.databaseInitMode == DatabaseInitMode.VALIDATE || this.databaseInitMode == DatabaseInitMode.ENSURE) ) {
+				this.databaseInitMode = DatabaseInitMode.NONE;
+			}
 			return this;
 		}
 
@@ -414,14 +416,19 @@ public interface PostgresEventStorage {
 		 * settings. If no custom DataSource was provided, it will be automatically created from
 		 * the {@code db.properties} file using {@link DataSourceFactory}.
 		 * <p>
-		 * If {@link #initializeDatabase()} was called, the database schema will be initialized
-		 * before returning the storage instance.
+		 * The configured {@link DatabaseInitMode} determines how the database schema is handled:
+		 * <ul>
+		 *   <li>{@link DatabaseInitMode#NONE}: No schema operations</li>
+		 *   <li>{@link DatabaseInitMode#VALIDATE}: Schema validation only</li>
+		 *   <li>{@link DatabaseInitMode#ENSURE}: Create missing objects, then validate (default)</li>
+		 *   <li>{@link DatabaseInitMode#INITIALIZE}: Drop and recreate all objects, then validate</li>
+		 * </ul>
 		 * <p>
 		 * The returned EventStorage can be passed to {@link EventStoreFactory#eventStore(EventStorage)}
 		 * to create an EventStore instance.
 		 *
 		 * @return a configured EventStorage instance backed by PostgreSQL
-		 * @throws RuntimeException if database configuration cannot be loaded or schema initialization fails
+		 * @throws RuntimeException if database configuration cannot be loaded or schema operations fail
 		 * @see #buildStore()
 		 * @see EventStoreFactory#eventStore(EventStorage)
 		 */
@@ -436,7 +443,7 @@ public interface PostgresEventStorage {
 					monitoringDataSource = dataSource;
 				}
 			}
-			
+
 			if ( dataSource != null && dataSource instanceof HikariDataSource hds ) {
 				try {
 					hds.setMetricRegistry(meterRegistry);
@@ -451,13 +458,13 @@ public interface PostgresEventStorage {
 					// already set
 				}
 			}
-			
+
 			var result = new PostgresEventStorageImpl(name, dataSource, monitoringDataSource, limit, prefix);
-			if ( initializeDatabase ) {
-				result.initializeDatabase();
-			}
-			if ( checkDatabase ) {
-				result.checkDatabase();
+			switch ( databaseInitMode ) {
+				case NONE       -> { }
+				case VALIDATE   -> result.validateDatabase();
+				case ENSURE     -> result.ensureDatabase();
+				case INITIALIZE -> result.initializeDatabase();
 			}
 			// if we didn't fail until here, then we can start the executor threads
 			result.start();

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -183,10 +183,61 @@ public class PostgresEventStorageImpl implements EventStorage {
 		return prefix;
 	}
 	
+	/**
+	 * Validates that all required database objects exist and are correctly defined.
+	 * <p>
+	 * This is equivalent to using {@link DatabaseInitMode#VALIDATE}. No objects are created
+	 * or modified. Throws {@link EventStorageException} if any required object is missing
+	 * or malformed.
+	 *
+	 * @return this instance for method chaining
+	 * @throws EventStorageException if the schema is invalid
+	 */
+	public PostgresEventStorageImpl validateDatabase ( ) {
+		checkDatabase();
+		return this;
+	}
+
+	/**
+	 * Creates missing database objects if they do not exist, leaving existing objects untouched,
+	 * then validates the schema.
+	 * <p>
+	 * This is equivalent to using {@link DatabaseInitMode#ENSURE}. It is safe to run repeatedly.
+	 * If an existing object has an incompatible definition, the subsequent validation will
+	 * detect and report it.
+	 *
+	 * @return this instance for method chaining
+	 * @throws EventStorageException if schema creation or validation fails
+	 */
+	public PostgresEventStorageImpl ensureDatabase ( ) {
+		LOGGER.info("Ensuring database schema for prefix '{}'", prefix);
+		executeSqlScript("ensure-schema.sql");
+		checkDatabase();
+		return this;
+	}
+
+	/**
+	 * Drops all event store objects and recreates them from scratch, then validates the schema.
+	 * <p>
+	 * This is equivalent to using {@link DatabaseInitMode#INITIALIZE}.
+	 * <p>
+	 * <strong>Warning:</strong> This is destructive — all existing event data will be lost.
+	 *
+	 * @return this instance for method chaining
+	 * @throws EventStorageException if schema initialization or validation fails
+	 */
 	public PostgresEventStorageImpl initializeDatabase ( ) {
-		try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("initialisation.sql")) {
+		LOGGER.info("Initializing database schema for prefix '{}' (drop and recreate)", prefix);
+		executeSqlScript("drop-schema.sql");
+		executeSqlScript("ensure-schema.sql");
+		checkDatabase();
+		return this;
+	}
+
+	private void executeSqlScript ( String scriptName ) {
+		try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(scriptName)) {
 			if (inputStream == null) {
-				throw new EventStorageException("Could not find initialisation.sql in classpath");
+				throw new EventStorageException("Could not find %s in classpath".formatted(scriptName));
 			}
 
 			String sql = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
@@ -199,12 +250,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 			}
 
 		} catch (IOException | SQLException e) {
-			throw new EventStorageException("Failed to initialize database", e);
+			throw new EventStorageException("Failed to execute database script: %s".formatted(scriptName), e);
 		}
-		return this;
 	}
 
-	public PostgresEventStorageImpl checkDatabase ( ) {
+	PostgresEventStorageImpl checkDatabase ( ) {
 		LOGGER.info("Starting database schema validation for prefix '{}'", prefix);
 
 		try ( Connection readConnection = dataSource.getConnection() ) {

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/package-info.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/package-info.java
@@ -34,9 +34,8 @@
  *
  * <h2>Quick Start:</h2>
  * <pre>{@code
- * // Using default configuration from db.properties
+ * // Using default configuration from db.properties (default mode is ENSURE)
  * EventStore eventStore = PostgresEventStorage.newBuilder()
- *     .initializeDatabase()
  *     .buildStore();
  * }</pre>
  *
@@ -73,13 +72,12 @@
  *     .dataSource(dataSource)
  *     .prefix("tenant1_")
  *     .resultLimit(10000)
- *     .initializeDatabase()
  *     .buildStore();
  * }</pre>
  *
  * <h2>Database Schema:</h2>
  * <p>
- * When {@code initializeDatabase()} is called, the following structures are created:
+ * The following database structures are managed by the event store:
  * <ul>
  *   <li><strong>{@code PREFIX_events}</strong>: Main event storage table with columns for stream, type, data, tags, and timestamp</li>
  *   <li><strong>{@code PREFIX_bookmarks}</strong>: Event processor position tracking</li>

--- a/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
@@ -21,16 +21,15 @@
 ----
 ---- Eventstore database schema DDL
 ----
----- 
+----
 ---- "PREFIX" can be removed or replaced to allow multiple eventstores next to each other in one database schema
----- 
+----
 
 
 
 ---- EVENTS
 
-DROP TABLE IF EXISTS events CASCADE;
-CREATE TABLE events (
+CREATE TABLE IF NOT EXISTS events (
       -- Primary key and positioning
       event_position BIGSERIAL PRIMARY KEY,
 
@@ -39,11 +38,11 @@ CREATE TABLE events (
 
       -- Event identification
       event_id UUID NOT NULL UNIQUE,
-      
+
       -- Idempotency key
       idempotency_key TEXT UNIQUE,
 
-      -- Stream identification  
+      -- Stream identification
       stream_context TEXT NOT NULL,
       stream_purpose TEXT NOT NULL DEFAULT '',
 
@@ -59,34 +58,31 @@ CREATE TABLE events (
 
       -- Tags as string array
       event_tags TEXT[] DEFAULT '{}'
-      
+
   ) WITH (FILLFACTOR = 100);
 
 
 	-- Compact BRIN index on event_position
-	CREATE INDEX idx_events_position_brin ON events USING BRIN (event_position);
+	CREATE INDEX IF NOT EXISTS idx_events_position_brin ON events USING BRIN (event_position);
 
 	-- Allows efficient filtering on multiple dimensions
 	-- Primary index for your most common query pattern
 	-- B-tree handles equality (=) and IN clauses efficiently
-	DROP INDEX IF EXISTS idx_events_stream_type_position;
-	CREATE INDEX idx_events_stream_type_position ON events (
-	    stream_context, 
-	    stream_purpose, 
+	CREATE INDEX IF NOT EXISTS idx_events_stream_type_position ON events (
+	    stream_context,
+	    stream_purpose,
 	    event_type,
 	    event_tx,
 	    event_position  -- for ordering
 	);
-	
+
 	-- Separate GIN index ONLY for tag filtering
-	DROP INDEX IF EXISTS idx_events_tags;
-	CREATE INDEX idx_events_tags ON events USING GIN (event_tags);
-	
+	CREATE INDEX IF NOT EXISTS idx_events_tags ON events USING GIN (event_tags);
+
 	-- Keep stream position index for stream reads
-	DROP INDEX IF EXISTS idx_events_stream_position;
-	CREATE INDEX idx_events_stream_position ON events (
-	    stream_context, 
-	    stream_purpose, 
+	CREATE INDEX IF NOT EXISTS idx_events_stream_position ON events (
+	    stream_context,
+	    stream_purpose,
 	    event_tx,
 	    event_position
 	);
@@ -94,32 +90,39 @@ CREATE TABLE events (
 
 ---- EVENT APPEND NOTIFICATIONS
 
-CREATE OR REPLACE FUNCTION notify_event_appended()
-RETURNS trigger AS $$
-BEGIN
-    PERFORM pg_notify('event_appended',
-        jsonb_build_object(
-            'streamContext', NEW.stream_context,
-            'streamPurpose', NEW.stream_purpose,
-            'eventPosition', NEW.event_position,
-            'eventTx', NEW.event_tx,
-            'eventId', NEW.event_id
-        )::text
-    );
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname = current_schema() AND p.proname = 'notify_event_appended') THEN
+    CREATE FUNCTION notify_event_appended()
+    RETURNS trigger AS $fn$
+    BEGIN
+        PERFORM pg_notify('event_appended',
+            jsonb_build_object(
+                'streamContext', NEW.stream_context,
+                'streamPurpose', NEW.stream_purpose,
+                'eventPosition', NEW.event_position,
+                'eventTx', NEW.event_tx,
+                'eventId', NEW.event_id
+            )::text
+        );
+        RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  END IF;
+END $$;
 
-CREATE OR REPLACE TRIGGER table_insert_trigger
-    AFTER INSERT ON events
-    FOR EACH ROW
-    EXECUTE FUNCTION notify_event_appended();
-    
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.triggers WHERE trigger_schema = current_schema() AND event_object_table = 'events' AND trigger_name = 'table_insert_trigger') THEN
+    CREATE TRIGGER table_insert_trigger
+        AFTER INSERT ON events
+        FOR EACH ROW
+        EXECUTE FUNCTION notify_event_appended();
+  END IF;
+END $$;
 
 
----- BOOKMARKING 
-    
-DROP TABLE IF EXISTS bookmarks CASCADE;  
+
+---- BOOKMARKING
+
 CREATE TABLE IF NOT EXISTS bookmarks (
       reader TEXT PRIMARY KEY,
       event_position BIGINT NOT NULL,
@@ -135,24 +138,31 @@ CREATE TABLE IF NOT EXISTS bookmarks (
 
   CREATE INDEX IF NOT EXISTS idx_bookmarks_event_id ON bookmarks(event_id);
 
-    
-CREATE OR REPLACE FUNCTION notify_bookmark_placed()
-RETURNS trigger AS $$
-BEGIN
-    PERFORM pg_notify('bookmark_placed',
-        jsonb_build_object(
-            'reader', NEW.reader,
-            'eventTx', NEW.event_tx,
-            'eventPosition', NEW.event_position,
-            'eventId', NEW.event_id
-        )::text
-    );
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER table_insert_or_update_trigger
-    AFTER INSERT OR UPDATE ON bookmarks
-    FOR EACH ROW
-    EXECUTE FUNCTION notify_bookmark_placed();
-    
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname = current_schema() AND p.proname = 'notify_bookmark_placed') THEN
+    CREATE FUNCTION notify_bookmark_placed()
+    RETURNS trigger AS $fn$
+    BEGIN
+        PERFORM pg_notify('bookmark_placed',
+            jsonb_build_object(
+                'reader', NEW.reader,
+                'eventTx', NEW.event_tx,
+                'eventPosition', NEW.event_position,
+                'eventId', NEW.event_id
+            )::text
+        );
+        RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.triggers WHERE trigger_schema = current_schema() AND event_object_table = 'bookmarks' AND trigger_name = 'table_insert_or_update_trigger') THEN
+    CREATE TRIGGER table_insert_or_update_trigger
+        AFTER INSERT OR UPDATE ON bookmarks
+        FOR EACH ROW
+        EXECUTE FUNCTION notify_bookmark_placed();
+  END IF;
+END $$;

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/drop-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/drop-schema.sql
@@ -1,0 +1,29 @@
+--
+-- Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+-- Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Lesser General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Lesser General Public License for more details.
+--
+-- You should have received a copy of the GNU Lesser General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+----
+---- __NOTICE__
+----
+---- Eventstore database schema DROP script
+----
+----
+---- "PREFIX" can be removed or replaced to allow multiple eventstores next to each other in one database schema
+----
+
+DROP TABLE IF EXISTS PREFIX_bookmarks CASCADE;
+DROP TABLE IF EXISTS PREFIX_events CASCADE;

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
@@ -21,16 +21,15 @@
 ----
 ---- Eventstore database schema DDL
 ----
----- 
+----
 ---- "PREFIX" can be removed or replaced to allow multiple eventstores next to each other in one database schema
----- 
+----
 
 
 
 ---- EVENTS
 
-DROP TABLE IF EXISTS PREFIX_events CASCADE;
-CREATE TABLE PREFIX_events (
+CREATE TABLE IF NOT EXISTS PREFIX_events (
       -- Primary key and positioning
       event_position BIGSERIAL PRIMARY KEY,
 
@@ -39,11 +38,11 @@ CREATE TABLE PREFIX_events (
 
       -- Event identification
       event_id UUID NOT NULL UNIQUE,
-      
+
       -- Idempotency key
       idempotency_key TEXT UNIQUE,
 
-      -- Stream identification  
+      -- Stream identification
       stream_context TEXT NOT NULL,
       stream_purpose TEXT NOT NULL DEFAULT '',
 
@@ -59,34 +58,31 @@ CREATE TABLE PREFIX_events (
 
       -- Tags as string array
       event_tags TEXT[] DEFAULT '{}'
-      
+
   ) WITH (FILLFACTOR = 100);
 
 
 	-- Compact BRIN index on event_position
-	CREATE INDEX PREFIX_idx_events_position_brin ON PREFIX_events USING BRIN (event_position);
+	CREATE INDEX IF NOT EXISTS PREFIX_idx_events_position_brin ON PREFIX_events USING BRIN (event_position);
 
 	-- Allows efficient filtering on multiple dimensions
 	-- Primary index for your most common query pattern
 	-- B-tree handles equality (=) and IN clauses efficiently
-	DROP INDEX IF EXISTS PREFIX_idx_events_stream_type_position;
-	CREATE INDEX PREFIX_idx_events_stream_type_position ON PREFIX_events (
-	    stream_context, 
-	    stream_purpose, 
+	CREATE INDEX IF NOT EXISTS PREFIX_idx_events_stream_type_position ON PREFIX_events (
+	    stream_context,
+	    stream_purpose,
 	    event_type,
 	    event_tx,
 	    event_position  -- for ordering
 	);
-	
+
 	-- Separate GIN index ONLY for tag filtering
-	DROP INDEX IF EXISTS PREFIX_idx_events_tags;
-	CREATE INDEX PREFIX_idx_events_tags ON PREFIX_events USING GIN (event_tags);
-	
+	CREATE INDEX IF NOT EXISTS PREFIX_idx_events_tags ON PREFIX_events USING GIN (event_tags);
+
 	-- Keep stream position index for stream reads
-	DROP INDEX IF EXISTS PREFIX_idx_events_stream_position;
-	CREATE INDEX PREFIX_idx_events_stream_position ON PREFIX_events (
-	    stream_context, 
-	    stream_purpose, 
+	CREATE INDEX IF NOT EXISTS PREFIX_idx_events_stream_position ON PREFIX_events (
+	    stream_context,
+	    stream_purpose,
 	    event_tx,
 	    event_position
 	);
@@ -94,32 +90,39 @@ CREATE TABLE PREFIX_events (
 
 ---- EVENT APPEND NOTIFICATIONS
 
-CREATE OR REPLACE FUNCTION PREFIX_notify_event_appended()
-RETURNS trigger AS $$
-BEGIN
-    PERFORM pg_notify('PREFIX_event_appended',
-        jsonb_build_object(
-            'streamContext', NEW.stream_context,
-            'streamPurpose', NEW.stream_purpose,
-            'eventPosition', NEW.event_position,
-            'eventTx', NEW.event_tx,
-            'eventId', NEW.event_id
-        )::text
-    );
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname = current_schema() AND p.proname = 'PREFIX_notify_event_appended') THEN
+    CREATE FUNCTION PREFIX_notify_event_appended()
+    RETURNS trigger AS $fn$
+    BEGIN
+        PERFORM pg_notify('PREFIX_event_appended',
+            jsonb_build_object(
+                'streamContext', NEW.stream_context,
+                'streamPurpose', NEW.stream_purpose,
+                'eventPosition', NEW.event_position,
+                'eventTx', NEW.event_tx,
+                'eventId', NEW.event_id
+            )::text
+        );
+        RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  END IF;
+END $$;
 
-CREATE OR REPLACE TRIGGER table_insert_trigger
-    AFTER INSERT ON PREFIX_events
-    FOR EACH ROW
-    EXECUTE FUNCTION PREFIX_notify_event_appended();
-    
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.triggers WHERE trigger_schema = current_schema() AND event_object_table = 'PREFIX_events' AND trigger_name = 'table_insert_trigger') THEN
+    CREATE TRIGGER table_insert_trigger
+        AFTER INSERT ON PREFIX_events
+        FOR EACH ROW
+        EXECUTE FUNCTION PREFIX_notify_event_appended();
+  END IF;
+END $$;
 
 
----- BOOKMARKING 
-    
-DROP TABLE IF EXISTS PREFIX_bookmarks CASCADE;  
+
+---- BOOKMARKING
+
 CREATE TABLE IF NOT EXISTS PREFIX_bookmarks (
       reader TEXT PRIMARY KEY,
       event_position BIGINT NOT NULL,
@@ -135,24 +138,31 @@ CREATE TABLE IF NOT EXISTS PREFIX_bookmarks (
 
   CREATE INDEX IF NOT EXISTS PREFIX_idx_bookmarks_event_id ON PREFIX_bookmarks(event_id);
 
-    
-CREATE OR REPLACE FUNCTION PREFIX_notify_bookmark_placed()
-RETURNS trigger AS $$
-BEGIN
-    PERFORM pg_notify('PREFIX_bookmark_placed',
-        jsonb_build_object(
-            'reader', NEW.reader,
-            'eventTx', NEW.event_tx,
-            'eventPosition', NEW.event_position,
-            'eventId', NEW.event_id
-        )::text
-    );
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER table_insert_or_update_trigger
-    AFTER INSERT OR UPDATE ON PREFIX_bookmarks
-    FOR EACH ROW
-    EXECUTE FUNCTION PREFIX_notify_bookmark_placed();
-    
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname = current_schema() AND p.proname = 'PREFIX_notify_bookmark_placed') THEN
+    CREATE FUNCTION PREFIX_notify_bookmark_placed()
+    RETURNS trigger AS $fn$
+    BEGIN
+        PERFORM pg_notify('PREFIX_bookmark_placed',
+            jsonb_build_object(
+                'reader', NEW.reader,
+                'eventTx', NEW.event_tx,
+                'eventPosition', NEW.event_position,
+                'eventId', NEW.event_id
+            )::text
+        );
+        RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.triggers WHERE trigger_schema = current_schema() AND event_object_table = 'PREFIX_bookmarks' AND trigger_name = 'table_insert_or_update_trigger') THEN
+    CREATE TRIGGER table_insert_or_update_trigger
+        AFTER INSERT OR UPDATE ON PREFIX_bookmarks
+        FOR EACH ROW
+        EXECUTE FUNCTION PREFIX_notify_bookmark_placed();
+  END IF;
+END $$;

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageInitialisationTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageInitialisationTest.java
@@ -37,40 +37,75 @@ public class PostgresEventStorageInitialisationTest {
 		.prefix("inittwice_")
 		.dataSource(PostgresContainer.dataSource())
 		.initializeDatabase()
-		.checkDatabase(true)
 		.build();
 
 		((PostgresEventStorageImpl)storage).stop();
-		
+
 		// second time, should drop/create once again
-		
+
 		storage = PostgresEventStorage.newBuilder()
 		.name("unit-test")
 		.prefix("inittwice_")
 		.dataSource(PostgresContainer.dataSource())
 		.initializeDatabase()
-		.checkDatabase(true)
 		.build();
 
 		((PostgresEventStorageImpl)storage).stop();
-		
+
 		PostgresContainer.closeDataSource();
 	}
-	
-	
+
 	@Test
-	public void testCheckDatabase ( ) {
+	public void testEnsureDatabase ( ) {
+		// first time: ensure creates everything
+		EventStorage storage = PostgresEventStorage.newBuilder()
+		.name("unit-test")
+		.prefix("ensure_")
+		.dataSource(PostgresContainer.dataSource())
+		.ensureDatabase()
+		.build();
+
+		((PostgresEventStorageImpl)storage).stop();
+
+		// second time: ensure leaves existing objects untouched
+		storage = PostgresEventStorage.newBuilder()
+		.name("unit-test")
+		.prefix("ensure_")
+		.dataSource(PostgresContainer.dataSource())
+		.ensureDatabase()
+		.build();
+
+		((PostgresEventStorageImpl)storage).stop();
+
+		PostgresContainer.closeDataSource();
+	}
+
+	@Test
+	public void testValidateDatabase ( ) {
 		EventStorageException e = assertThrows ( EventStorageException.class, () -> {
 			PostgresEventStorage.newBuilder()
 			.name("unit-test")
 			.prefix("check_")
 			.dataSource(PostgresContainer.dataSource())
-			//.initializeDatabase() // not init, check should fail!
-			.checkDatabase(true)
+			.validateDatabase()
 			.build();
 		});
 		assertEquals("Required table 'check_events' does not exist", e.getMessage());
-		
+
+		PostgresContainer.closeDataSource();
+	}
+
+	@Test
+	public void testDefaultModeIsEnsure ( ) {
+		// default mode (ENSURE) should create schema on empty database
+		EventStorage storage = PostgresEventStorage.newBuilder()
+		.name("unit-test")
+		.prefix("defaultmode_")
+		.dataSource(PostgresContainer.dataSource())
+		.build();
+
+		((PostgresEventStorageImpl)storage).stop();
+
 		PostgresContainer.closeDataSource();
 	}
 


### PR DESCRIPTION
## Summary
Refactored the database initialization logic in PostgresEventStorage to use a new `DatabaseInitMode` enum instead of separate boolean flags. This provides a clearer, more explicit API for controlling schema management during startup.

## Key Changes

- **New `DatabaseInitMode` enum** with four modes:
  - `NONE`: No schema operations (assume schema exists)
  - `VALIDATE`: Validate schema exists and is correct (read-only)
  - `ENSURE`: Create missing objects, then validate (default, safe to run repeatedly)
  - `INITIALIZE`: Drop and recreate all objects (destructive, for test environments)

- **Replaced boolean flags** with single `databaseInitMode` field in `PostgresEventStorage.Builder`
  - Removed `initializeDatabase` boolean field
  - Removed `checkDatabase` boolean field
  - Added `databaseInitMode` field with default value `DatabaseInitMode.ENSURE`

- **New builder convenience methods**:
  - `databaseInitMode(DatabaseInitMode mode)`: Set the mode explicitly
  - `validateDatabase()`: Shorthand for `VALIDATE` mode
  - `ensureDatabase()`: Shorthand for `ENSURE` mode
  - `initializeDatabase()`: Changed to set `INITIALIZE` mode (was boolean before)

- **Deprecated old methods** with migration path:
  - `initializeDatabase(boolean value)`: Now delegates to `databaseInitMode`
  - `checkDatabase(boolean value)`: Now delegates to `databaseInitMode`

- **Updated SQL scripts**:
  - Renamed `initialisation.sql` → `ensure-schema.sql` (idempotent, uses `IF NOT EXISTS`)
  - Created new `drop-schema.sql` for destructive initialization
  - Modified `ensure-schema.sql` to use conditional DDL statements instead of `DROP` statements

- **New methods in `PostgresEventStorageImpl`**:
  - `validateDatabase()`: Validates schema only
  - `ensureDatabase()`: Creates missing objects then validates
  - `initializeDatabase()`: Drops and recreates schema then validates
  - `executeSqlScript(String scriptName)`: Extracted common SQL execution logic

- **Updated documentation** and examples throughout to reflect the new API and default behavior

## Notable Implementation Details

- The default mode is now `ENSURE`, which is safer than the previous default (no initialization)
- The `ensure-schema.sql` script is now idempotent using `CREATE TABLE IF NOT EXISTS` and conditional function/trigger creation
- The builder's `build()` method uses a switch statement to handle the four modes cleanly
- Backward compatibility maintained through deprecated methods that delegate to the new enum-based approach
- Updated test cases to use new API and added test for default `ENSURE` mode behavior

https://claude.ai/code/session_01RT7WZbhPhKzsdepwqa1yFE