### PR TITLE
Skip final empty query when stored events count < batch limit

### DIFF
--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -18,6 +18,7 @@
 package org.sliceworkz.eventstore.projection;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
@@ -327,8 +328,12 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 					queriesDone++;
 
 					AtomicReference<EventReference> rawCursor = new AtomicReference<>();
+					AtomicLong storedEventsCount = new AtomicLong(0);
 
-					lastRead = es.query(effectiveQuery, lastRead, limit, rawCursor::set).map(e->offerEventToProjection(e, projection, until, batch)).map(e->e.reference()).reduce((first, second) -> second).orElse(null);
+					lastRead = es.query(effectiveQuery, lastRead, limit, ref -> {
+						rawCursor.set(ref);
+						storedEventsCount.incrementAndGet();
+					}).map(e->offerEventToProjection(e, projection, until, batch)).map(e->e.reference()).reduce((first, second) -> second).orElse(null);
 
 					// if we still read enriched data, keep the reference
 					if ( lastRead != null ) {
@@ -342,6 +347,12 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 						// Do NOT set done — there may be more events beyond the vanished batch.
 					} else {
 						// No stored events returned at all — we are truly at end of stream.
+						done = true;
+					}
+
+					// If storage returned fewer events than the batch limit, we've exhausted the stream —
+					// no need for another query that would return zero results.
+					if ( !done && limit.isSet() && storedEventsCount.get() < limit.value() ) {
 						done = true;
 					}
 				} catch ( Throwable t ) {

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/projection/ProjectorTest.java
@@ -71,24 +71,24 @@ public class ProjectorTest extends AbstractEventStoreTest {
 
 		ProjectorMetrics projectorMetrics = projector.run();
 		assertEquals(4, projection.counter()); // SecondDomainEvent type is left out by the query
-		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1, projectorMetrics.queriesDone()); // 1 batch, stored events < batch limit so no extra query needed
 		assertEquals(4,  projectorMetrics.eventsStreamed());
 		assertEquals(4,  projectorMetrics.eventsHandled());
 
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(1, accumulatedMetrics.queriesDone());
 		assertEquals(4,  accumulatedMetrics.eventsStreamed());
 		assertEquals(4,  accumulatedMetrics.eventsHandled());
 
 
-		BatchAwareTestProjection batchAwareProjection = new BatchAwareTestProjection();	
+		BatchAwareTestProjection batchAwareProjection = new BatchAwareTestProjection();
 		var batchAwareProjector = Projector.from(es).towards(batchAwareProjection).build();
 
 		projectorMetrics = batchAwareProjector.run();
 		assertEquals(4, batchAwareProjection.counter()); // SecondDomainEvent type is left out by the query
 		assertEquals(1, batchAwareProjection.beforeTriggered()); // single batch
 		assertEquals(1, batchAwareProjection.afterTriggered());  // equal amount expected
-		assertEquals(0, batchAwareProjection.cancelTriggered());  
+		assertEquals(0, batchAwareProjection.cancelTriggered());
 	}
 	
 	@Test
@@ -513,12 +513,12 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		
 		ProjectorMetrics projectorMetrics = projector.runUntil(ref);
 		assertEquals(3, projection.counter()); // SecondDomainEvent type is left out by the query, until removes everything after four
-		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1, projectorMetrics.queriesDone()); // 1 batch, stored events < batch limit so no extra query needed
 		assertEquals(3,  projectorMetrics.eventsStreamed()); // since we pass in until, we don't stream the extra events
 		assertEquals(3,  projectorMetrics.eventsHandled());
 
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(1, accumulatedMetrics.queriesDone());
 		assertEquals(3,  accumulatedMetrics.eventsStreamed());
 		assertEquals(3,  accumulatedMetrics.eventsHandled());
 	}
@@ -533,15 +533,15 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		append(alternativeStream, new FirstDomainEvent("1"), Tags.of("nr", "one"));
 
 		var projector = Projector.from(alternativeStream).towards(projection).build();
-		
+
 		ProjectorMetrics projectorMetrics = projector.run();
 		assertEquals(1, projection.counter());
-		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1, projectorMetrics.queriesDone()); // 1 batch, stored events < batch limit so no extra query needed
 		assertEquals(1,  projectorMetrics.eventsStreamed());
 		assertEquals(1,  projectorMetrics.eventsHandled());
 
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(1, accumulatedMetrics.queriesDone());
 		assertEquals(1,  accumulatedMetrics.eventsStreamed());
 		assertEquals(1,  accumulatedMetrics.eventsHandled());
 
