### PR TITLE
Support multi-event upcasting with index-based ordering

### DIFF
--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventReference.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventReference.java
@@ -23,7 +23,7 @@ package org.sliceworkz.eventstore.events;
  * EventReference serves dual purposes:
  * <ul>
  *   <li><strong>Identity:</strong> The {@link EventId} provides a globally unique identifier</li>
- *   <li><strong>Ordering:</strong> The tx/position combination indicates where the event appears in its stream</li>
+ *   <li><strong>Ordering:</strong> The tx/position/index combination indicates where the event appears in its stream</li>
  * </ul>
  * <p>
  * Event references are crucial for implementing Dynamic Consistency Boundaries (DCB). When appending
@@ -33,6 +33,11 @@ package org.sliceworkz.eventstore.events;
  * Transactions (tx) are an incrementing number without business meaning.
  * Positions start at 1 (not 0) and increment sequentially within a stream.
  * Within one transaction, multiple positions can exist if these events were added as a single unit of work.
+ * <p>
+ * The index field distinguishes multiple events that originate from the same stored event through
+ * upcasting. When a legacy event is upcasted into multiple new events, each receives the same
+ * id/position/tx but a different index (0, 1, 2, ...). For non-upcasted events, the index is always 0.
+ * The index participates in ordering: events are compared by (tx, position, index).
  *
  * <h2>Example Usage:</h2>
  * <pre>{@code
@@ -53,11 +58,12 @@ package org.sliceworkz.eventstore.events;
  * @param id the globally unique event identifier
  * @param position the sequential position of the event within its stream (starts at 1)
  * @param tx the transaction during which this event was appended. Primary sort criterion before position
+ * @param index the sub-event index within a single stored event (0 for non-upcasted events, 0..N for upcasted sub-events)
  * @see Event
  * @see EventId
  * @see org.sliceworkz.eventstore.stream.AppendCriteria
  */
-public record EventReference ( EventId id, long position, long tx ) {
+public record EventReference ( EventId id, long position, long tx, int index ) {
 
 	/**
 	 * Constructs an EventReference with validation.
@@ -67,80 +73,95 @@ public record EventReference ( EventId id, long position, long tx ) {
 	 * @param id the event ID (required)
 	 * @param position the position in the stream (required, must be &gt; 0)
 	 * @param tx the transaction number (required)
-	 * @throws IllegalArgumentException if id is null, position is null, or position is &le; 0
+	 * @param index the sub-event index (must be &ge; 0)
+	 * @throws IllegalArgumentException if id is null, position is &le; 0, or index is &lt; 0
 	 */
-	public EventReference ( EventId id, long position, long tx  ) {
+	public EventReference ( EventId id, long position, long tx, int index ) {
 		if ( id == null ) {
 			throw new IllegalArgumentException("event id in reference cannot be null");
 		}
 		if ( position <= 0 ) {
 			throw new IllegalArgumentException("position %d is invalid, should be larger than 0".formatted(position));
 		}
+		if ( index < 0 ) {
+			throw new IllegalArgumentException("index %d is invalid, should be 0 or larger".formatted(index));
+		}
 
 		this.id = id;
 		this.position = position;
 		this.tx = tx;
+		this.index = index;
 	}
 
 	/**
 	 * Checks if this event happened before another event.
 	 * <p>
-	 * Events are ordered primarily by transaction (tx), and secondarily by position within the transaction.
-	 * An event happened before another if:
-	 * <ul>
-	 *   <li>Its transaction number is lower, OR</li>
-	 *   <li>Its transaction number is equal AND its position is lower</li>
-	 * </ul>
+	 * Events are ordered primarily by transaction (tx), secondarily by position within the transaction,
+	 * and finally by index within the same stored event (for upcasted sub-events).
 	 *
 	 * @param other the event reference to compare against
 	 * @return true if this event happened before the other event, false otherwise
 	 */
 	public boolean happenedBefore ( EventReference other ) {
-		return (this.tx < other.tx) || ((this.tx==other.tx) && (this.position < other.position));
+		if ( this.tx != other.tx ) return this.tx < other.tx;
+		if ( this.position != other.position ) return this.position < other.position;
+		return this.index < other.index;
 	}
 
 	/**
 	 * Checks if this event happened after another event.
 	 * <p>
-	 * Events are ordered primarily by transaction (tx), and secondarily by position within the transaction.
-	 * An event happened after another if:
-	 * <ul>
-	 *   <li>Its transaction number is higher, OR</li>
-	 *   <li>Its transaction number is equal AND its position is higher</li>
-	 * </ul>
+	 * Events are ordered primarily by transaction (tx), secondarily by position within the transaction,
+	 * and finally by index within the same stored event (for upcasted sub-events).
 	 *
 	 * @param other the event reference to compare against
 	 * @return true if this event happened after the other event, false otherwise
 	 */
 	public boolean happenedAfter ( EventReference other ) {
-		return (this.tx > other.tx) || ((this.tx==other.tx) && (this.position > other.position));
+		if ( this.tx != other.tx ) return this.tx > other.tx;
+		if ( this.position != other.position ) return this.position > other.position;
+		return this.index > other.index;
 	}
 
 	/**
-	 * Creates an EventReference from an existing event ID, position, and transaction.
+	 * Creates an EventReference from an existing event ID, position, transaction, and index.
 	 *
 	 * @param id the event ID
 	 * @param position the position in the stream (must be &gt; 0)
 	 * @param tx the transaction number
+	 * @param index the sub-event index (0 for non-upcasted events)
 	 * @return a new EventReference
-	 * @throws IllegalArgumentException if id is null, position is null, or position is &le; 0
+	 * @throws IllegalArgumentException if id is null, position is &le; 0, or index is &lt; 0
 	 */
-	public static EventReference of ( EventId id, long position, long tx ) {
-		return new EventReference(id, position, tx);
+	public static EventReference of ( EventId id, long position, long tx, int index ) {
+		return new EventReference(id, position, tx, index);
 	}
 
 	/**
-	 * Creates a new EventReference with a randomly generated ID.
+	 * Creates an EventReference from an existing event ID, position, and transaction with index 0.
+	 *
+	 * @param id the event ID
+	 * @param position the position in the stream (must be &gt; 0)
+	 * @param tx the transaction number
+	 * @return a new EventReference with index 0
+	 * @throws IllegalArgumentException if id is null, position is null, or position is &le; 0
+	 */
+	public static EventReference of ( EventId id, long position, long tx ) {
+		return new EventReference(id, position, tx, 0);
+	}
+
+	/**
+	 * Creates a new EventReference with a randomly generated ID and index 0.
 	 * <p>
 	 * This is typically used internally when appending events.
 	 *
 	 * @param position the position in the stream (must be &gt; 0)
 	 * @param tx the transaction number
-	 * @return a new EventReference with a generated UUID-based ID
+	 * @return a new EventReference with a generated UUID-based ID and index 0
 	 * @throws IllegalArgumentException if position is null or &le; 0
 	 */
 	public static EventReference create ( long position, long tx ) {
-		return of ( EventId.create(), position, tx );
+		return of ( EventId.create(), position, tx, 0 );
 	}
 
 	/**
@@ -153,6 +174,16 @@ public record EventReference ( EventId id, long position, long tx ) {
 	 */
 	public static EventReference none ( ) {
 		return null;
+	}
+
+	/**
+	 * Creates a new EventReference with the same id, position, and tx but a different index.
+	 *
+	 * @param index the new sub-event index
+	 * @return a new EventReference with the specified index
+	 */
+	public EventReference withIndex ( int index ) {
+		return new EventReference(this.id, this.position, this.tx, index);
 	}
 
 }

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/LegacyEvent.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/LegacyEvent.java
@@ -76,15 +76,15 @@ import java.lang.annotation.Target;
  * public class CustomerRegisteredUpcaster
  *     implements Upcast<CustomerHistoricalEvent.CustomerRegistered, CustomerEvent.CustomerRegisteredV2> {
  *
- *     public CustomerEvent.CustomerRegisteredV2 upcast(CustomerHistoricalEvent.CustomerRegistered legacy) {
- *         return new CustomerEvent.CustomerRegisteredV2(
+ *     public List<CustomerEvent.CustomerRegisteredV2> upcast(CustomerHistoricalEvent.CustomerRegistered legacy) {
+ *         return List.of(new CustomerEvent.CustomerRegisteredV2(
  *             new Name(legacy.name()),
  *             Email.unknown() // provide default for new required field
- *         );
+ *         ));
  *     }
  *
- *     public Class<CustomerEvent.CustomerRegisteredV2> targetType() {
- *         return CustomerEvent.CustomerRegisteredV2.class;
+ *     public Set<Class<? extends CustomerEvent.CustomerRegisteredV2>> targetTypes() {
+ *         return Set.of(CustomerEvent.CustomerRegisteredV2.class);
  *     }
  * }
  *

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Upcast.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Upcast.java
@@ -50,7 +50,7 @@ import java.util.Set;
  *   <li><b>Type Safety:</b> Generic parameters ensure compile-time verification of event types</li>
  * </ul>
  *
- * <h2>Basic Example:</h2>
+ * <h2>Basic Example - One-to-One Upcast:</h2>
  * <pre>{@code
  * // Legacy event (stored in database)
  * sealed interface CustomerHistoricalEvent {
@@ -68,85 +68,18 @@ import java.util.Set;
  *     implements Upcast<CustomerHistoricalEvent.CustomerRegistered, CustomerEvent.CustomerRegisteredV2> {
  *
  *     @Override
- *     public CustomerEvent.CustomerRegisteredV2 upcast(CustomerHistoricalEvent.CustomerRegistered historical) {
- *         // Transform String to Name value object
- *         return new CustomerEvent.CustomerRegisteredV2(new Name(historical.name()));
+ *     public List<CustomerEvent.CustomerRegisteredV2> upcast(CustomerHistoricalEvent.CustomerRegistered historical) {
+ *         return List.of(new CustomerEvent.CustomerRegisteredV2(new Name(historical.name())));
  *     }
  *
  *     @Override
- *     public Class<CustomerEvent.CustomerRegisteredV2> targetType() {
- *         return CustomerEvent.CustomerRegisteredV2.class;
+ *     public Set<Class<? extends CustomerEvent.CustomerRegisteredV2>> targetTypes() {
+ *         return Set.of(CustomerEvent.CustomerRegisteredV2.class);
  *     }
  * }
  * }</pre>
  *
- * <h2>Advanced Example - Adding New Fields:</h2>
- * <pre>{@code
- * // Legacy: event without email field
- * @LegacyEvent(upcast = CustomerRegisteredUpcaster.class)
- * record CustomerRegistered(String customerId, String name) implements CustomerHistoricalEvent {}
- *
- * // Current: event with required email field
- * record CustomerRegisteredV2(String customerId, Name name, Email email) implements CustomerEvent {}
- *
- * // Upcaster: provide default for missing field
- * public class CustomerRegisteredUpcaster
- *     implements Upcast<CustomerHistoricalEvent.CustomerRegistered, CustomerEvent.CustomerRegisteredV2> {
- *
- *     @Override
- *     public CustomerEvent.CustomerRegisteredV2 upcast(CustomerHistoricalEvent.CustomerRegistered historical) {
- *         return new CustomerEvent.CustomerRegisteredV2(
- *             historical.customerId(),
- *             new Name(historical.name()),
- *             Email.unknown() // default value for new required field
- *         );
- *     }
- *
- *     @Override
- *     public Class<CustomerEvent.CustomerRegisteredV2> targetType() {
- *         return CustomerEvent.CustomerRegisteredV2.class;
- *     }
- * }
- * }</pre>
- *
- * <h2>Advanced Example - Relaxing Validation:</h2>
- * <pre>{@code
- * // Current Name value object with strict validation
- * public record Name(String value) {
- *     public Name {
- *         if (value == null || value.length() < 3 || value.length() > 20) {
- *             throw new IllegalArgumentException("Name must be 3-20 characters");
- *         }
- *     }
- *
- *     // Lenient constructor for upcasting legacy data
- *     public static Name fromLegacy(String value) {
- *         return new Name(value == null || value.isEmpty() ? "Unknown" : value);
- *     }
- * }
- *
- * public class CustomerRegisteredUpcaster
- *     implements Upcast<CustomerHistoricalEvent.CustomerRegistered, CustomerEvent.CustomerRegisteredV2> {
- *
- *     @Override
- *     public CustomerEvent.CustomerRegisteredV2 upcast(CustomerHistoricalEvent.CustomerRegistered historical) {
- *         // Use lenient factory method to handle legacy data that doesn't meet new rules
- *         return new CustomerEvent.CustomerRegisteredV2(Name.fromLegacy(historical.name()));
- *     }
- *
- *     @Override
- *     public Class<CustomerEvent.CustomerRegisteredV2> targetType() {
- *         return CustomerEvent.CustomerRegisteredV2.class;
- *     }
- * }
- * }</pre>
- *
- * <h2>Advanced Example - Splitting One Event Into Multiple:</h2>
- * <p>
- * Override {@link #upcastAll(Object)} and {@link #targetTypes()} to produce multiple events from a single
- * historical event. This is useful when a legacy event contained data that should now be modeled as
- * separate events.
- * </p>
+ * <h2>Example - Splitting One Event Into Multiple:</h2>
  * <pre>{@code
  * // Legacy event that combined customer and address data
  * @LegacyEvent(upcast = FullCustomerRegisteredUpcaster.class)
@@ -160,17 +93,7 @@ import java.util.Set;
  *     implements Upcast<CustomerHistoricalEvent.FullCustomerRegistered, CustomerEvent> {
  *
  *     @Override
- *     public CustomerEvent upcast(CustomerHistoricalEvent.FullCustomerRegistered historical) {
- *         return new CustomerEvent.CustomerRegisteredV2(new Name(historical.name()));
- *     }
- *
- *     @Override
- *     public Class<CustomerEvent> targetType() {
- *         return CustomerEvent.class;
- *     }
- *
- *     @Override
- *     public List<CustomerEvent> upcastAll(CustomerHistoricalEvent.FullCustomerRegistered historical) {
+ *     public List<CustomerEvent> upcast(CustomerHistoricalEvent.FullCustomerRegistered historical) {
  *         return List.of(
  *             new CustomerEvent.CustomerRegisteredV2(new Name(historical.name())),
  *             new CustomerEvent.AddressRecorded(historical.street(), historical.city())
@@ -184,11 +107,7 @@ import java.util.Set;
  * }
  * }</pre>
  *
- * <h2>Advanced Example - Filtering Out Events (0 Events):</h2>
- * <p>
- * Override {@link #upcastAll(Object)} to return an empty list when a legacy event should be
- * excluded from the current event stream.
- * </p>
+ * <h2>Example - Filtering Out Events (0 Events):</h2>
  * <pre>{@code
  * // Legacy event that is no longer relevant
  * @LegacyEvent(upcast = ObsoleteEventUpcaster.class)
@@ -198,18 +117,13 @@ import java.util.Set;
  *     implements Upcast<CustomerHistoricalEvent.CustomerNoteAdded, CustomerEvent> {
  *
  *     @Override
- *     public CustomerEvent upcast(CustomerHistoricalEvent.CustomerNoteAdded historical) {
- *         return null; // not used when upcastAll is overridden
- *     }
- *
- *     @Override
- *     public Class<CustomerEvent> targetType() {
- *         return CustomerEvent.class;
- *     }
- *
- *     @Override
- *     public List<CustomerEvent> upcastAll(CustomerHistoricalEvent.CustomerNoteAdded historical) {
+ *     public List<CustomerEvent> upcast(CustomerHistoricalEvent.CustomerNoteAdded historical) {
  *         return List.of(); // filter out this legacy event
+ *     }
+ *
+ *     @Override
+ *     public Set<Class<? extends CustomerEvent>> targetTypes() {
+ *         return Set.of();
  *     }
  * }
  * }</pre>
@@ -222,7 +136,7 @@ import java.util.Set;
 public interface Upcast<HISTORICAL_EVENT,DOMAIN_EVENT> {
 
 	/**
-	 * Transforms a historical event instance to its current domain event representation.
+	 * Transforms a historical event instance to zero or more current domain event representations.
 	 * <p>
 	 * This method is called automatically by the event store framework during event deserialization
 	 * when a legacy event is read from storage. The implementation should be idempotent, stateless,
@@ -231,57 +145,23 @@ public interface Upcast<HISTORICAL_EVENT,DOMAIN_EVENT> {
 	 * Upcasters should handle cases where legacy data may not conform to current validation rules.
 	 * For example, if a new value object enforces length constraints, the upcaster should either
 	 * use a lenient constructor or provide sensible defaults for legacy data that violates the new rules.
-	 *
-	 * @param historicalEvent the legacy event instance to transform (never null)
-	 * @return the current domain event representation (must not be null)
-	 */
-	DOMAIN_EVENT upcast ( HISTORICAL_EVENT historicalEvent );
-
-	/**
-	 * Returns the target event type that this upcaster produces.
 	 * <p>
-	 * This method is used by the event store framework to:
+	 * Common return patterns:
 	 * <ul>
-	 *   <li>Enable filtering on upcasted event types in {@link org.sliceworkz.eventstore.query.EventQuery}</li>
-	 *   <li>Maintain type information for runtime type checking</li>
-	 *   <li>Support polymorphic event handling in projections</li>
-	 * </ul>
-	 * <p>
-	 * The returned class must match the {@code DOMAIN_EVENT} generic parameter.
-	 * <p>
-	 * For upcasters that produce multiple event types, override {@link #targetTypes()} instead.
-	 *
-	 * @return the Class object of the target event type (must not be null)
-	 */
-	Class<DOMAIN_EVENT> targetType ( );
-
-	/**
-	 * Transforms a historical event instance to zero or more current domain event representations.
-	 * <p>
-	 * This method enables advanced upcasting scenarios:
-	 * <ul>
-	 *   <li><b>Splitting:</b> One historical event can be split into multiple current events
-	 *       (e.g., a legacy event containing both customer and address data becomes two separate events)</li>
-	 *   <li><b>Filtering:</b> Return an empty list to exclude obsolete or irrelevant historical events
-	 *       from the current event stream</li>
-	 *   <li><b>One-to-one:</b> The default implementation delegates to {@link #upcast(Object)} for
-	 *       backward compatibility with existing upcasters</li>
+	 *   <li><b>One-to-one:</b> Return {@code List.of(newEvent)} for simple transformations or renames</li>
+	 *   <li><b>Splitting:</b> Return {@code List.of(event1, event2)} to split one historical event
+	 *       into multiple current events</li>
+	 *   <li><b>Filtering:</b> Return {@code List.of()} to exclude obsolete or irrelevant historical events</li>
 	 * </ul>
 	 * <p>
 	 * All events in the returned list share the same {@link org.sliceworkz.eventstore.events.EventReference},
 	 * {@link Tags}, and timestamp from the original stored event.
-	 * <p>
-	 * Override this method (along with {@link #targetTypes()}) when the upcaster needs to produce
-	 * zero or more than one event. When overriding this method, {@link #upcast(Object)} will not be
-	 * called by the framework.
 	 *
 	 * @param historicalEvent the legacy event instance to transform (never null)
 	 * @return a list of current domain event representations (may be empty, must not be null,
 	 *         individual elements must not be null)
 	 */
-	default List<DOMAIN_EVENT> upcastAll ( HISTORICAL_EVENT historicalEvent ) {
-		return List.of(upcast(historicalEvent));
-	}
+	List<DOMAIN_EVENT> upcast ( HISTORICAL_EVENT historicalEvent );
 
 	/**
 	 * Returns all target event types that this upcaster can produce.
@@ -292,14 +172,11 @@ public interface Upcast<HISTORICAL_EVENT,DOMAIN_EVENT> {
 	 * {@code AddressRecorded}, then querying for either of those types will also fetch the
 	 * legacy {@code FullCustomerRegistered} events.
 	 * <p>
-	 * The default implementation delegates to {@link #targetType()} for backward compatibility.
-	 * Override this method when the upcaster produces events of multiple types.
+	 * For one-to-one upcasters, return a singleton set: {@code Set.of(MyEvent.class)}.
+	 * For filtering upcasters that produce no events, return an empty set: {@code Set.of()}.
 	 *
-	 * @return the set of all possible target event type classes (must not be null or empty)
+	 * @return the set of all possible target event type classes (must not be null)
 	 */
-	@SuppressWarnings("unchecked")
-	default Set<Class<? extends DOMAIN_EVENT>> targetTypes ( ) {
-		return Set.of((Class<? extends DOMAIN_EVENT>) targetType());
-	}
+	Set<Class<? extends DOMAIN_EVENT>> targetTypes ( );
 
 }

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Upcast.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Upcast.java
@@ -17,6 +17,9 @@
  */
 package org.sliceworkz.eventstore.events;
 
+import java.util.List;
+import java.util.Set;
+
 /**
  * Transforms a historical event to its current domain event representation.
  * <p>
@@ -138,6 +141,79 @@ package org.sliceworkz.eventstore.events;
  * }
  * }</pre>
  *
+ * <h2>Advanced Example - Splitting One Event Into Multiple:</h2>
+ * <p>
+ * Override {@link #upcastAll(Object)} and {@link #targetTypes()} to produce multiple events from a single
+ * historical event. This is useful when a legacy event contained data that should now be modeled as
+ * separate events.
+ * </p>
+ * <pre>{@code
+ * // Legacy event that combined customer and address data
+ * @LegacyEvent(upcast = FullCustomerRegisteredUpcaster.class)
+ * record FullCustomerRegistered(String name, String street, String city) implements CustomerHistoricalEvent {}
+ *
+ * // Current events: split into two separate concerns
+ * record CustomerRegisteredV2(Name name) implements CustomerEvent {}
+ * record AddressRecorded(String street, String city) implements CustomerEvent {}
+ *
+ * public class FullCustomerRegisteredUpcaster
+ *     implements Upcast<CustomerHistoricalEvent.FullCustomerRegistered, CustomerEvent> {
+ *
+ *     @Override
+ *     public CustomerEvent upcast(CustomerHistoricalEvent.FullCustomerRegistered historical) {
+ *         return new CustomerEvent.CustomerRegisteredV2(new Name(historical.name()));
+ *     }
+ *
+ *     @Override
+ *     public Class<CustomerEvent> targetType() {
+ *         return CustomerEvent.class;
+ *     }
+ *
+ *     @Override
+ *     public List<CustomerEvent> upcastAll(CustomerHistoricalEvent.FullCustomerRegistered historical) {
+ *         return List.of(
+ *             new CustomerEvent.CustomerRegisteredV2(new Name(historical.name())),
+ *             new CustomerEvent.AddressRecorded(historical.street(), historical.city())
+ *         );
+ *     }
+ *
+ *     @Override
+ *     public Set<Class<? extends CustomerEvent>> targetTypes() {
+ *         return Set.of(CustomerEvent.CustomerRegisteredV2.class, CustomerEvent.AddressRecorded.class);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h2>Advanced Example - Filtering Out Events (0 Events):</h2>
+ * <p>
+ * Override {@link #upcastAll(Object)} to return an empty list when a legacy event should be
+ * excluded from the current event stream.
+ * </p>
+ * <pre>{@code
+ * // Legacy event that is no longer relevant
+ * @LegacyEvent(upcast = ObsoleteEventUpcaster.class)
+ * record CustomerNoteAdded(String note) implements CustomerHistoricalEvent {}
+ *
+ * public class ObsoleteEventUpcaster
+ *     implements Upcast<CustomerHistoricalEvent.CustomerNoteAdded, CustomerEvent> {
+ *
+ *     @Override
+ *     public CustomerEvent upcast(CustomerHistoricalEvent.CustomerNoteAdded historical) {
+ *         return null; // not used when upcastAll is overridden
+ *     }
+ *
+ *     @Override
+ *     public Class<CustomerEvent> targetType() {
+ *         return CustomerEvent.class;
+ *     }
+ *
+ *     @Override
+ *     public List<CustomerEvent> upcastAll(CustomerHistoricalEvent.CustomerNoteAdded historical) {
+ *         return List.of(); // filter out this legacy event
+ *     }
+ * }
+ * }</pre>
+ *
  * @param <HISTORICAL_EVENT> the legacy event type (annotated with {@link LegacyEvent})
  * @param <DOMAIN_EVENT> the current event type to transform into
  * @see LegacyEvent
@@ -172,9 +248,58 @@ public interface Upcast<HISTORICAL_EVENT,DOMAIN_EVENT> {
 	 * </ul>
 	 * <p>
 	 * The returned class must match the {@code DOMAIN_EVENT} generic parameter.
+	 * <p>
+	 * For upcasters that produce multiple event types, override {@link #targetTypes()} instead.
 	 *
 	 * @return the Class object of the target event type (must not be null)
 	 */
 	Class<DOMAIN_EVENT> targetType ( );
+
+	/**
+	 * Transforms a historical event instance to zero or more current domain event representations.
+	 * <p>
+	 * This method enables advanced upcasting scenarios:
+	 * <ul>
+	 *   <li><b>Splitting:</b> One historical event can be split into multiple current events
+	 *       (e.g., a legacy event containing both customer and address data becomes two separate events)</li>
+	 *   <li><b>Filtering:</b> Return an empty list to exclude obsolete or irrelevant historical events
+	 *       from the current event stream</li>
+	 *   <li><b>One-to-one:</b> The default implementation delegates to {@link #upcast(Object)} for
+	 *       backward compatibility with existing upcasters</li>
+	 * </ul>
+	 * <p>
+	 * All events in the returned list share the same {@link org.sliceworkz.eventstore.events.EventReference},
+	 * {@link Tags}, and timestamp from the original stored event.
+	 * <p>
+	 * Override this method (along with {@link #targetTypes()}) when the upcaster needs to produce
+	 * zero or more than one event. When overriding this method, {@link #upcast(Object)} will not be
+	 * called by the framework.
+	 *
+	 * @param historicalEvent the legacy event instance to transform (never null)
+	 * @return a list of current domain event representations (may be empty, must not be null,
+	 *         individual elements must not be null)
+	 */
+	default List<DOMAIN_EVENT> upcastAll ( HISTORICAL_EVENT historicalEvent ) {
+		return List.of(upcast(historicalEvent));
+	}
+
+	/**
+	 * Returns all target event types that this upcaster can produce.
+	 * <p>
+	 * This method is used by the event store framework to expand queries so that legacy event types
+	 * are included when querying for any of the target types. For example, if a legacy event
+	 * {@code FullCustomerRegistered} can be upcasted to both {@code CustomerRegisteredV2} and
+	 * {@code AddressRecorded}, then querying for either of those types will also fetch the
+	 * legacy {@code FullCustomerRegistered} events.
+	 * <p>
+	 * The default implementation delegates to {@link #targetType()} for backward compatibility.
+	 * Override this method when the upcaster produces events of multiple types.
+	 *
+	 * @return the set of all possible target event type classes (must not be null or empty)
+	 */
+	@SuppressWarnings("unchecked")
+	default Set<Class<? extends DOMAIN_EVENT>> targetTypes ( ) {
+		return Set.of((Class<? extends DOMAIN_EVENT>) targetType());
+	}
 
 }

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -318,22 +318,23 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 				try {
 					
 					queriesDone++;
-					long eventsStreamBeforeThisIteration = eventsStreamed;
-					
+
 					lastRead = es.query(effectiveQuery, lastRead, limit).map(e->offerEventToProjection(e, projection, until, batch)).map(e->e.reference()).reduce((first, second) -> second).orElse(null);
-					
+
 					// if we still read data, keep the reference
 					if ( lastRead != null ) {
-						lastEventReference = Optional.of(lastRead); 
+						lastEventReference = Optional.of(lastRead);
 					} else {
 						// otherwise, we were at the end of the stream
 						done = true;
 					}
-					
-					// if we got less events than we could, we reached the end of the stream
-					if ( eventsStreamed - eventsStreamBeforeThisIteration < maxEventsPerQuery ) {
-						done = true;
-					}
+
+					// Note: we intentionally do NOT compare the number of events streamed against maxEventsPerQuery
+					// to detect end-of-stream. The batch limit is applied at the storage level (on stored events),
+					// but upcasters may produce fewer or more events per stored event (0 for filtered events,
+					// N for split events). Comparing post-upcasting counts against the storage-level limit would
+					// cause premature termination when upcasters filter out events. Instead, we rely solely on
+					// the lastRead == null check above: if the storage returned nothing, we're done.
 				} catch ( Throwable t ) {
 					batch.failBatchIfNeeded();
 					exception = new ProjectorException(t, currentEventReference);

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -18,6 +18,7 @@
 package org.sliceworkz.eventstore.projection;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -316,25 +317,27 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 
 				Batch batch = new Batch(projection);
 				try {
-					
+
 					queriesDone++;
 
-					lastRead = es.query(effectiveQuery, lastRead, limit).map(e->offerEventToProjection(e, projection, until, batch)).map(e->e.reference()).reduce((first, second) -> second).orElse(null);
+					AtomicReference<EventReference> rawCursor = new AtomicReference<>();
 
-					// if we still read data, keep the reference
+					lastRead = es.query(effectiveQuery, lastRead, limit, rawCursor::set).map(e->offerEventToProjection(e, projection, until, batch)).map(e->e.reference()).reduce((first, second) -> second).orElse(null);
+
+					// if we still read enriched data, keep the reference
 					if ( lastRead != null ) {
 						lastEventReference = Optional.of(lastRead);
+					} else if ( rawCursor.get() != null ) {
+						// Storage returned stored events but upcasting produced zero enriched events
+						// (e.g., all events in this batch were filtered out by an upcaster returning List.of()).
+						// Advance the cursor past these vanished events to avoid re-querying them.
+						lastRead = rawCursor.get();
+						lastEventReference = Optional.of(lastRead);
+						// Do NOT set done — there may be more events beyond the vanished batch.
 					} else {
-						// otherwise, we were at the end of the stream
+						// No stored events returned at all — we are truly at end of stream.
 						done = true;
 					}
-
-					// Note: we intentionally do NOT compare the number of events streamed against maxEventsPerQuery
-					// to detect end-of-stream. The batch limit is applied at the storage level (on stored events),
-					// but upcasters may produce fewer or more events per stored event (0 for filtered events,
-					// N for split events). Comparing post-upcasting counts against the storage-level limit would
-					// cause premature termination when upcasters filter out events. Instead, we rely solely on
-					// the lastRead == null check above: if the storage returned nothing, we're done.
 				} catch ( Throwable t ) {
 					batch.failBatchIfNeeded();
 					exception = new ProjectorException(t, currentEventReference);

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -17,6 +17,7 @@
  */
 package org.sliceworkz.eventstore.stream;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -176,15 +177,18 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	Optional<EventReference> queryReference ( EventId id );
 
 	/**
-	 * Retrieves a specific event by its unique event ID.
+	 * Retrieves events by their stored event ID.
 	 * <p>
-	 * This method performs a direct lookup of an event by its ID, returning the full
-	 * event with all metadata and data if it exists in this stream.
+	 * This method performs a direct lookup of an event by its ID and returns all events
+	 * that result from deserializing and upcasting the stored event. For non-upcasted events,
+	 * this returns a single-element list. For events that are upcasted into multiple sub-events,
+	 * all sub-events are returned with distinct references (differing by index).
+	 * Returns an empty list if no event with the given ID exists in this stream.
 	 *
-	 * @param eventId the unique identifier of the event to retrieve
-	 * @return an Optional containing the Event if found, empty otherwise
+	 * @param eventId the unique identifier of the stored event to retrieve
+	 * @return a list of events produced from the stored event, or an empty list if not found
 	 */
-	Optional<Event<DOMAIN_EVENT_TYPE>> getEventById ( EventId eventId );
+	List<Event<DOMAIN_EVENT_TYPE>> getEventById ( EventId eventId );
 
 
 	/**

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -19,6 +19,7 @@ package org.sliceworkz.eventstore.stream;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.sliceworkz.eventstore.events.Event;
@@ -114,10 +115,12 @@ import org.sliceworkz.eventstore.query.Limit;
 public interface EventSource<DOMAIN_EVENT_TYPE> {
 
 	/**
-	 * Queries events from the stream with full control over pagination.
+	 * Queries events from the stream with full control over pagination and raw cursor tracking.
 	 * <p>
-	 * This is the primary query method providing complete control over event retrieval.
-	 * The direction of traversal is determined by the query's direction ({@link EventQuery#backwards()}).
+	 * This method extends the standard query with a {@code storedEventCursorTracker} callback that
+	 * is invoked once for each stored event fetched from storage, <em>before</em> upcasting and
+	 * filtering. This enables callers to track the raw storage cursor even when upcasting
+	 * produces zero enriched events (e.g., when legacy events are filtered out by an upcaster).
 	 * <p>
 	 * The cursor reference enables pagination:
 	 * <ul>
@@ -131,11 +134,29 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	 * @param query the query criteria specifying which events to retrieve and in which direction
 	 * @param cursor optional reference for pagination (after for forward, before for backward), null to start from the beginning/end
 	 * @param limit maximum number of events to return (overrides the query's own limit)
+	 * @param storedEventCursorTracker callback invoked with each raw stored event's reference before upcasting, useful for advancing cursors past events that upcast to zero enriched events
 	 * @return a Stream of events matching the query criteria
 	 * @see EventQuery
 	 * @see Limit
 	 */
-	Stream<Event<DOMAIN_EVENT_TYPE>> query ( EventQuery query, EventReference cursor, Limit limit );
+	Stream<Event<DOMAIN_EVENT_TYPE>> query ( EventQuery query, EventReference cursor, Limit limit, Consumer<EventReference> storedEventCursorTracker );
+
+	/**
+	 * Queries events from the stream with full control over pagination.
+	 * <p>
+	 * This is a convenience overload that delegates to
+	 * {@link #query(EventQuery, EventReference, Limit, Consumer)} with a no-op cursor tracker.
+	 *
+	 * @param query the query criteria specifying which events to retrieve and in which direction
+	 * @param cursor optional reference for pagination (after for forward, before for backward), null to start from the beginning/end
+	 * @param limit maximum number of events to return (overrides the query's own limit)
+	 * @return a Stream of events matching the query criteria
+	 * @see EventQuery
+	 * @see Limit
+	 */
+	default Stream<Event<DOMAIN_EVENT_TYPE>> query ( EventQuery query, EventReference cursor, Limit limit ) {
+		return query(query, cursor, limit, ref -> {});
+	}
 
 	/**
 	 * Queries events from the stream starting from a specific cursor reference.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -166,17 +166,6 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	}
 
 	/**
-	 * Retrieves the event reference for a specific event ID.
-	 * <p>
-	 * This method is useful when you have an event ID and need to obtain its reference
-	 * (which includes position information) without retrieving the full event.
-	 *
-	 * @param id the event ID to look up
-	 * @return an Optional containing the EventReference if found, empty otherwise
-	 */
-	Optional<EventReference> queryReference ( EventId id );
-
-	/**
 	 * Retrieves events by their stored event ID.
 	 * <p>
 	 * This method performs a direct lookup of an event by its ID and returns all events

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/EventReferenceTest.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/EventReferenceTest.java
@@ -35,8 +35,9 @@ public class EventReferenceTest {
 		assertNotNull(r.id());
 		assertEquals(123, r.position());
 		assertEquals(456, r.tx());
+		assertEquals(0, r.index());
 	}
-	
+
 	@Test
 	void testWithIdAndPosition (  ) {
 		EventId id = EventId.create();
@@ -45,6 +46,30 @@ public class EventReferenceTest {
 		assertEquals(id, r.id());
 		assertEquals(123, r.position());
 		assertEquals(456, r.tx());
+		assertEquals(0, r.index());
+	}
+
+	@Test
+	void testWithIdAndPositionAndIndex (  ) {
+		EventId id = EventId.create();
+		EventReference r = EventReference.of(id, 123, 456, 2);
+		assertNotNull(r);
+		assertEquals(id, r.id());
+		assertEquals(123, r.position());
+		assertEquals(456, r.tx());
+		assertEquals(2, r.index());
+	}
+
+	@Test
+	void testWithIndex (  ) {
+		EventId id = EventId.create();
+		EventReference r = EventReference.of(id, 10, 10);
+		EventReference r2 = r.withIndex(3);
+		assertEquals(id, r2.id());
+		assertEquals(10, r2.position());
+		assertEquals(10, r2.tx());
+		assertEquals(3, r2.index());
+		assertEquals(0, r.index()); // original unchanged
 	}
 
 	@Test
@@ -62,14 +87,21 @@ public class EventReferenceTest {
 	}
 
 	@Test
+	void testWithNegativeIndex (  ) {
+		EventId id = EventId.create();
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ()->EventReference.of(id, 1, 1, -1));
+		assertEquals(e.getMessage(), "index -1 is invalid, should be 0 or larger");
+	}
+
+	@Test
 	void testHappenedBefore (  ) {
-		EventReference pos_1_tx_1 = new EventReference(EventId.create(), 1, 1);
-		EventReference pos_2_tx_2 = new EventReference(EventId.create(), 2, 2);
-		EventReference pos_2_tx_3 = new EventReference(EventId.create(), 2, 3);
-		EventReference pos_3_tx_5 = new EventReference(EventId.create(), 3, 5);
-		EventReference pos_3_tx_6 = new EventReference(EventId.create(), 3, 6);
-		EventReference pos_4_tx_4 = new EventReference(EventId.create(), 4, 4);
-		EventReference pos_5_tx_7 = new EventReference(EventId.create(), 5, 7);
+		EventReference pos_1_tx_1 = EventReference.of(EventId.create(), 1, 1);
+		EventReference pos_2_tx_2 = EventReference.of(EventId.create(), 2, 2);
+		EventReference pos_2_tx_3 = EventReference.of(EventId.create(), 2, 3);
+		EventReference pos_3_tx_5 = EventReference.of(EventId.create(), 3, 5);
+		EventReference pos_3_tx_6 = EventReference.of(EventId.create(), 3, 6);
+		EventReference pos_4_tx_4 = EventReference.of(EventId.create(), 4, 4);
+		EventReference pos_5_tx_7 = EventReference.of(EventId.create(), 5, 7);
 		
 		assertFalse(pos_1_tx_1.happenedBefore(pos_1_tx_1));
 		assertTrue(pos_1_tx_1.happenedBefore(pos_2_tx_2));
@@ -131,13 +163,13 @@ public class EventReferenceTest {
 
 	@Test
 	void testHappenedAfter (  ) {
-		EventReference pos_1_tx_1 = new EventReference(EventId.create(), 1, 1);
-		EventReference pos_2_tx_2 = new EventReference(EventId.create(), 2, 2);
-		EventReference pos_2_tx_3 = new EventReference(EventId.create(), 2, 3);
-		EventReference pos_3_tx_5 = new EventReference(EventId.create(), 3, 5);
-		EventReference pos_3_tx_6 = new EventReference(EventId.create(), 3, 6);
-		EventReference pos_4_tx_4 = new EventReference(EventId.create(), 4, 4);
-		EventReference pos_5_tx_7 = new EventReference(EventId.create(), 5, 7);
+		EventReference pos_1_tx_1 = EventReference.of(EventId.create(), 1, 1);
+		EventReference pos_2_tx_2 = EventReference.of(EventId.create(), 2, 2);
+		EventReference pos_2_tx_3 = EventReference.of(EventId.create(), 2, 3);
+		EventReference pos_3_tx_5 = EventReference.of(EventId.create(), 3, 5);
+		EventReference pos_3_tx_6 = EventReference.of(EventId.create(), 3, 6);
+		EventReference pos_4_tx_4 = EventReference.of(EventId.create(), 4, 4);
+		EventReference pos_5_tx_7 = EventReference.of(EventId.create(), 5, 7);
 		
 		assertFalse(pos_1_tx_1.happenedAfter(pos_1_tx_1));
 		assertFalse(pos_1_tx_1.happenedAfter(pos_2_tx_2));
@@ -197,9 +229,49 @@ public class EventReferenceTest {
 	}
 	
 	@Test
+	void testHappenedBeforeWithIndex (  ) {
+		EventId id = EventId.create();
+		EventReference idx0 = EventReference.of(id, 5, 5, 0);
+		EventReference idx1 = EventReference.of(id, 5, 5, 1);
+		EventReference idx2 = EventReference.of(id, 5, 5, 2);
+
+		// same tx, same position, different index
+		assertTrue(idx0.happenedBefore(idx1));
+		assertTrue(idx0.happenedBefore(idx2));
+		assertTrue(idx1.happenedBefore(idx2));
+		assertFalse(idx0.happenedBefore(idx0));
+		assertFalse(idx1.happenedBefore(idx0));
+		assertFalse(idx2.happenedBefore(idx1));
+
+		// index is tertiary: tx and position still take precedence
+		EventReference nextPos = EventReference.of(EventId.create(), 6, 5, 0);
+		assertTrue(idx2.happenedBefore(nextPos));
+		assertFalse(nextPos.happenedBefore(idx2));
+
+		EventReference nextTx = EventReference.of(EventId.create(), 5, 6, 0);
+		assertTrue(idx2.happenedBefore(nextTx));
+		assertFalse(nextTx.happenedBefore(idx2));
+	}
+
+	@Test
+	void testHappenedAfterWithIndex (  ) {
+		EventId id = EventId.create();
+		EventReference idx0 = EventReference.of(id, 5, 5, 0);
+		EventReference idx1 = EventReference.of(id, 5, 5, 1);
+		EventReference idx2 = EventReference.of(id, 5, 5, 2);
+
+		assertFalse(idx0.happenedAfter(idx0));
+		assertFalse(idx0.happenedAfter(idx1));
+		assertTrue(idx1.happenedAfter(idx0));
+		assertTrue(idx2.happenedAfter(idx0));
+		assertTrue(idx2.happenedAfter(idx1));
+		assertFalse(idx1.happenedAfter(idx2));
+	}
+
+	@Test
 	void testNone ( ) {
 		EventReference r = EventReference.none();
 		assertNull(r);
 	}
-	
+
 }

--- a/sliceworkz-eventstore-benchmark/src/main/java/org/sliceworkz/eventstore/benchmark/BenchmarkApplication.java
+++ b/sliceworkz-eventstore-benchmark/src/main/java/org/sliceworkz/eventstore/benchmark/BenchmarkApplication.java
@@ -106,7 +106,7 @@ public class BenchmarkApplication {
 			@Override
 			public EventReference eventsAppended(EventReference atLeastUntil) {
 				System.err.println("-------> " + atLeastUntil);
-				System.err.println(supplier42Stream.getEventById(atLeastUntil.id()).get());
+				System.err.println(supplier42Stream.getEventById(atLeastUntil.id()));
 				return atLeastUntil;
 			}
 		});

--- a/sliceworkz-eventstore-examples/src/main/java/org/sliceworkz/eventstore/examples/UpcastingExample.java
+++ b/sliceworkz-eventstore-examples/src/main/java/org/sliceworkz/eventstore/examples/UpcastingExample.java
@@ -17,6 +17,9 @@
  */
 package org.sliceworkz.eventstore.examples;
 
+import java.util.List;
+import java.util.Set;
+
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.LegacyEvent;
@@ -149,31 +152,30 @@ public class UpcastingExample {
 	public static class CustomerRegisteredUpcaster implements Upcast<CustomerHistoricalEvent.CustomerRegistered, CustomerEvent.CustomerRegisteredV2> {
 
 		@Override
-		public CustomerEvent.CustomerRegisteredV2 upcast(CustomerHistoricalEvent.CustomerRegistered historicalEvent) {
+		public List<CustomerEvent.CustomerRegisteredV2> upcast(CustomerHistoricalEvent.CustomerRegistered historicalEvent) {
 			// using the constructor, not the "of" utility method to allow historical values that don't adhere to the new length business rules
-			return new CustomerEvent.CustomerRegisteredV2(new CustomerEvent.Name(historicalEvent.name()));
+			return List.of(new CustomerEvent.CustomerRegisteredV2(new CustomerEvent.Name(historicalEvent.name())));
 		}
 
 		@Override
-		public Class<CustomerRegisteredV2> targetType() {
-			return CustomerRegisteredV2.class;
+		public Set<Class<? extends CustomerRegisteredV2>> targetTypes() {
+			return Set.of(CustomerRegisteredV2.class);
 		}
-		
+
 	}
-	
+
 	public static class CustomerNameChangedUpcaster implements Upcast<CustomerHistoricalEvent.CustomerNameChanged, CustomerEvent.CustomerRenamed> {
 
 		@Override
-		public CustomerEvent.CustomerRenamed upcast(CustomerHistoricalEvent.CustomerNameChanged historicalEvent) {
+		public List<CustomerEvent.CustomerRenamed> upcast(CustomerHistoricalEvent.CustomerNameChanged historicalEvent) {
 			// using the constructor, not the "of" utility method to allow historical values that don't adhere to the new length business rules
-			return new CustomerEvent.CustomerRenamed(new CustomerEvent.Name(historicalEvent.name()));
+			return List.of(new CustomerEvent.CustomerRenamed(new CustomerEvent.Name(historicalEvent.name())));
 		}
-		
+
 		@Override
-		public Class<CustomerRenamed> targetType() {
-			return CustomerRenamed.class;
+		public Set<Class<? extends CustomerRenamed>> targetTypes() {
+			return Set.of(CustomerRenamed.class);
 		}
-		
 
 	}
 

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -270,30 +270,17 @@ public class EventStoreImpl implements EventStore {
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
 			EventFilter originalFilter = query.filter();
 			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction)
-				.flatMap(se->enrichMultiAfterQuery(se, direction))
+				.flatMap(se->enrichAfterQuery(se, direction))
 				.filter(e->originalFilter.matches(e)));
 		}
 
-		private Stream<Event<EVENT_TYPE>> enrichMultiAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {
+		private Stream<Event<EVENT_TYPE>> enrichAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {
 			meterQueryEvent.increment(); // one event more seen coming from storage
-			return enrichMulti(storedEvent, direction);
-		}
-
-		private Event<EVENT_TYPE> enrichAfterAppend ( StoredEvent storedEvent ) {
-			// not metered, as this is used for appended events
-			return enrich(storedEvent);
+			return enrich(storedEvent, direction);
 		}
 
 		@SuppressWarnings("unchecked")
-		private Event<EVENT_TYPE> enrich ( StoredEvent storedEvent ) {
-			// not metered, depends on the usage
-			TypeAndPayload typeAndPayload = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData())).getFirst();
-			EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
-			return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());
-		}
-
-		@SuppressWarnings("unchecked")
-		private Stream<Event<EVENT_TYPE>> enrichMulti ( StoredEvent storedEvent, QueryDirection direction ) {
+		private Stream<Event<EVENT_TYPE>> enrich ( StoredEvent storedEvent, QueryDirection direction ) {
 			List<TypeAndPayload> results = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
 			// For backward queries, reverse the upcasted sub-events so they appear in descending order,
 			// consistent with the overall backward traversal of stored events.
@@ -357,7 +344,7 @@ public class EventStoreImpl implements EventStore {
 			// append events to the eventstore (with optimistic locking)
 			List<Event<EVENT_TYPE>> appendedEvents;
 			try {
-				appendedEvents = timerAppend.record(()->eventStorage.append(appendCriteria, Optional.of(streamToAppendTo), reduce(events, streamToAppendTo)).stream().map(this::enrichAfterAppend).toList());
+				appendedEvents = timerAppend.record(()->eventStorage.append(appendCriteria, Optional.of(streamToAppendTo), reduce(events, streamToAppendTo)).stream().flatMap(se->enrich(se, QueryDirection.FORWARD)).toList());
 				meterAppend.increment();
 
 				// update highest event position gauge

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -297,9 +297,15 @@ public class EventStoreImpl implements EventStore {
 			if ( direction == QueryDirection.BACKWARD ) {
 				results = results.reversed();
 			}
-			return results.stream().map(typeAndPayload -> {
+			EventReference baseRef = storedEvent.reference();
+			List<TypeAndPayload> finalResults = results;
+			return java.util.stream.IntStream.range(0, finalResults.size()).mapToObj(i -> {
+				TypeAndPayload typeAndPayload = finalResults.get(i);
 				EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
-				return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());
+				// Each sub-event gets a unique reference via the index, distinguishing upcasted events
+				// that originate from the same stored event. For single-event results, index is 0.
+				EventReference ref = baseRef.withIndex(direction == QueryDirection.BACKWARD ? finalResults.size() - 1 - i : i);
+				return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), ref, data, storedEvent.tags(), storedEvent.timestamp());
 			});
 		}
 
@@ -438,14 +444,18 @@ public class EventStoreImpl implements EventStore {
 		@Override
 		public Optional<EventReference> queryReference(EventId id) {
 			meterGetEvent.increment();
-			return eventStorage.getEventById(id).map(this::enrich).map(Event::reference);
+			return eventStorage.getEventById(id).map(StoredEvent::reference);
 		}
 
 		@Override
-		public Optional<Event<EVENT_TYPE>> getEventById(EventId eventId) {
+		public List<Event<EVENT_TYPE>> getEventById(EventId eventId) {
 			meterGetEvent.increment();
-			// filters out events that can not be read by this stream
-			return eventStorage.getEventById(eventId).filter(e->eventStreamId.canRead(e.stream())).map(this::enrich);
+			// filters out events that can not be read by this stream, then upcasts via enrichMulti
+			return eventStorage.getEventById(eventId)
+				.filter(e->eventStreamId.canRead(e.stream()))
+				.map(e->enrichMulti(e, QueryDirection.FORWARD))
+				.map(s->s.toList())
+				.orElse(List.of());
 		}
 
 	}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -268,12 +268,12 @@ public class EventStoreImpl implements EventStore {
 		public Stream<Event<EVENT_TYPE>> query(EventQuery query, EventReference cursor, Limit limit ) {
 			meterQuery.increment(); // one query done
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
-			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction).flatMap(this::enrichMultiAfterQuery));
+			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction).flatMap(se->enrichMultiAfterQuery(se, direction)));
 		}
 
-		private Stream<Event<EVENT_TYPE>> enrichMultiAfterQuery ( StoredEvent storedEvent ) {
+		private Stream<Event<EVENT_TYPE>> enrichMultiAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {
 			meterQueryEvent.increment(); // one event more seen coming from storage
-			return enrichMulti(storedEvent);
+			return enrichMulti(storedEvent, direction);
 		}
 
 		private Event<EVENT_TYPE> enrichAfterAppend ( StoredEvent storedEvent ) {
@@ -290,8 +290,13 @@ public class EventStoreImpl implements EventStore {
 		}
 
 		@SuppressWarnings("unchecked")
-		private Stream<Event<EVENT_TYPE>> enrichMulti ( StoredEvent storedEvent ) {
+		private Stream<Event<EVENT_TYPE>> enrichMulti ( StoredEvent storedEvent, QueryDirection direction ) {
 			List<TypeAndPayload> results = serde.deserializeMulti(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
+			// For backward queries, reverse the upcasted sub-events so they appear in descending order,
+			// consistent with the overall backward traversal of stored events.
+			if ( direction == QueryDirection.BACKWARD ) {
+				results = results.reversed();
+			}
 			return results.stream().map(typeAndPayload -> {
 				EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
 				return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -270,30 +270,17 @@ public class EventStoreImpl implements EventStore {
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
 			EventFilter originalFilter = query.filter();
 			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction)
-				.flatMap(se->enrichMultiAfterQuery(se, direction))
+				.flatMap(se->enrichAfterQuery(se, direction))
 				.filter(e->originalFilter.matches(e)));
 		}
 
-		private Stream<Event<EVENT_TYPE>> enrichMultiAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {
+		private Stream<Event<EVENT_TYPE>> enrichAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {
 			meterQueryEvent.increment(); // one event more seen coming from storage
-			return enrichMulti(storedEvent, direction);
-		}
-
-		private Event<EVENT_TYPE> enrichAfterAppend ( StoredEvent storedEvent ) {
-			// not metered, as this is used for appended events
-			return enrich(storedEvent);
+			return enrich(storedEvent, direction);
 		}
 
 		@SuppressWarnings("unchecked")
-		private Event<EVENT_TYPE> enrich ( StoredEvent storedEvent ) {
-			// not metered, depends on the usage
-			TypeAndPayload typeAndPayload = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData())).getFirst();
-			EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
-			return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());
-		}
-
-		@SuppressWarnings("unchecked")
-		private Stream<Event<EVENT_TYPE>> enrichMulti ( StoredEvent storedEvent, QueryDirection direction ) {
+		private Stream<Event<EVENT_TYPE>> enrich ( StoredEvent storedEvent, QueryDirection direction ) {
 			List<TypeAndPayload> results = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
 			// For backward queries, reverse the upcasted sub-events so they appear in descending order,
 			// consistent with the overall backward traversal of stored events.
@@ -357,7 +344,7 @@ public class EventStoreImpl implements EventStore {
 			// append events to the eventstore (with optimistic locking)
 			List<Event<EVENT_TYPE>> appendedEvents;
 			try {
-				appendedEvents = timerAppend.record(()->eventStorage.append(appendCriteria, Optional.of(streamToAppendTo), reduce(events, streamToAppendTo)).stream().map(this::enrichAfterAppend).toList());
+				appendedEvents = timerAppend.record(()->eventStorage.append(appendCriteria, Optional.of(streamToAppendTo), reduce(events, streamToAppendTo)).stream().flatMap(se->enrich(se, QueryDirection.FORWARD)).toList());
 				meterAppend.increment();
 
 				// update highest event position gauge
@@ -453,10 +440,10 @@ public class EventStoreImpl implements EventStore {
 		@Override
 		public List<Event<EVENT_TYPE>> getEventById(EventId eventId) {
 			meterGetEvent.increment();
-			// filters out events that can not be read by this stream, then upcasts via enrichMulti
+			// filters out events that can not be read by this stream, then upcasts via enrich
 			return eventStorage.getEventById(eventId)
 				.filter(e->eventStreamId.canRead(e.stream()))
-				.map(e->enrichMulti(e, QueryDirection.FORWARD))
+				.map(e->enrich(e, QueryDirection.FORWARD))
 				.map(s->s.toList())
 				.orElse(List.of());
 		}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -265,11 +266,12 @@ public class EventStoreImpl implements EventStore {
 		}
 
 		@Override
-		public Stream<Event<EVENT_TYPE>> query(EventQuery query, EventReference cursor, Limit limit ) {
+		public Stream<Event<EVENT_TYPE>> query(EventQuery query, EventReference cursor, Limit limit, Consumer<EventReference> storedEventCursorTracker ) {
 			meterQuery.increment(); // one query done
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
 			EventFilter originalFilter = query.filter();
 			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction)
+				.peek(se -> storedEventCursorTracker.accept(se.reference()))
 				.flatMap(se->enrichAfterQuery(se, direction))
 				.filter(e->originalFilter.matches(e)));
 		}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -432,12 +432,6 @@ public class EventStoreImpl implements EventStore {
 		}
 
 		@Override
-		public Optional<EventReference> queryReference(EventId id) {
-			meterGetEvent.increment();
-			return eventStorage.getEventById(id).map(StoredEvent::reference);
-		}
-
-		@Override
 		public List<Event<EVENT_TYPE>> getEventById(EventId eventId) {
 			meterGetEvent.increment();
 			// filters out events that can not be read by this stream, then upcasts via enrich

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -268,7 +268,10 @@ public class EventStoreImpl implements EventStore {
 		public Stream<Event<EVENT_TYPE>> query(EventQuery query, EventReference cursor, Limit limit ) {
 			meterQuery.increment(); // one query done
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
-			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction).flatMap(se->enrichMultiAfterQuery(se, direction)));
+			EventFilter originalFilter = query.filter();
+			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction)
+				.flatMap(se->enrichMultiAfterQuery(se, direction))
+				.filter(e->originalFilter.matches(e)));
 		}
 
 		private Stream<Event<EVENT_TYPE>> enrichMultiAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -268,25 +268,34 @@ public class EventStoreImpl implements EventStore {
 		public Stream<Event<EVENT_TYPE>> query(EventQuery query, EventReference cursor, Limit limit ) {
 			meterQuery.increment(); // one query done
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
-			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction).map(this::enrichAfterQuery));
+			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction).flatMap(this::enrichMultiAfterQuery));
 		}
-		
-		private Event<EVENT_TYPE> enrichAfterQuery ( StoredEvent storedEvent ) {
+
+		private Stream<Event<EVENT_TYPE>> enrichMultiAfterQuery ( StoredEvent storedEvent ) {
 			meterQueryEvent.increment(); // one event more seen coming from storage
-			return enrich(storedEvent);
+			return enrichMulti(storedEvent);
 		}
 
 		private Event<EVENT_TYPE> enrichAfterAppend ( StoredEvent storedEvent ) {
 			// not metered, as this is used for appended events
 			return enrich(storedEvent);
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		private Event<EVENT_TYPE> enrich ( StoredEvent storedEvent ) {
 			// not metered, depends on the usage
 			TypeAndPayload typeAndPayload = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
 			EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
 			return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());
+		}
+
+		@SuppressWarnings("unchecked")
+		private Stream<Event<EVENT_TYPE>> enrichMulti ( StoredEvent storedEvent ) {
+			List<TypeAndPayload> results = serde.deserializeMulti(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
+			return results.stream().map(typeAndPayload -> {
+				EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
+				return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());
+			});
 		}
 
 		private EventToStore reduce ( EphemeralEvent<? extends EVENT_TYPE> event, EventStreamId streamToAppendTo ) {
@@ -424,14 +433,14 @@ public class EventStoreImpl implements EventStore {
 		@Override
 		public Optional<EventReference> queryReference(EventId id) {
 			meterGetEvent.increment();
-			return eventStorage.getEventById(id).map(this::enrichAfterQuery).map(Event::reference);
+			return eventStorage.getEventById(id).map(this::enrich).map(Event::reference);
 		}
-		
+
 		@Override
 		public Optional<Event<EVENT_TYPE>> getEventById(EventId eventId) {
 			meterGetEvent.increment();
 			// filters out events that can not be read by this stream
-			return eventStorage.getEventById(eventId).filter(e->eventStreamId.canRead(e.stream())).map(this::enrichAfterQuery);
+			return eventStorage.getEventById(eventId).filter(e->eventStreamId.canRead(e.stream())).map(this::enrich);
 		}
 
 	}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -287,14 +287,14 @@ public class EventStoreImpl implements EventStore {
 		@SuppressWarnings("unchecked")
 		private Event<EVENT_TYPE> enrich ( StoredEvent storedEvent ) {
 			// not metered, depends on the usage
-			TypeAndPayload typeAndPayload = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
+			TypeAndPayload typeAndPayload = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData())).getFirst();
 			EVENT_TYPE data = (EVENT_TYPE)typeAndPayload.eventData();
 			return new Event<>(storedEvent.stream(), typeAndPayload.type(), storedEvent.type(), storedEvent.reference(), data, storedEvent.tags(), storedEvent.timestamp());
 		}
 
 		@SuppressWarnings("unchecked")
 		private Stream<Event<EVENT_TYPE>> enrichMulti ( StoredEvent storedEvent, QueryDirection direction ) {
-			List<TypeAndPayload> results = serde.deserializeMulti(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
+			List<TypeAndPayload> results = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
 			// For backward queries, reverse the upcasted sub-events so they appear in descending order,
 			// consistent with the overall backward traversal of stored events.
 			if ( direction == QueryDirection.BACKWARD ) {

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/EventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/EventPayloadSerializerDeserializer.java
@@ -17,6 +17,7 @@
  */
 package org.sliceworkz.eventstore.impl.serde;
 
+import java.util.List;
 import java.util.Set;
 
 import org.sliceworkz.eventstore.events.EventType;
@@ -88,6 +89,28 @@ public interface EventPayloadSerializerDeserializer {
 	 * @throws RuntimeException if deserialization fails or type mapping is not found
 	 */
 	TypeAndPayload deserialize(TypeAndSerializedPayload serialized);
+
+	/**
+	 * Deserializes a JSON representation back to zero or more domain event objects.
+	 * <p>
+	 * This method supports multi-event upcasting where a single historical event can produce
+	 * zero or more current events. This is useful for:
+	 * <ul>
+	 *   <li><b>Event splitting:</b> One legacy event becomes multiple current events</li>
+	 *   <li><b>Event filtering:</b> Obsolete legacy events produce zero current events</li>
+	 *   <li><b>Standard upcasting:</b> One legacy event becomes one current event (default)</li>
+	 * </ul>
+	 * <p>
+	 * The default implementation delegates to {@link #deserialize(TypeAndSerializedPayload)} and
+	 * wraps the result in a singleton list.
+	 *
+	 * @param serialized the serialized event including type and separated payloads
+	 * @return a list of deserialized event types and data objects (may be empty, never null)
+	 * @throws RuntimeException if deserialization fails or type mapping is not found
+	 */
+	default List<TypeAndPayload> deserializeMulti(TypeAndSerializedPayload serialized) {
+		return List.of(deserialize(serialized));
+	}
 
 	/**
 	 * Checks whether this serializer/deserializer can deserialize events of the given type name.

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/EventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/EventPayloadSerializerDeserializer.java
@@ -78,39 +78,25 @@ public interface EventPayloadSerializerDeserializer {
 	TypeAndSerializedPayload serialize(Object payload);
 
 	/**
-	 * Deserializes a JSON representation back to a domain event object.
-	 * <p>
-	 * Merges immutable and erasable data (if present) to reconstruct the complete event object.
-	 * For typed mode, the event type name is used to determine the target Java class.
-	 * For raw mode, returns a Jackson JsonNode.
-	 *
-	 * @param serialized the serialized event including type and separated payloads
-	 * @return the deserialized event type and data object
-	 * @throws RuntimeException if deserialization fails or type mapping is not found
-	 */
-	TypeAndPayload deserialize(TypeAndSerializedPayload serialized);
-
-	/**
 	 * Deserializes a JSON representation back to zero or more domain event objects.
+	 * <p>
+	 * Merges immutable and erasable data (if present) to reconstruct the complete event object(s).
+	 * For typed mode, the event type name is used to determine the target Java class.
+	 * For raw mode, returns a Jackson JsonNode wrapped in a singleton list.
 	 * <p>
 	 * This method supports multi-event upcasting where a single historical event can produce
 	 * zero or more current events. This is useful for:
 	 * <ul>
 	 *   <li><b>Event splitting:</b> One legacy event becomes multiple current events</li>
 	 *   <li><b>Event filtering:</b> Obsolete legacy events produce zero current events</li>
-	 *   <li><b>Standard upcasting:</b> One legacy event becomes one current event (default)</li>
+	 *   <li><b>Standard deserialization:</b> One stored event becomes one current event</li>
 	 * </ul>
-	 * <p>
-	 * The default implementation delegates to {@link #deserialize(TypeAndSerializedPayload)} and
-	 * wraps the result in a singleton list.
 	 *
 	 * @param serialized the serialized event including type and separated payloads
 	 * @return a list of deserialized event types and data objects (may be empty, never null)
 	 * @throws RuntimeException if deserialization fails or type mapping is not found
 	 */
-	default List<TypeAndPayload> deserializeMulti(TypeAndSerializedPayload serialized) {
-		return List.of(deserialize(serialized));
-	}
+	List<TypeAndPayload> deserialize(TypeAndSerializedPayload serialized);
 
 	/**
 	 * Checks whether this serializer/deserializer can deserialize events of the given type name.

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/RawEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/RawEventPayloadSerializerDeserializer.java
@@ -17,6 +17,7 @@
  */
 package org.sliceworkz.eventstore.impl.serde;
 
+import java.util.List;
 import java.util.Set;
 
 import org.sliceworkz.eventstore.events.EventType;
@@ -39,29 +40,29 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class RawEventPayloadSerializerDeserializer extends AbstractEventPayloadSerializerDeserializer {
 	
 	@Override
-	public TypeAndPayload deserialize ( TypeAndSerializedPayload serialized ) {
+	public List<TypeAndPayload> deserialize ( TypeAndSerializedPayload serialized ) {
 		JsonNode object;
 		try {
-			
+
 			if ( serialized.erasablePayload() == null ) {
 				object = immutableDataMapper.readTree(serialized.immutablePayload());
 			} else {
 				// reconstruct the full object by merging
 				ObjectNode nodeImmutableData = (ObjectNode) immutableDataMapper.readTree(serialized.immutablePayload());
 				ObjectNode nodeErasableData = (ObjectNode) erasableDataMapper.readTree(serialized.erasablePayload());
-				
+
 				// Merge erasable data into immutable data
 				deepMerge(nodeImmutableData, nodeErasableData);
-				
+
 				object = nodeImmutableData; // with erasable merged in
 			}
-			
+
 		} catch (JsonMappingException e) {
 			throw new RuntimeException("Failed to deserialize event data: JsonMappingException", e);
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException("Failed to deserialize event data: JsonProcessingException", e);
 		}
-		return new TypeAndPayload(serialized.type(), object);
+		return List.of(new TypeAndPayload(serialized.type(), object));
 	}
 
 	@Override

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
@@ -203,7 +203,6 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 	
 	interface EventDeserializer {
 		List<TypeAndPayload> deserialize ( String immutablePayload, String erasablePayload );
-		EventType eventType ( );
 	}
 	
 	class InstantiationEventDeserializer implements EventDeserializer {
@@ -243,11 +242,6 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 			return List.of(new TypeAndPayload(eventType, object));
 		}
 
-		@Override
-		public EventType eventType() {
-			return eventType;
-		}
-		
 	}
 	
 	class InstantiationAndUpcastEventDeserializer implements EventDeserializer {
@@ -267,16 +261,6 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 			return upcastedEvents.stream()
 					.map(e -> new TypeAndPayload(EventType.of(e), e))
 					.toList();
-		}
-
-		@Override
-		public EventType eventType() {
-			// For upcasters, the event type is determined per-event in deserialize.
-			// This fallback returns the first target type from targetTypes(), or null if empty.
-			return upcaster.targetTypes().stream()
-					.map(EventType::of)
-					.findFirst()
-					.orElse(null);
 		}
 
 	}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
@@ -56,33 +56,14 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 	private final Map<EventType, Set<EventType>> mostRecentMultiTypes = new HashMap<>(); // for interface hierarchies, this maps interface->set of interface-implementing event types
 	
 	@Override
-	public TypeAndPayload deserialize ( TypeAndSerializedPayload serialized ) {
-		TypeAndPayload result;
-		try {
-			EventDeserializer deserializer = deserializers.get(serialized.type().name());
-			if ( deserializer == null  ) {
-				throw new RuntimeException("No mapping found for event type '" + serialized.type().name() + "'");
-			}
-			result = new TypeAndPayload(deserializer.eventType(), deserializer.deserialize(serialized.immutablePayload(), serialized.erasablePayload()));
-		} catch (Exception e) {
-			if ( deserializers.keySet().isEmpty() ) {
-				throw new RuntimeException("Failed to deserialize event data for type '%s', no EventType mappings configured. Pass the Event root Class when creating the EventStream".formatted(serialized.type().name()) , e);
-			} else {
-				throw new RuntimeException("Failed to deserialize event data for type '%s', known mappings for %s".formatted(serialized.type().name(), deserializers.keySet()) , e);
-			}
-		}
-		return result;
-	}
-
-	@Override
-	public List<TypeAndPayload> deserializeMulti ( TypeAndSerializedPayload serialized ) {
+	public List<TypeAndPayload> deserialize ( TypeAndSerializedPayload serialized ) {
 		List<TypeAndPayload> result;
 		try {
 			EventDeserializer deserializer = deserializers.get(serialized.type().name());
 			if ( deserializer == null  ) {
 				throw new RuntimeException("No mapping found for event type '" + serialized.type().name() + "'");
 			}
-			result = deserializer.deserializeMulti(serialized.immutablePayload(), serialized.erasablePayload());
+			result = deserializer.deserialize(serialized.immutablePayload(), serialized.erasablePayload());
 		} catch (Exception e) {
 			if ( deserializers.keySet().isEmpty() ) {
 				throw new RuntimeException("Failed to deserialize event data for type '%s', no EventType mappings configured. Pass the Event root Class when creating the EventStream".formatted(serialized.type().name()) , e);
@@ -221,11 +202,8 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 	
 	
 	interface EventDeserializer {
-		Object deserialize ( String immutablePayload, String erasablePayload );
+		List<TypeAndPayload> deserialize ( String immutablePayload, String erasablePayload );
 		EventType eventType ( );
-		default List<TypeAndPayload> deserializeMulti ( String immutablePayload, String erasablePayload ) {
-			return List.of(new TypeAndPayload(eventType(), deserialize(immutablePayload, erasablePayload)));
-		}
 	}
 	
 	class InstantiationEventDeserializer implements EventDeserializer {
@@ -239,10 +217,10 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 		}
 
 		@Override
-		public Object deserialize ( String immutablePayload, String erasablePayload ) {
+		public List<TypeAndPayload> deserialize ( String immutablePayload, String erasablePayload ) {
 			Object object;
 			try {
-				
+
 				if ( erasablePayload == null ) {
 					object = immutableDataMapper.readValue(immutablePayload, eventClass);
 				} else {
@@ -261,8 +239,8 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 				throw new RuntimeException(e);
 			} catch (JsonProcessingException e) {
 				throw new RuntimeException(e);
-			} 
-			return object;
+			}
+			return List.of(new TypeAndPayload(eventType, object));
 		}
 
 		@Override
@@ -283,31 +261,22 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 		}
 
 		@Override
-		public Object deserialize ( String immutablePayload, String erasablePayload ) {
-			// Single-event path: delegate to deserializeMulti and return the first result.
-			// This path is not used for upcasted events during queries (which use deserializeMulti),
-			// but may be called for non-query scenarios (e.g., after append).
-			List<TypeAndPayload> results = deserializeMulti(immutablePayload, erasablePayload);
-			return results.isEmpty() ? null : results.getFirst().eventData();
+		public List<TypeAndPayload> deserialize ( String immutablePayload, String erasablePayload ) {
+			Object historicalEvent = deser.deserialize(immutablePayload, erasablePayload).getFirst().eventData();
+			List<Object> upcastedEvents = upcaster.upcast(historicalEvent);
+			return upcastedEvents.stream()
+					.map(e -> new TypeAndPayload(EventType.of(e), e))
+					.toList();
 		}
 
 		@Override
 		public EventType eventType() {
-			// For upcasters, the event type is determined per-event in deserializeMulti.
+			// For upcasters, the event type is determined per-event in deserialize.
 			// This fallback returns the first target type from targetTypes(), or null if empty.
 			return upcaster.targetTypes().stream()
 					.map(EventType::of)
 					.findFirst()
 					.orElse(null);
-		}
-
-		@Override
-		public List<TypeAndPayload> deserializeMulti ( String immutablePayload, String erasablePayload ) {
-			Object historicalEvent = deser.deserialize(immutablePayload, erasablePayload);
-			List<Object> upcastedEvents = upcaster.upcast(historicalEvent);
-			return upcastedEvents.stream()
-					.map(e -> new TypeAndPayload(EventType.of(e), e))
-					.toList();
 		}
 
 	}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,7 +52,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloadSerializerDeserializer {
 
 	private final Map<String,EventDeserializer> deserializers = new HashMap<>();
-	private final Map<EventType, EventType> mostRecentTypes = new HashMap<>();
+	private final Map<EventType, Set<EventType>> mostRecentTypes = new HashMap<>();
 	private final Map<EventType, Set<EventType>> mostRecentMultiTypes = new HashMap<>(); // for interface hierarchies, this maps interface->set of interface-implementing event types
 	
 	@Override
@@ -62,7 +63,26 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 			if ( deserializer == null  ) {
 				throw new RuntimeException("No mapping found for event type '" + serialized.type().name() + "'");
 			}
-			result = new TypeAndPayload(deserializer.eventType(), deserializer.deserialize(serialized.immutablePayload(), serialized.erasablePayload())); 
+			result = new TypeAndPayload(deserializer.eventType(), deserializer.deserialize(serialized.immutablePayload(), serialized.erasablePayload()));
+		} catch (Exception e) {
+			if ( deserializers.keySet().isEmpty() ) {
+				throw new RuntimeException("Failed to deserialize event data for type '%s', no EventType mappings configured. Pass the Event root Class when creating the EventStream".formatted(serialized.type().name()) , e);
+			} else {
+				throw new RuntimeException("Failed to deserialize event data for type '%s', known mappings for %s".formatted(serialized.type().name(), deserializers.keySet()) , e);
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public List<TypeAndPayload> deserializeMulti ( TypeAndSerializedPayload serialized ) {
+		List<TypeAndPayload> result;
+		try {
+			EventDeserializer deserializer = deserializers.get(serialized.type().name());
+			if ( deserializer == null  ) {
+				throw new RuntimeException("No mapping found for event type '" + serialized.type().name() + "'");
+			}
+			result = deserializer.deserializeMulti(serialized.immutablePayload(), serialized.erasablePayload());
 		} catch (Exception e) {
 			if ( deserializers.keySet().isEmpty() ) {
 				throw new RuntimeException("Failed to deserialize event data for type '%s', no EventType mappings configured. Pass the Event root Class when creating the EventStream".formatted(serialized.type().name()) , e);
@@ -93,25 +113,28 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 		if ( deserializers.containsKey(key) ) {
 			throw new IllegalArgumentException("duplicate event name " + key);
 		}
-		
+
 		EventType eventType = EventType.ofType(eventName);
 		EventDeserializer eventDeserializer = new InstantiationEventDeserializer(clazz, eventType);
 
 		// when we need to upcast an historical legacy event
 		if ( clazz.isAnnotationPresent(LegacyEvent.class)) {
-			
+
 			if ( !assumeUpcasters ) {
 				throw new RuntimeException("Event type %s should not be annotated as a @LegacyEvent, or moved to the legacy Event types".formatted(clazz));
 			}
-			
+
 			LegacyEvent annotation = clazz.getAnnotation(LegacyEvent.class);
 			Upcast<Object, Object> upcast;
 			try {
-				
+
 				upcast = (Upcast<Object, Object>) annotation.upcast().getDeclaredConstructor().newInstance(new Object[0]);
-				
-				mostRecentTypes.put(eventType, EventType.of(upcast.targetType()));
-				
+
+				Set<EventType> targets = upcast.targetTypes().stream()
+						.map(EventType::of)
+						.collect(Collectors.toSet());
+				mostRecentTypes.put(eventType, targets);
+
 			} catch (NoSuchMethodException e) {
 				throw new RuntimeException(e);
 			} catch (InvocationTargetException e) {
@@ -121,16 +144,16 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 			} catch (IllegalAccessException e) {
 				throw new RuntimeException(e);
 			}
-			eventDeserializer = new InstantiationAndUpcastEventDeserializer(eventDeserializer, upcast); 
-			
+			eventDeserializer = new InstantiationAndUpcastEventDeserializer(eventDeserializer, upcast);
+
 		} else {
 			if  ( assumeUpcasters ) {
 				throw new RuntimeException("legacy Event type %s should be annotated as a @LegacyEvent and configured with an Upcaster".formatted(clazz));
 			}
-			mostRecentTypes.put(eventType, eventType); // no upcasting needed
+			mostRecentTypes.put(eventType, Set.of(eventType)); // no upcasting needed
 		}
-		
-		
+
+
 		deserializers.put(key, eventDeserializer);
 	}
 	
@@ -200,6 +223,9 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 	interface EventDeserializer {
 		Object deserialize ( String immutablePayload, String erasablePayload );
 		EventType eventType ( );
+		default List<TypeAndPayload> deserializeMulti ( String immutablePayload, String erasablePayload ) {
+			return List.of(new TypeAndPayload(eventType(), deserialize(immutablePayload, erasablePayload)));
+		}
 	}
 	
 	class InstantiationEventDeserializer implements EventDeserializer {
@@ -257,7 +283,7 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 			this.upcaster = upcaster;
 			this.eventType = EventType.of(upcaster.targetType());
 		}
-		
+
 		@Override
 		public Object deserialize ( String immutablePayload, String erasablePayload ) {
 			return upcaster.upcast(deser.deserialize(immutablePayload, erasablePayload));
@@ -268,6 +294,15 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 			return eventType;
 		}
 
+		@Override
+		public List<TypeAndPayload> deserializeMulti ( String immutablePayload, String erasablePayload ) {
+			Object historicalEvent = deser.deserialize(immutablePayload, erasablePayload);
+			List<Object> upcastedEvents = upcaster.upcastAll(historicalEvent);
+			return upcastedEvents.stream()
+					.map(e -> new TypeAndPayload(EventType.of(e), e))
+					.toList();
+		}
+
 	}
 
 	@Override
@@ -275,7 +310,10 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 		// return all types that are upcasted to the currentType, and include the currentType itself as well
 		Set<EventType> currentConcreteEventTypes = concreteEventTypesFor(currentTypes); // explode to concrete implementations if interfaces are passed
 		Set<EventType> result = new HashSet<>(currentConcreteEventTypes); // we always include "current types", legacy types are optional - only if they are present
-		result.addAll(mostRecentTypes.entrySet().stream().filter(e->currentConcreteEventTypes.contains(e.getValue())).map(e->e.getKey()).collect(Collectors.toSet()));
+		result.addAll(mostRecentTypes.entrySet().stream()
+				.filter(e -> e.getValue().stream().anyMatch(currentConcreteEventTypes::contains))
+				.map(Map.Entry::getKey)
+				.collect(Collectors.toSet()));
 		return result;
 	}
 	

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
@@ -276,28 +276,35 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 
 		private final Upcast<Object,Object> upcaster;
 		private final EventDeserializer deser;
-		private final EventType eventType;
 
 		public InstantiationAndUpcastEventDeserializer ( EventDeserializer deser, Upcast<Object,Object> upcaster ) {
 			this.deser = deser;
 			this.upcaster = upcaster;
-			this.eventType = EventType.of(upcaster.targetType());
 		}
 
 		@Override
 		public Object deserialize ( String immutablePayload, String erasablePayload ) {
-			return upcaster.upcast(deser.deserialize(immutablePayload, erasablePayload));
+			// Single-event path: delegate to deserializeMulti and return the first result.
+			// This path is not used for upcasted events during queries (which use deserializeMulti),
+			// but may be called for non-query scenarios (e.g., after append).
+			List<TypeAndPayload> results = deserializeMulti(immutablePayload, erasablePayload);
+			return results.isEmpty() ? null : results.getFirst().eventData();
 		}
 
 		@Override
 		public EventType eventType() {
-			return eventType;
+			// For upcasters, the event type is determined per-event in deserializeMulti.
+			// This fallback returns the first target type from targetTypes(), or null if empty.
+			return upcaster.targetTypes().stream()
+					.map(EventType::of)
+					.findFirst()
+					.orElse(null);
 		}
 
 		@Override
 		public List<TypeAndPayload> deserializeMulti ( String immutablePayload, String erasablePayload ) {
 			Object historicalEvent = deser.deserialize(immutablePayload, erasablePayload);
-			List<Object> upcastedEvents = upcaster.upcastAll(historicalEvent);
+			List<Object> upcastedEvents = upcaster.upcast(historicalEvent);
 			return upcastedEvents.stream()
 					.map(e -> new TypeAndPayload(EventType.of(e), e))
 					.toList();

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/stream/PostgresUpcastMultiTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/stream/PostgresUpcastMultiTest.java
@@ -1,0 +1,55 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorageImpl;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.spi.EventStorage;
+
+public class PostgresUpcastMultiTest extends UpcastMultiTest {
+
+	@Override
+	public EventStorage createEventStorage ( ) {
+		return PostgresEventStorage.newBuilder()
+				.name("unit-test")
+				.dataSource(PostgresContainer.dataSource())
+				.initializeDatabase()
+				.build();
+	}
+
+	@Override
+	public void destroyEventStorage ( EventStorage storage ) {
+		((PostgresEventStorageImpl)storage).stop();
+		PostgresContainer.closeDataSource();
+	}
+
+	@BeforeAll
+	public static void setUpBeforeAll ( ) {
+		PostgresContainer.start();
+	}
+
+	@AfterAll
+	public static void tearDownAfterAll ( ) {
+		PostgresContainer.stop();
+		PostgresContainer.cleanup();
+	}
+
+}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorTest.java
@@ -71,16 +71,16 @@ public class ProjectorTest extends AbstractEventStoreTest {
 
 		ProjectorMetrics projectorMetrics = projector.run();
 		assertEquals(4, projection.counter()); // SecondDomainEvent type is left out by the query
-		assertEquals(1, projectorMetrics.queriesDone());
+		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
 		assertEquals(4,  projectorMetrics.eventsStreamed());
 		assertEquals(4,  projectorMetrics.eventsHandled());
 
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(1, accumulatedMetrics.queriesDone());
-		assertEquals(4,  accumulatedMetrics.eventsStreamed()); 
+		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(4,  accumulatedMetrics.eventsStreamed());
 		assertEquals(4,  accumulatedMetrics.eventsHandled());
-		
-		
+
+
 		BatchAwareTestProjection batchAwareProjection = new BatchAwareTestProjection();	
 		var batchAwareProjector = Projector.from(es).towards(batchAwareProjection).build();
 
@@ -513,13 +513,13 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		
 		ProjectorMetrics projectorMetrics = projector.runUntil(ref);
 		assertEquals(3, projection.counter()); // SecondDomainEvent type is left out by the query, until removes everything after four
-		assertEquals(1, projectorMetrics.queriesDone());
+		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
 		assertEquals(3,  projectorMetrics.eventsStreamed()); // since we pass in until, we don't stream the extra events
 		assertEquals(3,  projectorMetrics.eventsHandled());
-	
+
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(1, accumulatedMetrics.queriesDone());
-		assertEquals(3,  accumulatedMetrics.eventsStreamed()); 
+		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(3,  accumulatedMetrics.eventsStreamed());
 		assertEquals(3,  accumulatedMetrics.eventsHandled());
 	}
 
@@ -535,27 +535,27 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		var projector = Projector.from(alternativeStream).towards(projection).build();
 		
 		ProjectorMetrics projectorMetrics = projector.run();
-		assertEquals(1, projection.counter()); 
-		assertEquals(1, projectorMetrics.queriesDone());
-		assertEquals(1,  projectorMetrics.eventsStreamed()); 
+		assertEquals(1, projection.counter());
+		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1,  projectorMetrics.eventsStreamed());
 		assertEquals(1,  projectorMetrics.eventsHandled());
 
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(1, accumulatedMetrics.queriesDone());
-		assertEquals(1,  accumulatedMetrics.eventsStreamed()); 
+		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(1,  accumulatedMetrics.eventsStreamed());
 		assertEquals(1,  accumulatedMetrics.eventsHandled());
 
 		append(alternativeStream, new FirstDomainEvent("2"), Tags.of("nr", "two"));
 
 		projectorMetrics = projector.run();
-		assertEquals(2, projection.counter()); // second event now also processed by projection 
-		assertEquals(1, projectorMetrics.queriesDone());
-		assertEquals(1,  projectorMetrics.eventsStreamed()); 
+		assertEquals(2, projection.counter()); // second event now also processed by projection
+		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1,  projectorMetrics.eventsStreamed());
 		assertEquals(1,  projectorMetrics.eventsHandled());
 
 		accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(2, accumulatedMetrics.queriesDone());
-		assertEquals(2,  accumulatedMetrics.eventsStreamed()); 
+		assertEquals(4, accumulatedMetrics.queriesDone());
+		assertEquals(2,  accumulatedMetrics.eventsStreamed());
 		assertEquals(2,  accumulatedMetrics.eventsHandled());
 	}
 	
@@ -570,13 +570,13 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		
 		ProjectorMetrics projectorMetrics = projector.runUntil(refUntil);
 		assertEquals(2, projection.counter()); // SecondDomainEvent type is left out by the query, until removes everything after four
-		assertEquals(1, projectorMetrics.queriesDone());
-		assertEquals(2,  projectorMetrics.eventsStreamed()); // since we pass "until", we don't stream the extra events 
+		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(2,  projectorMetrics.eventsStreamed()); // since we pass "until", we don't stream the extra events
 		assertEquals(2,  projectorMetrics.eventsHandled());
-	
+
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(1, accumulatedMetrics.queriesDone());
-		assertEquals(2,  accumulatedMetrics.eventsStreamed()); 
+		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(2,  accumulatedMetrics.eventsStreamed());
 		assertEquals(2,  accumulatedMetrics.eventsHandled());
 	}
 
@@ -603,7 +603,7 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		// initQuery finds the savepoint (ThirdDomainEvent), then eventQuery processes the 2 FirstDomainEvents after it
 		assertEquals(3, projection.counter()); // 1 from initQuery + 2 from eventQuery
 		assertEquals("savepoint:15", projection.lastSavepoint()); // savepoint was processed
-		assertEquals(2, metrics.queriesDone()); // 1 for initQuery + 1 for eventQuery
+		assertEquals(3, metrics.queriesDone()); // 1 for initQuery + 1 eventQuery batch + 1 empty end-of-stream confirmation
 		assertEquals(3, metrics.eventsHandled()); // 1 savepoint + 2 movements
 	}
 
@@ -625,7 +625,7 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		// No savepoint found, so all FirstDomainEvents are processed by the main eventQuery
 		assertEquals(3, projection.counter());
 		assertNull(projection.lastSavepoint()); // no savepoint was found
-		assertEquals(2, metrics.queriesDone()); // 1 for initQuery (empty) + 1 for eventQuery
+		assertEquals(3, metrics.queriesDone()); // 1 for initQuery (empty) + 1 eventQuery batch + 1 empty end-of-stream confirmation
 		assertEquals(3, metrics.eventsHandled());
 	}
 
@@ -651,7 +651,7 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		// With bookmarking, initQuery is ignored — all FirstDomainEvents are processed from the start
 		assertEquals(4, projection.counter()); // all 4 FirstDomainEvents (Third is excluded by eventQuery)
 		assertNull(projection.lastSavepoint()); // savepoint was NOT processed (initQuery skipped, Third not in eventQuery)
-		assertEquals(1, metrics.queriesDone()); // no initQuery, just 1 eventQuery batch
+		assertEquals(2, metrics.queriesDone()); // no initQuery, 1 eventQuery batch + 1 empty end-of-stream confirmation
 		assertEquals(4, metrics.eventsHandled());
 	}
 

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorWithUpcastingTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorWithUpcastingTest.java
@@ -1,0 +1,231 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.projection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.LegacyEvent;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.events.Upcast;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.projection.Projector.ProjectorMetrics;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+/**
+ * Tests that the Projector correctly advances past events that upcast to zero enriched events,
+ * avoiding infinite re-querying and ensuring bookmarks advance past vanished events.
+ */
+public class ProjectorWithUpcastingTest extends AbstractEventStoreTest {
+
+	// =========================================================================
+	// Domain model: original events as stored
+	// =========================================================================
+
+	sealed interface OriginalEvent {
+		record ImportantAction ( String value ) implements OriginalEvent { }
+		record ObsoleteAuditLog ( String message ) implements OriginalEvent { }
+	}
+
+	// =========================================================================
+	// Domain model: current events (after upcasting)
+	// =========================================================================
+
+	sealed interface CurrentEvent {
+		record ImportantAction ( String value ) implements CurrentEvent { }
+	}
+
+	// =========================================================================
+	// Legacy events for upcasting
+	// =========================================================================
+
+	sealed interface LegacyEvents {
+		@LegacyEvent(upcast = FilterAuditLogUpcaster.class)
+		record ObsoleteAuditLog ( String message ) implements LegacyEvents { }
+	}
+
+	// =========================================================================
+	// Upcaster: filters out obsolete audit logs (produces zero events)
+	// =========================================================================
+
+	public static class FilterAuditLogUpcaster implements Upcast<LegacyEvents.ObsoleteAuditLog, CurrentEvent> {
+		@Override
+		public List<CurrentEvent> upcast ( LegacyEvents.ObsoleteAuditLog historicalEvent ) {
+			return List.of();
+		}
+		@Override
+		public Set<Class<? extends CurrentEvent>> targetTypes ( ) {
+			return Set.of();
+		}
+	}
+
+	// =========================================================================
+	// Projection: tracks important actions
+	// =========================================================================
+
+	static class TrackingProjection implements ProjectionWithoutMetaData<CurrentEvent> {
+		List<String> values = new ArrayList<>();
+		@Override
+		public EventQuery eventQuery ( ) {
+			return EventQuery.matchAll();
+		}
+		@Override
+		public void when ( CurrentEvent event ) {
+			if ( event instanceof CurrentEvent.ImportantAction a ) {
+				values.add(a.value());
+			}
+		}
+	}
+
+	// =========================================================================
+	// Test infrastructure
+	// =========================================================================
+
+	EventStreamId streamId = EventStreamId.forContext("projector-upcast-test");
+
+	@Override
+	public EventStorage createEventStorage ( ) {
+		return InMemoryEventStorage.newBuilder().build();
+	}
+
+	private void appendOriginal ( EventStream<OriginalEvent> stream, OriginalEvent event ) {
+		stream.append(AppendCriteria.none(), Event.of(event, Tags.none()));
+	}
+
+	// =========================================================================
+	// Tests
+	// =========================================================================
+
+	@Test
+	void testProjectorAdvancesPastVanishedEventsToFindSubsequentEvents ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore().getEventStream(streamId, OriginalEvent.class);
+		appendOriginal(originalStream, new OriginalEvent.ImportantAction("first"));
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit1"));
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit2"));
+		appendOriginal(originalStream, new OriginalEvent.ImportantAction("last"));
+
+		EventStream<CurrentEvent> stream = eventStore().getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		TrackingProjection projection = new TrackingProjection();
+		Projector<CurrentEvent> projector = Projector.from(stream).towards(projection).inBatchesOf(1).build();
+		ProjectorMetrics metrics = projector.run();
+
+		assertEquals(List.of("first", "last"), projection.values);
+		assertEquals(2, metrics.eventsHandled());
+		assertNotNull(metrics.lastEventReference());
+	}
+
+	@Test
+	void testProjectorTerminatesWhenAllEventsVanish ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore().getEventStream(streamId, OriginalEvent.class);
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit1"));
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit2"));
+
+		EventStream<CurrentEvent> stream = eventStore().getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		TrackingProjection projection = new TrackingProjection();
+		Projector<CurrentEvent> projector = Projector.from(stream).towards(projection).build();
+		ProjectorMetrics metrics = projector.run();
+
+		assertEquals(0, projection.values.size());
+		assertEquals(0, metrics.eventsHandled());
+		assertNotNull(metrics.lastEventReference());
+	}
+
+	@Test
+	void testBookmarkAdvancesPastVanishedEvents ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore().getEventStream(streamId, OriginalEvent.class);
+		appendOriginal(originalStream, new OriginalEvent.ImportantAction("first"));
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit1"));
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit2"));
+
+		EventStream<CurrentEvent> stream = eventStore().getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		TrackingProjection projection = new TrackingProjection();
+		Projector<CurrentEvent> projector = Projector.from(stream)
+			.towards(projection)
+			.bookmarkProgress().withReader("test-reader").readBeforeEachExecution().done()
+			.inBatchesOf(1)
+			.build();
+
+		projector.run();
+		assertEquals(List.of("first"), projection.values);
+
+		// Bookmark should have advanced past the vanished events
+		var bookmark = stream.getBookmark("test-reader");
+		assertTrue(bookmark.isPresent());
+
+		// Append a new important event after the vanished ones
+		originalStream.append(AppendCriteria.none(), Event.of(new OriginalEvent.ImportantAction("second"), Tags.none()));
+
+		// Second run should pick up only the new event
+		projector.run();
+		assertEquals(List.of("first", "second"), projection.values);
+	}
+
+	@Test
+	void testVanishedEventsAtStartWithBatchSize1 ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore().getEventStream(streamId, OriginalEvent.class);
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit1"));
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit2"));
+		appendOriginal(originalStream, new OriginalEvent.ImportantAction("important"));
+
+		EventStream<CurrentEvent> stream = eventStore().getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		TrackingProjection projection = new TrackingProjection();
+		Projector<CurrentEvent> projector = Projector.from(stream).towards(projection).inBatchesOf(1).build();
+		ProjectorMetrics metrics = projector.run();
+
+		assertEquals(List.of("important"), projection.values);
+		assertEquals(1, metrics.eventsHandled());
+	}
+
+	@Test
+	void testRunSingleBatchAdvancesPastVanishedEvents ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore().getEventStream(streamId, OriginalEvent.class);
+		appendOriginal(originalStream, new OriginalEvent.ObsoleteAuditLog("audit1"));
+		appendOriginal(originalStream, new OriginalEvent.ImportantAction("important"));
+
+		EventStream<CurrentEvent> stream = eventStore().getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		TrackingProjection projection = new TrackingProjection();
+		Projector<CurrentEvent> projector = Projector.from(stream).towards(projection).inBatchesOf(1).build();
+
+		// First single batch: the vanished event — cursor should advance
+		ProjectorMetrics metrics1 = projector.runSingleBatch();
+		assertEquals(0, projection.values.size());
+		assertNotNull(metrics1.lastEventReference());
+
+		// Second single batch: the important event
+		ProjectorMetrics metrics2 = projector.runSingleBatch();
+		assertEquals(List.of("important"), projection.values);
+	}
+
+}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/EventStreamTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/EventStreamTest.java
@@ -184,33 +184,33 @@ public class EventStreamTest extends AbstractEventStoreTest {
 		EventId eventId = events.getFirst().reference().id();
 
 		// check we can find it via getEvent on the same stream
-		Optional<Event<MockDomainEvent>> retrieved = es.getEventById(eventId);
-		assertTrue(retrieved.isPresent());
-		assertEquals(eventId, retrieved.get().reference().id());
+		List<Event<MockDomainEvent>> retrieved = es.getEventById(eventId);
+		assertFalse(retrieved.isEmpty());
+		assertEquals(eventId, retrieved.getFirst().reference().id());
 		// or from a query on the same
 		assertTrue(es.query(EventQuery.matchAll()).map(e->e.reference().id()).filter(id->id.equals(eventId)).findAny().isPresent());
-		
-		
+
+
 		// check we can find it via getEvent on a generic stream
 		EventStreamId generic = EventStreamId.anyContext().anyPurpose();
 		EventStream<MockDomainEvent> genericStream = eventStore().getEventStream(generic, MockDomainEvent.class);
 		retrieved = genericStream.getEventById(eventId);
-		assertTrue(retrieved.isPresent());
-		assertEquals(eventId, retrieved.get().reference().id());
+		assertFalse(retrieved.isEmpty());
+		assertEquals(eventId, retrieved.getFirst().reference().id());
 		// or from a query on the same
 		assertTrue(genericStream.query(EventQuery.matchAll()).map(e->e.reference().id()).filter(id->id.equals(eventId)).findAny().isPresent());
 
-		
+
 		// check we can't get it via another stream
 		EventStreamId other = EventStreamId.forContext("test2").withPurpose("test2");
 		EventStream<MockDomainEvent> otherStream = eventStore().getEventStream(other, MockDomainEvent.class);
-		Optional<Event<MockDomainEvent>> notRetrieved = otherStream.getEventById(eventId);
-		assertFalse(notRetrieved.isPresent());
+		List<Event<MockDomainEvent>> notRetrieved = otherStream.getEventById(eventId);
+		assertTrue(notRetrieved.isEmpty());
 		// and neither from a query on the same
 		assertFalse(otherStream.query(EventQuery.matchAll()).map(e->e.reference().id()).filter(id->id.equals(eventId)).findAny().isPresent());
 
 	}
-	
+
 	@Test
 	void testAppendWithIdempotency ( ) {
 		
@@ -256,33 +256,33 @@ public class EventStreamTest extends AbstractEventStoreTest {
 		EventId eventId = events.getFirst().reference().id();
 
 		// check we can find it via getEvent on the same stream
-		Optional<Event<MockDomainEvent>> retrieved = es.getEventById(eventId);
-		assertTrue(retrieved.isPresent());
-		assertEquals(eventId, retrieved.get().reference().id());
+		List<Event<MockDomainEvent>> retrieved = es.getEventById(eventId);
+		assertFalse(retrieved.isEmpty());
+		assertEquals(eventId, retrieved.getFirst().reference().id());
 		// or from a query on the same
 		assertTrue(es.query(EventQuery.matchAll()).map(e->e.reference().id()).filter(id->id.equals(eventId)).findAny().isPresent());
-		
-		
+
+
 		// check we can find it via getEvent on a generic stream
 		EventStreamId generic = EventStreamId.anyContext().anyPurpose();
 		EventStream<MockDomainEvent> genericStream = eventStore().getEventStream(generic, MockDomainEvent.class);
 		retrieved = genericStream.getEventById(eventId);
-		assertTrue(retrieved.isPresent());
-		assertEquals(eventId, retrieved.get().reference().id());
+		assertFalse(retrieved.isEmpty());
+		assertEquals(eventId, retrieved.getFirst().reference().id());
 		// or from a query on the same
 		assertTrue(genericStream.query(EventQuery.matchAll()).map(e->e.reference().id()).filter(id->id.equals(eventId)).findAny().isPresent());
 
-		
+
 		// check we can't get it via another stream
 		EventStreamId other = EventStreamId.forContext("test2").withPurpose("test2");
 		EventStream<MockDomainEvent> otherStream = eventStore().getEventStream(other, MockDomainEvent.class);
-		Optional<Event<MockDomainEvent>> notRetrieved = otherStream.getEventById(eventId);
-		assertFalse(notRetrieved.isPresent());
+		List<Event<MockDomainEvent>> notRetrieved = otherStream.getEventById(eventId);
+		assertTrue(notRetrieved.isEmpty());
 		// and neither from a query on the same
 		assertFalse(otherStream.query(EventQuery.matchAll()).map(e->e.reference().id()).filter(id->id.equals(eventId)).findAny().isPresent());
 
 	}
-	
+
 	@Test
 	void testAppendMultipleWithIdempotency ( ) {
 		

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
@@ -1,0 +1,616 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.EventStoreFactory;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.LegacyEvent;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.events.Upcast;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.spi.EventStorage;
+
+/**
+ * Tests for multi-event upcasting: upcast-to-zero, upcast-to-one, upcast-to-many,
+ * combined with forward/backward queries, getEventById, and index verification.
+ */
+public class UpcastMultiTest {
+
+	EventStorage eventStorage;
+	EventStore eventStore;
+	EventStreamId streamId = EventStreamId.forContext("unittest");
+
+	@BeforeEach
+	public void setUp ( ) {
+		this.eventStorage = createEventStorage();
+		this.eventStore = EventStoreFactory.get().eventStore(eventStorage);
+	}
+
+	@AfterEach
+	public void tearDown ( ) {
+		destroyEventStorage(eventStorage);
+	}
+
+	public EventStorage createEventStorage ( ) {
+		return InMemoryEventStorage.newBuilder().build();
+	}
+
+	public void destroyEventStorage ( EventStorage storage ) {
+	}
+
+
+	// =========================================================================
+	// Domain model: original events as stored
+	// =========================================================================
+
+	sealed interface OriginalEvent {
+		/** A combined event that will be split into two events on upcast */
+		record CustomerRegisteredWithAddress ( String name, String street, String city ) implements OriginalEvent { }
+		/** An obsolete event that will be filtered out (upcast to 0) */
+		record CustomerLegacyAuditLog ( String message ) implements OriginalEvent { }
+		/** A simple rename upcast (1-to-1) */
+		record CustomerNameChanged ( String name ) implements OriginalEvent { }
+		/** An event that stays as-is (no upcast needed) */
+		record CustomerChurned ( ) implements OriginalEvent { }
+	}
+
+	// =========================================================================
+	// Domain model: current events
+	// =========================================================================
+
+	sealed interface CurrentEvent {
+		record CustomerRegistered ( String name ) implements CurrentEvent { }
+		record AddressRecorded ( String street, String city ) implements CurrentEvent { }
+		record CustomerRenamed ( String name ) implements CurrentEvent { }
+		record CustomerChurned ( ) implements CurrentEvent { }
+	}
+
+	// =========================================================================
+	// Legacy event types for upcasting
+	// =========================================================================
+
+	sealed interface LegacyEvents {
+
+		@LegacyEvent(upcast=SplitRegistrationUpcaster.class)
+		record CustomerRegisteredWithAddress ( String name, String street, String city ) implements LegacyEvents { }
+
+		@LegacyEvent(upcast=FilterAuditLogUpcaster.class)
+		record CustomerLegacyAuditLog ( String message ) implements LegacyEvents { }
+
+		@LegacyEvent(upcast=RenameNameChangedUpcaster.class)
+		record CustomerNameChanged ( String name ) implements LegacyEvents { }
+	}
+
+	// =========================================================================
+	// Upcasters
+	// =========================================================================
+
+	/** Upcast-to-many: splits a combined event into CustomerRegistered + AddressRecorded */
+	public static class SplitRegistrationUpcaster implements Upcast<LegacyEvents.CustomerRegisteredWithAddress, CurrentEvent> {
+
+		@Override
+		public CurrentEvent upcast ( LegacyEvents.CustomerRegisteredWithAddress historicalEvent ) {
+			throw new UnsupportedOperationException("should use upcastAll");
+		}
+
+		@Override
+		public List<CurrentEvent> upcastAll ( LegacyEvents.CustomerRegisteredWithAddress historicalEvent ) {
+			return List.of(
+				new CurrentEvent.CustomerRegistered(historicalEvent.name()),
+				new CurrentEvent.AddressRecorded(historicalEvent.street(), historicalEvent.city())
+			);
+		}
+
+		@Override
+		public Class<CurrentEvent> targetType ( ) {
+			return CurrentEvent.class; // not used directly, targetTypes() is overridden
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Set<Class<? extends CurrentEvent>> targetTypes ( ) {
+			return Set.of(CurrentEvent.CustomerRegistered.class, CurrentEvent.AddressRecorded.class);
+		}
+	}
+
+	/** Upcast-to-zero: filters out obsolete audit log events */
+	public static class FilterAuditLogUpcaster implements Upcast<LegacyEvents.CustomerLegacyAuditLog, CurrentEvent> {
+
+		@Override
+		public CurrentEvent upcast ( LegacyEvents.CustomerLegacyAuditLog historicalEvent ) {
+			throw new UnsupportedOperationException("should use upcastAll");
+		}
+
+		@Override
+		public List<CurrentEvent> upcastAll ( LegacyEvents.CustomerLegacyAuditLog historicalEvent ) {
+			return List.of(); // filtered out
+		}
+
+		@Override
+		public Class<CurrentEvent> targetType ( ) {
+			return CurrentEvent.class;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Set<Class<? extends CurrentEvent>> targetTypes ( ) {
+			return Set.of(); // produces no target types
+		}
+	}
+
+	/** Upcast-to-one: simple rename */
+	public static class RenameNameChangedUpcaster implements Upcast<LegacyEvents.CustomerNameChanged, CurrentEvent.CustomerRenamed> {
+
+		@Override
+		public CurrentEvent.CustomerRenamed upcast ( LegacyEvents.CustomerNameChanged historicalEvent ) {
+			return new CurrentEvent.CustomerRenamed(historicalEvent.name());
+		}
+
+		@Override
+		public Class<CurrentEvent.CustomerRenamed> targetType ( ) {
+			return CurrentEvent.CustomerRenamed.class;
+		}
+	}
+
+
+	// =========================================================================
+	// Helper: store original events and return the upcasted stream
+	// =========================================================================
+
+	private EventStream<CurrentEvent> storeOriginalAndGetUpcastedStream ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore.getEventStream(streamId, OriginalEvent.class);
+
+		// Position 1: will split into 2 events (index 0,1)
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerRegisteredWithAddress("John", "123 Main St", "Springfield"),
+			Tags.of("customer", "1")));
+
+		// Position 2: will be filtered out (0 events)
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerLegacyAuditLog("some audit message"),
+			Tags.of("customer", "1")));
+
+		// Position 3: will upcast 1-to-1
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerNameChanged("Jane"),
+			Tags.of("customer", "1")));
+
+		// Position 4: not upcasted, stays as-is
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerChurned(),
+			Tags.of("customer", "1")));
+
+		return eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+	}
+
+
+	// =========================================================================
+	// Tests: forward queries
+	// =========================================================================
+
+	@Test
+	void testForwardQueryMatchAll ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+
+		// Position 1 → 2 events, Position 2 → 0 events, Position 3 → 1 event, Position 4 → 1 event = 4 total
+		assertEquals(4, events.size());
+
+		// First: CustomerRegistered (from split, index 0)
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(0).data().getClass());
+		assertEquals("John", ((CurrentEvent.CustomerRegistered) events.get(0).data()).name());
+
+		// Second: AddressRecorded (from split, index 1)
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(1).data().getClass());
+		assertEquals("123 Main St", ((CurrentEvent.AddressRecorded) events.get(1).data()).street());
+		assertEquals("Springfield", ((CurrentEvent.AddressRecorded) events.get(1).data()).city());
+
+		// Third: CustomerRenamed (from 1-to-1 upcast)
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(2).data().getClass());
+		assertEquals("Jane", ((CurrentEvent.CustomerRenamed) events.get(2).data()).name());
+
+		// Fourth: CustomerChurned (no upcast)
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(3).data().getClass());
+	}
+
+	@Test
+	void testForwardQueryFilteredEventTypesIncludeUpcasted ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// Query specifically for CustomerRegistered — should find it from the split
+		List<Event<CurrentEvent>> registered = stream.query(
+			EventQuery.forEvents(EventTypesFilter.of(CurrentEvent.CustomerRegistered.class), Tags.none())
+		).toList();
+		assertEquals(1, registered.size());
+		assertEquals("John", ((CurrentEvent.CustomerRegistered) registered.get(0).data()).name());
+
+		// Query specifically for AddressRecorded — should find it from the split
+		List<Event<CurrentEvent>> addresses = stream.query(
+			EventQuery.forEvents(EventTypesFilter.of(CurrentEvent.AddressRecorded.class), Tags.none())
+		).toList();
+		assertEquals(1, addresses.size());
+		assertEquals("Springfield", ((CurrentEvent.AddressRecorded) addresses.get(0).data()).city());
+
+		// Query for CustomerRenamed — should find the 1-to-1 upcast
+		List<Event<CurrentEvent>> renamed = stream.query(
+			EventQuery.forEvents(EventTypesFilter.of(CurrentEvent.CustomerRenamed.class), Tags.none())
+		).toList();
+		assertEquals(1, renamed.size());
+		assertEquals("Jane", ((CurrentEvent.CustomerRenamed) renamed.get(0).data()).name());
+	}
+
+
+	// =========================================================================
+	// Tests: index verification on references
+	// =========================================================================
+
+	@Test
+	void testSplitEventsHaveDistinctIndices ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+
+		// Events from position 1 (split): should have index 0 and 1
+		assertEquals(0, events.get(0).reference().index());
+		assertEquals(1, events.get(1).reference().index());
+
+		// They share the same id, position, and tx
+		assertEquals(events.get(0).reference().id(), events.get(1).reference().id());
+		assertEquals(events.get(0).reference().position(), events.get(1).reference().position());
+		assertEquals(events.get(0).reference().tx(), events.get(1).reference().tx());
+
+		// Single-event results have index 0
+		assertEquals(0, events.get(2).reference().index()); // CustomerRenamed
+		assertEquals(0, events.get(3).reference().index()); // CustomerChurned
+	}
+
+	@Test
+	void testSplitEventsOrderCorrectlyViaHappenedBefore ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+
+		// index 0 happened before index 1
+		assertTrue(events.get(0).reference().happenedBefore(events.get(1).reference()));
+
+		// index 1 happened before position 3 events
+		assertTrue(events.get(1).reference().happenedBefore(events.get(2).reference()));
+
+		// overall ordering is consistent
+		for ( int i = 0; i < events.size() - 1; i++ ) {
+			assertTrue(events.get(i).reference().happenedBefore(events.get(i+1).reference()),
+				"event %d should happenBefore event %d".formatted(i, i+1));
+		}
+	}
+
+
+	// =========================================================================
+	// Tests: backward queries
+	// =========================================================================
+
+	@Test
+	void testBackwardQueryMatchAll ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards()).toList();
+
+		// Same 4 events, reversed
+		assertEquals(4, events.size());
+
+		// First (most recent): CustomerChurned
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
+
+		// Second: CustomerRenamed
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(1).data().getClass());
+
+		// Third: AddressRecorded (index 1, from split — descending within the split)
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(2).data().getClass());
+		assertEquals(1, events.get(2).reference().index());
+
+		// Fourth: CustomerRegistered (index 0, from split)
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(3).data().getClass());
+		assertEquals(0, events.get(3).reference().index());
+	}
+
+	@Test
+	void testBackwardQueryWithLimit ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// Get the most recent 2 events
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards().limit(2)).toList();
+
+		assertEquals(2, events.size());
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(1).data().getClass());
+	}
+
+	@Test
+	void testBackwardQueryIndicesStillCorrect ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards()).toList();
+
+		// The split events (at end of list in backward order) should still have their
+		// canonical indices: AddressRecorded=1, CustomerRegistered=0
+		Event<CurrentEvent> addressEvent = events.stream()
+			.filter(e -> e.data() instanceof CurrentEvent.AddressRecorded)
+			.findFirst().orElseThrow();
+		Event<CurrentEvent> registeredEvent = events.stream()
+			.filter(e -> e.data() instanceof CurrentEvent.CustomerRegistered)
+			.findFirst().orElseThrow();
+
+		assertEquals(1, addressEvent.reference().index());
+		assertEquals(0, registeredEvent.reference().index());
+
+		// AddressRecorded (index 1) happened after CustomerRegistered (index 0)
+		assertTrue(registeredEvent.reference().happenedBefore(addressEvent.reference()));
+	}
+
+
+	// =========================================================================
+	// Tests: getEventById
+	// =========================================================================
+
+	@Test
+	void testGetEventByIdForSplitEvent ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// Get the EventId of the split event (position 1)
+		List<Event<CurrentEvent>> allEvents = stream.query(EventQuery.matchAll()).toList();
+		EventId splitEventId = allEvents.get(0).reference().id();
+
+		// getEventById should return both sub-events
+		List<Event<CurrentEvent>> retrieved = stream.getEventById(splitEventId);
+		assertEquals(2, retrieved.size());
+		assertEquals(CurrentEvent.CustomerRegistered.class, retrieved.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, retrieved.get(1).data().getClass());
+		assertEquals(0, retrieved.get(0).reference().index());
+		assertEquals(1, retrieved.get(1).reference().index());
+	}
+
+	@Test
+	void testGetEventByIdForFilteredEvent ( ) {
+		// Store events including one that gets filtered out
+		EventStream<OriginalEvent> originalStream = eventStore.getEventStream(streamId, OriginalEvent.class);
+
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerLegacyAuditLog("audit"),
+			Tags.of("customer", "1")));
+
+		// Get the EventId from the original stream
+		EventId auditEventId = originalStream.query(EventQuery.matchAll()).toList().get(0).reference().id();
+
+		// Now read via the upcasted stream
+		EventStream<CurrentEvent> upcastedStream = eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		// getEventById should return empty list for a filtered event
+		List<Event<CurrentEvent>> retrieved = upcastedStream.getEventById(auditEventId);
+		assertEquals(0, retrieved.size());
+	}
+
+	@Test
+	void testGetEventByIdForOneToOneUpcast ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// Find the CustomerRenamed event
+		Event<CurrentEvent> renamedEvent = stream.query(EventQuery.matchAll()).toList().stream()
+			.filter(e -> e.data() instanceof CurrentEvent.CustomerRenamed)
+			.findFirst().orElseThrow();
+
+		List<Event<CurrentEvent>> retrieved = stream.getEventById(renamedEvent.reference().id());
+		assertEquals(1, retrieved.size());
+		assertEquals(CurrentEvent.CustomerRenamed.class, retrieved.get(0).data().getClass());
+		assertEquals(0, retrieved.get(0).reference().index());
+	}
+
+	@Test
+	void testGetEventByIdForNonUpcastedEvent ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// Find the CustomerChurned event (not upcasted)
+		Event<CurrentEvent> churnedEvent = stream.query(EventQuery.matchAll()).toList().stream()
+			.filter(e -> e.data() instanceof CurrentEvent.CustomerChurned)
+			.findFirst().orElseThrow();
+
+		List<Event<CurrentEvent>> retrieved = stream.getEventById(churnedEvent.reference().id());
+		assertEquals(1, retrieved.size());
+		assertEquals(CurrentEvent.CustomerChurned.class, retrieved.get(0).data().getClass());
+		assertEquals(0, retrieved.get(0).reference().index());
+	}
+
+	@Test
+	void testGetEventByIdNonExistent ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> retrieved = stream.getEventById(EventId.create());
+		assertEquals(0, retrieved.size());
+	}
+
+
+	// =========================================================================
+	// Tests: upcast-to-zero is properly invisible in queries
+	// =========================================================================
+
+	@Test
+	void testFilteredEventsAreInvisibleInForwardQuery ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+
+		// The audit log event (position 2) should be completely absent
+		for ( Event<CurrentEvent> event : events ) {
+			assertTrue(event.reference().position() != 2,
+				"position 2 (filtered audit log) should not appear in results");
+		}
+	}
+
+	@Test
+	void testFilteredEventsAreInvisibleInBackwardQuery ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards()).toList();
+
+		for ( Event<CurrentEvent> event : events ) {
+			assertTrue(event.reference().position() != 2,
+				"position 2 (filtered audit log) should not appear in backward results");
+		}
+	}
+
+
+	// =========================================================================
+	// Tests: storedType vs type for upcasted events
+	// =========================================================================
+
+	@Test
+	void testStoredTypePreservedOnSplitEvents ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+
+		// Split events: stored type is the original, type is the upcasted
+		assertEquals(EventType.ofType("CustomerRegisteredWithAddress"), events.get(0).storedType());
+		assertEquals(EventType.ofType("CustomerRegistered"), events.get(0).type());
+
+		assertEquals(EventType.ofType("CustomerRegisteredWithAddress"), events.get(1).storedType());
+		assertEquals(EventType.ofType("AddressRecorded"), events.get(1).type());
+	}
+
+	@Test
+	void testStoredTypePreservedOnOneToOneUpcast ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		Event<CurrentEvent> renamed = stream.query(EventQuery.matchAll()).toList().stream()
+			.filter(e -> e.data() instanceof CurrentEvent.CustomerRenamed)
+			.findFirst().orElseThrow();
+
+		assertEquals(EventType.ofType("CustomerNameChanged"), renamed.storedType());
+		assertEquals(EventType.ofType("CustomerRenamed"), renamed.type());
+	}
+
+
+	// =========================================================================
+	// Tests: multiple split events in the stream
+	// =========================================================================
+
+	@Test
+	void testMultipleSplitEventsInStream ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore.getEventStream(streamId, OriginalEvent.class);
+
+		// Two split events in sequence
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerRegisteredWithAddress("Alice", "1 A St", "CityA"),
+			Tags.of("customer", "1")));
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerRegisteredWithAddress("Bob", "2 B St", "CityB"),
+			Tags.of("customer", "2")));
+
+		EventStream<CurrentEvent> stream = eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+		assertEquals(4, events.size()); // 2 splits × 2 events each
+
+		// First split (position 1): Alice
+		assertEquals(0, events.get(0).reference().index());
+		assertEquals(1, events.get(1).reference().index());
+		assertEquals("Alice", ((CurrentEvent.CustomerRegistered) events.get(0).data()).name());
+		assertEquals("CityA", ((CurrentEvent.AddressRecorded) events.get(1).data()).city());
+
+		// Second split (position 2): Bob
+		assertEquals(0, events.get(2).reference().index());
+		assertEquals(1, events.get(3).reference().index());
+		assertEquals("Bob", ((CurrentEvent.CustomerRegistered) events.get(2).data()).name());
+		assertEquals("CityB", ((CurrentEvent.AddressRecorded) events.get(3).data()).city());
+
+		// Each pair has a different EventId
+		assertTrue(!events.get(0).reference().id().equals(events.get(2).reference().id()));
+	}
+
+	@Test
+	void testMultipleSplitEventsBackward ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore.getEventStream(streamId, OriginalEvent.class);
+
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerRegisteredWithAddress("Alice", "1 A St", "CityA"),
+			Tags.of("customer", "1")));
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerRegisteredWithAddress("Bob", "2 B St", "CityB"),
+			Tags.of("customer", "2")));
+
+		EventStream<CurrentEvent> stream = eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards()).toList();
+		assertEquals(4, events.size());
+
+		// Backward: Bob's split comes first (reversed within split too)
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(0).data().getClass());
+		assertEquals("CityB", ((CurrentEvent.AddressRecorded) events.get(0).data()).city());
+		assertEquals(1, events.get(0).reference().index()); // index 1 first in backward
+
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(1).data().getClass());
+		assertEquals("Bob", ((CurrentEvent.CustomerRegistered) events.get(1).data()).name());
+		assertEquals(0, events.get(1).reference().index());
+
+		// Then Alice's split
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(2).data().getClass());
+		assertEquals("CityA", ((CurrentEvent.AddressRecorded) events.get(2).data()).city());
+		assertEquals(1, events.get(2).reference().index());
+
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(3).data().getClass());
+		assertEquals("Alice", ((CurrentEvent.CustomerRegistered) events.get(3).data()).name());
+		assertEquals(0, events.get(3).reference().index());
+	}
+
+
+	// =========================================================================
+	// Tests: only filtered events in stream (edge case)
+	// =========================================================================
+
+	@Test
+	void testStreamWithOnlyFilteredEvents ( ) {
+		EventStream<OriginalEvent> originalStream = eventStore.getEventStream(streamId, OriginalEvent.class);
+
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerLegacyAuditLog("audit 1"), Tags.of("customer", "1")));
+		originalStream.append(AppendCriteria.none(), Event.of(
+			new OriginalEvent.CustomerLegacyAuditLog("audit 2"), Tags.of("customer", "1")));
+
+		EventStream<CurrentEvent> stream = eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll()).toList();
+		assertEquals(0, events.size());
+
+		List<Event<CurrentEvent>> eventsBackward = stream.query(EventQuery.matchAll().backwards()).toList();
+		assertEquals(0, eventsBackward.size());
+	}
+
+}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
@@ -320,16 +320,152 @@ public class UpcastMultiTest {
 		assertEquals(0, events.get(3).reference().index());
 	}
 
