### PR TITLE
Simplify OptimisticLockingTest by using stored reference directly

### DIFF
--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/OptimisticLockingTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/OptimisticLockingTest.java
@@ -140,8 +140,7 @@ public class OptimisticLockingTest {
 
 		// Try to append on expecting stream with assumed only first append (should fail)
 		EphemeralEvent<ThirdDomainEvent> thirdEvent = Event.of(new ThirdDomainEvent("test3"), Tags.none());
-		// re-read from stread to get position filled in
-		AppendCriteria criteria = AppendCriteria.of(EventQuery.matchAll(), eventStream.getEventById(firstEventStored.reference().id()).get().reference());
+		AppendCriteria criteria = AppendCriteria.of(EventQuery.matchAll(), firstEventStored.reference());
 		
 		// Should throw OptimisticLockingException
 		assertThrows(OptimisticLockingException.class, () -> {


### PR DESCRIPTION
## Summary
Simplified the test setup in `OptimisticLockingTest` by removing an unnecessary re-read operation and using the already-stored event reference directly.

## Key Changes
- Removed redundant `eventStream.getEventById()` call that was re-reading the event from the stream
- Updated `AppendCriteria` to use `firstEventStored.reference()` directly instead of fetching it again
- Removed outdated comment about re-reading from stream to get position filled in

## Implementation Details
The change improves test clarity and efficiency by eliminating unnecessary I/O. The event reference is already available from the initial store operation (`firstEventStored`), so there's no need to re-query the stream to obtain it. This makes the test more straightforward while maintaining the same validation logic for optimistic locking behavior.

https://claude.ai/code/session_01YApxKjyqV5uFrL4VsZJPPw