### PR TITLE
Implement RFC 9562 UUIDv7 for time-ordered event IDs

### DIFF
--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventId.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventId.java
@@ -17,26 +17,27 @@
  */
 package org.sliceworkz.eventstore.events;
 
-import java.util.UUID;
-
 /**
  * Unique identifier for an event.
  * <p>
- * Each event in the store has a globally unique ID, typically a UUID. The EventId is part of
+ * Each event in the store has a globally unique ID, generated as a UUIDv7. The EventId is part of
  * the {@link EventReference} which combines the ID with the event's position in its stream.
  * <p>
  * Event IDs are immutable and are automatically generated when events are appended to a stream.
+ * Since version 0.8.0, IDs are generated using {@link UUIDv7} (time-ordered) instead of random UUID v4,
+ * which improves B-tree index performance for append-only workloads.
  *
  * <h2>Example Usage:</h2>
  * <pre>{@code
  * // Typically generated automatically when appending
- * EventId id = EventId.create();  // Generates a new UUID
+ * EventId id = EventId.create();  // Generates a new UUIDv7
  *
  * // Or create from existing ID string
  * EventId id = EventId.of("550e8400-e29b-41d4-a716-446655440000");
  * }</pre>
  *
  * @param value the unique identifier string (typically a UUID)
+ * @see UUIDv7
  * @see EventReference
  * @see Event
  */