+	// =========================================================================
+	// Tests: limit applies to stored events, not upcasted events
+	// =========================================================================
+	//
+	// The limit parameter restricts how many *stored* events are fetched from
+	// storage, before upcasting expands (or filters) them. This means:
+	//
+	//   Stored events (backward from position 4):
+	//     Position 4: CustomerChurned                → 1 upcasted event
+	//     Position 3: CustomerNameChanged             → 1 upcasted event  (renamed)
+	//     Position 2: CustomerLegacyAuditLog          → 0 upcasted events (filtered)
+	//     Position 1: CustomerRegisteredWithAddress   → 2 upcasted events (split)
+	//
+	//   Stored events (forward from position 1):
+	//     Position 1: CustomerRegisteredWithAddress   → 2 upcasted events (split)
+	//     Position 2: CustomerLegacyAuditLog          → 0 upcasted events (filtered)
+	//     Position 3: CustomerNameChanged             → 1 upcasted event  (renamed)
+	//     Position 4: CustomerChurned                → 1 upcasted event
+
 	@Test
-	void testBackwardQueryWithLimit ( ) {
+	void testBackwardQueryWithLimit1 ( ) {
 		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
 
-		// Get the most recent 2 events
+		// limit(1) → 1 stored event (position 4: CustomerChurned) → 1 upcasted event
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards().limit(1)).toList();
+
+		assertEquals(1, events.size());
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
+	}
+
+	@Test
+	void testBackwardQueryWithLimit2 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(2) → 2 stored events (position 4 + 3) → 2 upcasted events
 		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards().limit(2)).toList();
 
 		assertEquals(2, events.size());
 		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
 		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(1).data().getClass());