@@ -549,12 +549,12 @@ public class ProjectorTest extends AbstractEventStoreTest {
 
 		projectorMetrics = projector.run();
 		assertEquals(2, projection.counter()); // second event now also processed by projection
-		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1, projectorMetrics.queriesDone()); // 1 batch, stored events < batch limit so no extra query needed
 		assertEquals(1,  projectorMetrics.eventsStreamed());
 		assertEquals(1,  projectorMetrics.eventsHandled());
 
 		accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(4, accumulatedMetrics.queriesDone());
+		assertEquals(2, accumulatedMetrics.queriesDone());
 		assertEquals(2,  accumulatedMetrics.eventsStreamed());
 		assertEquals(2,  accumulatedMetrics.eventsHandled());
 	}
@@ -570,12 +570,12 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		
 		ProjectorMetrics projectorMetrics = projector.runUntil(refUntil);
 		assertEquals(2, projection.counter()); // SecondDomainEvent type is left out by the query, until removes everything after four
-		assertEquals(2, projectorMetrics.queriesDone()); // 1 batch + 1 empty end-of-stream confirmation
+		assertEquals(1, projectorMetrics.queriesDone()); // 1 batch, stored events < batch limit so no extra query needed
 		assertEquals(2,  projectorMetrics.eventsStreamed()); // since we pass "until", we don't stream the extra events
 		assertEquals(2,  projectorMetrics.eventsHandled());
 
 		ProjectorMetrics accumulatedMetrics = projector.accumulatedMetrics();
-		assertEquals(2, accumulatedMetrics.queriesDone());
+		assertEquals(1, accumulatedMetrics.queriesDone());
 		assertEquals(2,  accumulatedMetrics.eventsStreamed());
 		assertEquals(2,  accumulatedMetrics.eventsHandled());
 	}
@@ -603,7 +603,7 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		// initQuery finds the savepoint (ThirdDomainEvent), then eventQuery processes the 2 FirstDomainEvents after it
 		assertEquals(3, projection.counter()); // 1 from initQuery + 2 from eventQuery
 		assertEquals("savepoint:15", projection.lastSavepoint()); // savepoint was processed
-		assertEquals(3, metrics.queriesDone()); // 1 for initQuery + 1 eventQuery batch + 1 empty end-of-stream confirmation
+		assertEquals(2, metrics.queriesDone()); // 1 for initQuery + 1 eventQuery batch (stored events < batch limit, no extra query needed)
 		assertEquals(3, metrics.eventsHandled()); // 1 savepoint + 2 movements
 	}
 
@@ -625,7 +625,7 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		// No savepoint found, so all FirstDomainEvents are processed by the main eventQuery
 		assertEquals(3, projection.counter());
 		assertNull(projection.lastSavepoint()); // no savepoint was found
-		assertEquals(3, metrics.queriesDone()); // 1 for initQuery (empty) + 1 eventQuery batch + 1 empty end-of-stream confirmation
+		assertEquals(2, metrics.queriesDone()); // 1 for initQuery (empty) + 1 eventQuery batch (stored events < batch limit, no extra query needed)
 		assertEquals(3, metrics.eventsHandled());
 	}
 
@@ -651,7 +651,7 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		// With bookmarking, initQuery is ignored — all FirstDomainEvents are processed from the start
 		assertEquals(4, projection.counter()); // all 4 FirstDomainEvents (Third is excluded by eventQuery)
 		assertNull(projection.lastSavepoint()); // savepoint was NOT processed (initQuery skipped, Third not in eventQuery)
-		assertEquals(2, metrics.queriesDone()); // no initQuery, 1 eventQuery batch + 1 empty end-of-stream confirmation
+		assertEquals(1, metrics.queriesDone()); // no initQuery, 1 eventQuery batch (stored events < batch limit, no extra query needed)
 		assertEquals(4, metrics.eventsHandled());
 	}
 


### PR DESCRIPTION
Track the number of stored events returned per batch via the existing
storedEventCursorTracker callback. When storage returns fewer events
than the batch limit, we know the stream is exhausted and can exit the
loop immediately — avoiding one redundant query that would return zero
results.

This saves one query per Projector.run() execution in the common case
where all events fit within a single batch (i.e. total events < default
batch size of 500).

https://claude.ai/code/session_01RHAdV8PcwjpjcnXNhF2EYj