@@ -60,14 +61,16 @@ public record EventId ( String value ) {
 	}
 
 	/**
-	 * Generates a new random EventId using a UUID.
+	 * Generates a new EventId using a UUIDv7 (time-ordered).
 	 * <p>
 	 * This is typically used internally when appending events to generate unique identifiers.
+	 * UUIDv7 provides monotonically increasing IDs that improve B-tree index locality.
 	 *
-	 * @return a new EventId with a randomly generated UUID as its value
+	 * @return a new EventId with a UUIDv7 as its value
+	 * @see UUIDv7#generate()
 	 */
 	public static EventId create ( ) {
-		return new EventId ( UUID.randomUUID().toString() );
+		return new EventId ( UUIDv7.generateString() );
 	}
 
 	/**

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/UUIDv7.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/UUIDv7.java
@@ -1,0 +1,118 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.events;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Generator for RFC 9562 UUIDv7 identifiers.
+ * <p>
+ * UUIDv7 encodes a Unix epoch millisecond timestamp in the most significant 48 bits,
+ * making generated IDs monotonically increasing over time. This yields better B-tree index
+ * locality compared to random UUID v4, which is especially beneficial for append-only
+ * workloads like event stores.
+ * <p>
+ * The remaining bits are filled with cryptographically secure random data, ensuring
+ * global uniqueness without coordination.
+ *
+ * <h2>Layout (128 bits):</h2>
+ * <pre>
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                       unix_ts_ms (32 high)                    |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |   unix_ts_ms (16 low) | ver=7 |        rand_a (12 bits)      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |var=10|              rand_b (62 bits)                          |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                       rand_b (continued)                      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * </pre>
+ *
+ * <h2>Usage:</h2>
+ * <pre>{@code
+ * // Generate a new UUIDv7
+ * UUID id = UUIDv7.generate();
+ *
+ * // As a string
+ * String idStr = UUIDv7.generateString();
+ *
+ * // Extract the embedded timestamp
+ * Instant ts = UUIDv7.extractTimestamp(id);
+ * }</pre>
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9562#section-5.7">RFC 9562 Section 5.7</a>
+ */
+public final class UUIDv7 {
+
+	private static final SecureRandom RANDOM = new SecureRandom();
+
+	private UUIDv7 ( ) { }
+
+	/**
+	 * Generates a new UUIDv7.
+	 *
+	 * @return a new time-ordered UUID
+	 */
+	public static UUID generate ( ) {
+
+		long timestamp = System.currentTimeMillis();
+
+		// Random bits for rand_a (12 bits) and rand_b (62 bits)
+		long randomHigh = RANDOM.nextLong();
+		long randomLow = RANDOM.nextLong();
+
+		// MSB: 48 bits timestamp | 4 bits version (0111) | 12 bits rand_a
+		long msb = ( timestamp << 16 )                  // shift timestamp to top 48 bits
+				| ( 0x7L << 12 )                        // version 7
+				| ( randomHigh & 0x0FFFL );             // 12 bits of randomness
+
+		// LSB: 2 bits variant (10) | 62 bits rand_b
+		long lsb = ( 0b10L << 62 )                     // variant bits
+				| ( randomLow & 0x3FFFFFFFFFFFFFFFL );  // 62 bits of randomness
+
+		return new UUID ( msb, lsb );
+	}
+
+	/**
+	 * Generates a new UUIDv7 as a string.
+	 *
+	 * @return the canonical string representation of a new time-ordered UUID
+	 */
+	public static String generateString ( ) {
+		return generate().toString();
+	}
+
+	/**
+	 * Extracts the embedded Unix epoch millisecond timestamp from a UUIDv7.
+	 * <p>
+	 * This is useful for debugging and operational tooling — you can determine approximately
+	 * when an event was created just from its ID.
+	 *
+	 * @param uuid a UUIDv7 (behavior is undefined for non-v7 UUIDs)
+	 * @return the {@link Instant} embedded in the UUID
+	 */
+	public static Instant extractTimestamp ( UUID uuid ) {
+		long millis = uuid.getMostSignificantBits() >>> 16;
+		return Instant.ofEpochMilli ( millis );
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/UUIDv7Test.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/UUIDv7Test.java
@@ -1,0 +1,95 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+public class UUIDv7Test {
+
+	@Test
+	void shouldGenerateValidUUIDv7WithVersion7 ( ) {
+		UUID uuid = UUIDv7.generate();
+		assertEquals ( 7, uuid.version(), "UUID version should be 7" );
+	}
+
+	@Test
+	void shouldGenerateValidUUIDv7WithVariant2 ( ) {
+		UUID uuid = UUIDv7.generate();
+		assertEquals ( 2, uuid.variant(), "UUID variant should be 2 (RFC 4122)" );
+	}
+
+	@Test
+	void shouldGenerateUniqueIds ( ) {
+		Set<UUID> ids = new HashSet<>();
+		for ( int i = 0; i < 10_000; i++ ) {
+			ids.add ( UUIDv7.generate() );
+		}
+		assertEquals ( 10_000, ids.size(), "All generated UUIDs should be unique" );
+	}
+
+	@Test
+	void shouldBeMonotonicallyIncreasingOverTime ( ) throws InterruptedException {
+		UUID first = UUIDv7.generate();
+		Thread.sleep ( 2 );
+		UUID second = UUIDv7.generate();
+
+		// UUIDv7 with later timestamp should compare greater (unsigned MSB comparison)
+		assertTrue (
+			first.getMostSignificantBits() < second.getMostSignificantBits(),
+			"UUIDv7 generated later should have a greater MSB (time-ordered)"
+		);
+	}
+
+	@Test
+	void shouldEmbedTimestampWithinTolerance ( ) {
+		Instant before = Instant.now();
+		UUID uuid = UUIDv7.generate();
+		Instant after = Instant.now();
+
+		Instant extracted = UUIDv7.extractTimestamp ( uuid );
+
+		assertTrue (
+			! extracted.isBefore ( before.minusMillis ( 1 ) ) && ! extracted.isAfter ( after.plusMillis ( 1 ) ),
+			"Extracted timestamp should be within tolerance of generation time"
+		);
+	}
+
+	@Test
+	void shouldProduceValidStringRepresentation ( ) {
+		String uuidStr = UUIDv7.generateString();
+		UUID parsed = UUID.fromString ( uuidStr );
+		assertEquals ( 7, parsed.version() );
+		assertEquals ( 2, parsed.variant() );
+	}
+
+	@Test
+	void eventIdCreateShouldUseUUIDv7 ( ) {
+		EventId eventId = EventId.create();
+		UUID parsed = UUID.fromString ( eventId.value() );
+		assertEquals ( 7, parsed.version(), "EventId.create() should generate UUIDv7" );
+	}
+
+}


### PR DESCRIPTION
## Summary
Replace random UUID v4 generation with RFC 9562 UUIDv7 for event IDs to improve B-tree index performance in append-only event store workloads. UUIDv7 encodes a Unix epoch millisecond timestamp in the most significant 48 bits, making generated IDs monotonically increasing over time while maintaining cryptographic uniqueness.

## Changes
- **New `UUIDv7` class**: Implements RFC 9562 UUIDv7 generation with:
  - `generate()` - creates a new time-ordered UUID
  - `generateString()` - returns the string representation
  - `extractTimestamp(UUID)` - extracts the embedded timestamp for debugging/tooling
  - Comprehensive JavaDoc with bit layout diagram and usage examples

- **Updated `EventId.create()`**: Changed from `UUID.randomUUID()` to `UUIDv7.generateString()` to use time-ordered IDs by default

- **Updated documentation**: 
  - `EventId` class documentation now references UUIDv7 and explains the performance benefits
  - Added version note (0.8.0) indicating when this change was introduced

- **Comprehensive test coverage** (`UUIDv7Test`):
  - Validates RFC 4122 compliance (version 7, variant 2)
  - Verifies uniqueness across 10,000 generated IDs
  - Confirms monotonic ordering over time
  - Tests timestamp extraction accuracy
  - Validates string representation round-tripping
  - Integration test with `EventId.create()`

## Implementation Details
- Uses `SecureRandom` for cryptographically secure random bits
- Timestamp occupies the top 48 bits (millisecond precision)
- Version field (4 bits) set to 0111 (7)
- 12 bits of random data in the high portion
- Variant bits (10) and 62 bits of random data in the low portion
- Maintains backward compatibility with UUID string format

https://claude.ai/code/session_01AmKQvAsiDYwFKBdKyqu5h9