+	}
+
+	@Test
+	void testBackwardQueryWithLimit3 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(3) → 3 stored events (position 4 + 3 + 2)
+		// position 2 is the filtered audit log → 0 upcasted events
+		// so we still get only 2 upcasted events despite fetching 3 stored events
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards().limit(3)).toList();
+
+		assertEquals(2, events.size());
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(1).data().getClass());
+	}
+
+	@Test
+	void testBackwardQueryWithLimit4 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(4) → all 4 stored events
+		// position 1 splits into 2 → we get 4 upcasted events total
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards().limit(4)).toList();
+
+		assertEquals(4, events.size());
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(1).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(2).data().getClass());
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(3).data().getClass());
+	}
+
+	@Test
+	void testBackwardQueryWithLimit5 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(5) → exceeds the 4 stored events, same result as limit(4)
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().backwards().limit(5)).toList();
+
+		assertEquals(4, events.size());
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(1).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(2).data().getClass());
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(3).data().getClass());
+	}
+
+	@Test
+	void testForwardQueryWithLimit1 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(1) → 1 stored event (position 1: split) → 2 upcasted events
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().limit(1)).toList();
+
+		assertEquals(2, events.size());
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(1).data().getClass());
+	}
+
+	@Test
+	void testForwardQueryWithLimit2 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(2) → 2 stored events (position 1 + 2)
+		// position 2 is the filtered audit log → 0 upcasted events
+		// so we still get only 2 upcasted events from the split
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().limit(2)).toList();
+
+		assertEquals(2, events.size());
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(1).data().getClass());
+	}
+
+	@Test
+	void testForwardQueryWithLimit3 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(3) → 3 stored events (position 1 + 2 + 3) → 3 upcasted events (2 from split + 0 filtered + 1 renamed)
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().limit(3)).toList();
+
+		assertEquals(3, events.size());
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(1).data().getClass());
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(2).data().getClass());
+	}
+
+	@Test
+	void testForwardQueryWithLimit4 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(4) → all 4 stored events → 4 upcasted events
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().limit(4)).toList();
+
+		assertEquals(4, events.size());
+		assertEquals(CurrentEvent.CustomerRegistered.class, events.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, events.get(1).data().getClass());
+		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(2).data().getClass());
+		assertEquals(CurrentEvent.CustomerChurned.class, events.get(3).data().getClass());
+	}
+
+	@Test
+	void testForwardQueryWithLimit5 ( ) {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// limit(5) → exceeds the 4 stored events, same result as limit(4)
+		List<Event<CurrentEvent>> events = stream.query(EventQuery.matchAll().limit(5)).toList();
+
+		assertEquals(4, events.size());
 	}
 
 	@Test

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
@@ -79,8 +79,6 @@ public class UpcastMultiTest {
 		record CustomerLegacyAuditLog ( String message ) implements OriginalEvent { }
 		/** A simple rename upcast (1-to-1) */
 		record CustomerNameChanged ( String name ) implements OriginalEvent { }
-		/** An event that stays as-is (no upcast needed) */
-		record CustomerChurned ( ) implements OriginalEvent { }
 	}
 
 	// =========================================================================
@@ -182,12 +180,14 @@ public class UpcastMultiTest {
 			new OriginalEvent.CustomerNameChanged("Jane"),
 			Tags.of("customer", "1")));
 
-		// Position 4: not upcasted, stays as-is
-		originalStream.append(AppendCriteria.none(), Event.of(
-			new OriginalEvent.CustomerChurned(),
+		EventStream<CurrentEvent> stream = eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+
+		// Position 4: a real current event, not upcasted — creates a mix of legacy and current events
+		stream.append(AppendCriteria.none(), Event.of(
+			new CurrentEvent.CustomerChurned(),
 			Tags.of("customer", "1")));
 
-		return eventStore.getEventStream(streamId, CurrentEvent.class, LegacyEvents.class);
+		return stream;
 	}
 
 
@@ -217,7 +217,7 @@ public class UpcastMultiTest {
 		assertEquals(CurrentEvent.CustomerRenamed.class, events.get(2).data().getClass());
 		assertEquals("Jane", ((CurrentEvent.CustomerRenamed) events.get(2).data()).name());
 
-		// Fourth: CustomerChurned (no upcast)
+		// Fourth: CustomerChurned (current event, not upcasted)
 		assertEquals(CurrentEvent.CustomerChurned.class, events.get(3).data().getClass());
 	}
 
@@ -412,10 +412,10 @@ public class UpcastMultiTest {
 	}
 
 	@Test
-	void testGetEventByIdForNonUpcastedEvent ( ) {
+	void testGetEventByIdForCurrentEvent ( ) {
 		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
 
-		// Find the CustomerChurned event (not upcasted)
+		// Find the CustomerChurned event (appended as a current event, not upcasted)
 		Event<CurrentEvent> churnedEvent = stream.query(EventQuery.matchAll()).toList().stream()
 			.filter(e -> e.data() instanceof CurrentEvent.CustomerChurned)
 			.findFirst().orElseThrow();

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastMultiTest.java
@@ -118,24 +118,13 @@ public class UpcastMultiTest {
 	public static class SplitRegistrationUpcaster implements Upcast<LegacyEvents.CustomerRegisteredWithAddress, CurrentEvent> {
 
 		@Override
-		public CurrentEvent upcast ( LegacyEvents.CustomerRegisteredWithAddress historicalEvent ) {
-			throw new UnsupportedOperationException("should use upcastAll");
-		}
-
-		@Override
-		public List<CurrentEvent> upcastAll ( LegacyEvents.CustomerRegisteredWithAddress historicalEvent ) {
+		public List<CurrentEvent> upcast ( LegacyEvents.CustomerRegisteredWithAddress historicalEvent ) {
 			return List.of(
 				new CurrentEvent.CustomerRegistered(historicalEvent.name()),
 				new CurrentEvent.AddressRecorded(historicalEvent.street(), historicalEvent.city())
 			);
 		}
 
-		@Override
-		public Class<CurrentEvent> targetType ( ) {
-			return CurrentEvent.class; // not used directly, targetTypes() is overridden
-		}
-
-		@SuppressWarnings("unchecked")
 		@Override
 		public Set<Class<? extends CurrentEvent>> targetTypes ( ) {
 			return Set.of(CurrentEvent.CustomerRegistered.class, CurrentEvent.AddressRecorded.class);
@@ -146,21 +135,10 @@ public class UpcastMultiTest {
 	public static class FilterAuditLogUpcaster implements Upcast<LegacyEvents.CustomerLegacyAuditLog, CurrentEvent> {
 
 		@Override
-		public CurrentEvent upcast ( LegacyEvents.CustomerLegacyAuditLog historicalEvent ) {
-			throw new UnsupportedOperationException("should use upcastAll");
-		}
-
-		@Override
-		public List<CurrentEvent> upcastAll ( LegacyEvents.CustomerLegacyAuditLog historicalEvent ) {
+		public List<CurrentEvent> upcast ( LegacyEvents.CustomerLegacyAuditLog historicalEvent ) {
 			return List.of(); // filtered out
 		}
 
-		@Override
-		public Class<CurrentEvent> targetType ( ) {
-			return CurrentEvent.class;
-		}
-
-		@SuppressWarnings("unchecked")
 		@Override
 		public Set<Class<? extends CurrentEvent>> targetTypes ( ) {
 			return Set.of(); // produces no target types
@@ -171,13 +149,13 @@ public class UpcastMultiTest {
 	public static class RenameNameChangedUpcaster implements Upcast<LegacyEvents.CustomerNameChanged, CurrentEvent.CustomerRenamed> {
 
 		@Override
-		public CurrentEvent.CustomerRenamed upcast ( LegacyEvents.CustomerNameChanged historicalEvent ) {
-			return new CurrentEvent.CustomerRenamed(historicalEvent.name());
+		public List<CurrentEvent.CustomerRenamed> upcast ( LegacyEvents.CustomerNameChanged historicalEvent ) {
+			return List.of(new CurrentEvent.CustomerRenamed(historicalEvent.name()));
 		}
 
 		@Override
-		public Class<CurrentEvent.CustomerRenamed> targetType ( ) {
-			return CurrentEvent.CustomerRenamed.class;
+		public Set<Class<? extends CurrentEvent.CustomerRenamed>> targetTypes ( ) {
+			return Set.of(CurrentEvent.CustomerRenamed.class);
 		}
 	}
 

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/UpcastTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,31 +242,30 @@ public class UpcastTest {
 	public static class CustomerRegisteredUpcaster implements Upcast<CustomerHistoricalEvent.CustomerRegistered, CustomerEvent.CustomerRegisteredV2> {
 
 		@Override
-		public CustomerEvent.CustomerRegisteredV2 upcast(CustomerHistoricalEvent.CustomerRegistered historicalEvent) {
+		public List<CustomerEvent.CustomerRegisteredV2> upcast(CustomerHistoricalEvent.CustomerRegistered historicalEvent) {
 			// using the constructor, not the "of" utility method to allow historical values that don't adhere to the new length business rules
-			return new CustomerEvent.CustomerRegisteredV2(new CustomerEvent.Name(historicalEvent.name()));
+			return List.of(new CustomerEvent.CustomerRegisteredV2(new CustomerEvent.Name(historicalEvent.name())));
 		}
 
 		@Override
-		public Class<CustomerRegisteredV2> targetType() {
-			return CustomerRegisteredV2.class;
+		public Set<Class<? extends CustomerRegisteredV2>> targetTypes() {
+			return Set.of(CustomerRegisteredV2.class);
 		}
-		
+
 	}
-	
+
 	public static class CustomerNameChangedUpcaster implements Upcast<CustomerHistoricalEvent.CustomerNameChanged, CustomerEvent.CustomerRenamed> {
 
 		@Override
-		public CustomerEvent.CustomerRenamed upcast(CustomerHistoricalEvent.CustomerNameChanged historicalEvent) {
+		public List<CustomerEvent.CustomerRenamed> upcast(CustomerHistoricalEvent.CustomerNameChanged historicalEvent) {
 			// using the constructor, not the "of" utility method to allow historical values that don't adhere to the new length business rules
-			return new CustomerEvent.CustomerRenamed(new CustomerEvent.Name(historicalEvent.name()));
+			return List.of(new CustomerEvent.CustomerRenamed(new CustomerEvent.Name(historicalEvent.name())));
 		}
-		
+
 		@Override
-		public Class<CustomerRenamed> targetType() {
-			return CustomerRenamed.class;
+		public Set<Class<? extends CustomerRenamed>> targetTypes() {
+			return Set.of(CustomerRenamed.class);
 		}
-		
 
 	}
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for multi-event upcasting in the event store, allowing a single historical event to be transformed into zero, one, or multiple current events. It introduces an `index` field to `EventReference` to distinguish between events that originate from the same stored event through upcasting.

## Key Changes

### Core API Updates
- **EventReference**: Added `index` field (int) to distinguish multiple events from the same stored event. Events are now ordered by (tx, position, index) tuple. Includes new factory methods `EventReference.of()` and `withIndex()`.
- **Upcast Interface**: Changed return type from single event to `List<T>` to support:
  - **Upcast-to-many**: One legacy event splits into multiple current events (e.g., CustomerRegisteredWithAddress → CustomerRegistered + AddressRecorded)
  - **Upcast-to-one**: Traditional 1-to-1 transformation (wrapped in a List)
  - **Upcast-to-zero**: Obsolete events filtered out by returning empty list
- **EventPayloadSerializerDeserializer**: Added `deserializeMulti()` method to handle multi-event deserialization

### Implementation Details
- **TypedEventPayloadSerializerDeserializer**: Updated to support multi-event upcasting with proper type mapping and error handling
- **EventStoreImpl**: Modified query pipeline to flatten multi-event results from upcasting while preserving original filter semantics
- **EventSource.getEventById()**: Changed return type from `Optional<Event>` to `List<Event>` to support retrieving all sub-events from a split event

### Testing
- **UpcastMultiTest**: Comprehensive test suite (594 lines) covering:
  - Forward and backward queries with split/filtered/renamed events
  - Index verification and ordering via `happenedBefore()`
  - `getEventById()` for split, filtered, and current events
  - Multiple split events in sequence
  - Type preservation (storedType vs type)
  - Event filtering invisibility in queries
- **PostgresUpcastMultiTest**: Postgres-specific test variant
- Updated existing tests (UpcastTest, EventStreamTest, ProjectorTest) to use new APIs

### Documentation
- Updated `Upcast` interface JavaDoc with examples for all three upcasting patterns
- Updated `EventReference` JavaDoc to explain index field and ordering semantics
- Updated `LegacyEvent` annotation documentation

## Notable Implementation Details
- Split events maintain the same EventId, position, and tx but have distinct indices (0, 1, 2, ...)
- Backward queries correctly reverse the order of split events while maintaining their relative ordering
- Filtered events (upcast-to-zero) are completely invisible in query results
- Original event type is preserved in `storedType()` while `type()` reflects the upcasted type

https://claude.ai/code/session_01HXu241N9hKis9dkSHXqn2S