### PR TITLE
Remove unused queryFrom and simplify query methods

### DIFF
--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -78,11 +78,11 @@ import org.sliceworkz.eventstore.stream.EventStreamId;
  *
  *     @Override
  *     public Stream<StoredEvent> query(EventQuery query, Optional<EventStreamId> stream,
- *                                      EventReference from, Limit limit, QueryDirection direction) {
+ *                                      EventReference after, Limit limit, QueryDirection direction) {
  *         // 1. Filter events by stream (if specified)
  *         // 2. Apply event type filters from query
  *         // 3. Apply tag filters from query
- *         // 4. Filter events after 'from' reference
+ *         // 4. Filter events after 'after' reference
  *         // 5. Apply limit and direction
  *         // 6. Return stream of StoredEvent records
  *     }
@@ -144,7 +144,7 @@ public interface EventStorage {
 	 * <ul>
 	 *   <li><b>query</b> - Defines which events to retrieve based on types and tags</li>
 	 *   <li><b>stream</b> - Optional stream filter; if present, only events from matching streams are returned</li>
-	 *   <li><b>from</b> - Starting reference point; events after this reference are returned</li>
+	 *   <li><b>after</b> - Starting reference point; events after this reference are returned</li>
 	 *   <li><b>limit</b> - Maximum number of events to return (or unlimited)</li>
 	 *   <li><b>queryDirection</b> - Direction of traversal (FORWARD or BACKWARD)</li>
 	 * </ul>
@@ -157,7 +157,7 @@ public interface EventStorage {
 	 *
 	 * @param query the event query defining type and tag filters
 	 * @param stream optional stream identifier to filter events by stream
-	 * @param from the reference point to start querying from (events after this reference)
+	 * @param after the reference point to start querying after (exclusive - events after this reference)
 	 * @param limit maximum number of events to return
 	 * @param queryDirection the direction of query traversal (FORWARD or BACKWARD)
 	 * @return a stream of stored events matching the query criteria
@@ -166,7 +166,7 @@ public interface EventStorage {
 	 * @see QueryDirection
 	 * @see StoredEvent
 	 */
-	Stream<StoredEvent> query ( EventQuery query, Optional<EventStreamId> stream, EventReference from, Limit limit, QueryDirection queryDirection );
+	Stream<StoredEvent> query ( EventQuery query, Optional<EventStreamId> stream, EventReference after, Limit limit, QueryDirection queryDirection );
 
 	/**
 	 * Queries events from storage in forward (chronological) direction.

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -161,87 +161,22 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 */
 	@Override
 	public synchronized Stream<StoredEvent> query(EventQuery query, Optional<EventStreamId> stream, EventReference after, Limit limit, QueryDirection direction ) {
-		return queryAfter(query, stream, after, limit, direction);
-	}
-
-	/**
-	 * Queries events starting from (and including) the specified reference.
-	 * <p>
-	 * This is a convenience method that delegates to {@link #queryFromOrAfter(EventQuery, Optional, Limit, EventReference, boolean, QueryDirection)}
-	 * with includeReference set to true.
-	 *
-	 * @param query the event query specifying which events to retrieve
-	 * @param streamId optional stream ID to filter events
-	 * @param from the reference to start from (inclusive)
-	 * @param limit soft limit on the number of results
-	 * @param direction the direction to traverse the event log
-	 * @return a Stream of StoredEvent instances matching the criteria
-	 */
-	public synchronized Stream<StoredEvent> queryFrom (EventQuery query, Optional<EventStreamId> streamId, EventReference from, Limit limit, QueryDirection direction ) {
-		return queryFromOrAfter(query, streamId, limit, from, true, direction);
-	}
-
-	/**
-	 * Queries events starting after (excluding) the specified reference.
-	 * <p>
-	 * This is a convenience method that delegates to {@link #queryFromOrAfter(EventQuery, Optional, Limit, EventReference, boolean, QueryDirection)}
-	 * with includeReference set to false.
-	 *
-	 * @param query the event query specifying which events to retrieve
-	 * @param streamId optional stream ID to filter events
-	 * @param after the reference to start after (exclusive)
-	 * @param limit soft limit on the number of results
-	 * @param direction the direction to traverse the event log
-	 * @return a Stream of StoredEvent instances matching the criteria
-	 */
-	public synchronized Stream<StoredEvent> queryAfter (EventQuery query, Optional<EventStreamId> streamId, EventReference after, Limit limit, QueryDirection direction ) {
-		return queryFromOrAfter(query, streamId, limit, after, false, direction);
-	}
-
-	/**
-	 * Core query method supporting both inclusive and exclusive reference-based queries.
-	 * <p>
-	 * This method provides the underlying implementation for both {@link #queryFrom(EventQuery, Optional, EventReference, Limit, QueryDirection)}
-	 * and {@link #queryAfter(EventQuery, Optional, EventReference, Limit, QueryDirection)} by allowing control over whether
-	 * the reference event itself is included in the results.
-	 * <p>
-	 * The method handles:
-	 * <ul>
-	 *   <li>Bidirectional traversal (forward/backward) of the event log</li>
-	 *   <li>Position-based skipping to start from the correct event</li>
-	 *   <li>Stream filtering based on the provided stream ID</li>
-	 *   <li>Event matching based on the query criteria</li>
-	 *   <li>Enforcement of both soft and absolute limits</li>
-	 * </ul>
-	 *
-	 * @param query the event query specifying which events to retrieve
-	 * @param streamId optional stream ID to filter events
-	 * @param limit soft limit on the number of results
-	 * @param reference the reference event to position from, or null to start from the beginning
-	 * @param includeReference true to include the reference event in results, false to start after it
-	 * @param direction the direction to traverse the event log (FORWARD or BACKWARD)
-	 * @return a Stream of StoredEvent instances matching the criteria
-	 * @throws EventStorageException if the result exceeds the configured absolute limit
-	 * @see #queryFrom(EventQuery, Optional, EventReference, Limit, QueryDirection)
-	 * @see #queryAfter(EventQuery, Optional, EventReference, Limit, QueryDirection)
-	 */
-	public synchronized Stream<StoredEvent> queryFromOrAfter (EventQuery query, Optional<EventStreamId> streamId, Limit limit, EventReference reference, boolean includeReference, QueryDirection direction ) {
 		Stream<StoredEvent> on;
-		
+
 		switch ( direction ) {
 			case BACKWARD:
 				on = eventlog.reversed().stream();
 				break;
 			case FORWARD:
 			default:
-				on = eventlog.stream(); 
+				on = eventlog.stream();
 		}
-		
-		if ( reference != null ) {
+
+		if ( after != null ) {
 			if ( direction == QueryDirection.FORWARD ) {
-				on = on.skip(reference.position()-(includeReference?1:0));  // skip until the position in the stream, including the referenced/current one as first or not
+				on = on.skip(after.position());
 			} else {
-				on = on.skip(eventlog.size()-reference.position()+(includeReference?0:1));  // skip until the position in the stream, including the referenced/current one as first or not
+				on = on.skip(eventlog.size()-after.position()+1);
 			}
 		}
 		
@@ -295,7 +230,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 			// we query the stream with the event filter from the last event known as our reference
 			// we only need to fetch max 1 event to prove a locking issue
 			EventQuery lockingQuery = new EventQuery(appendCriteria.eventFilter(), EventQuery.Direction.FORWARD, Limit.none());
-			Stream<StoredEvent> newEventStream = queryAfter(lockingQuery, streamId, appendCriteria.expectedLastEventReference().orElse(null), Limit.to(1), QueryDirection.FORWARD);
+			Stream<StoredEvent> newEventStream = query(lockingQuery, streamId, appendCriteria.expectedLastEventReference().orElse(null), Limit.to(1), QueryDirection.FORWARD);
 
 			List<StoredEvent> newEvents = newEventStream.toList();
 

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -187,10 +187,10 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		
 		Stream<StoredEvent> result = on;
 
-		if ( streamId.isPresent() ) {
-			result = result.filter(e->streamId.get().canRead(e.stream()));
+		if ( stream.isPresent() ) {
+			result = result.filter(e->stream.get().canRead(e.stream()));
 		} else {
-			// no streamId specified, considering all streams present in the store
+			// no stream specified, considering all streams present in the store
 		}
 		
 		result = result.filter(query::matches);

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -525,55 +525,35 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 	@Override
 	public Stream<StoredEvent> query(EventQuery query, Optional<EventStreamId> stream, EventReference after, Limit limit, QueryDirection direction ) {
-		return queryAfter(query, stream, after, limit, direction);
-	}
-	
-	public Stream<StoredEvent> queryFrom(EventQuery query, Optional<EventStreamId> streamId, EventReference from, Limit limit, QueryDirection direction) {
-		return queryFromOrAfter(query, streamId, limit, from, true, direction);
-	}
-	
-	public Stream<StoredEvent> queryAfter(EventQuery query, Optional<EventStreamId> streamId, EventReference after, Limit limit, QueryDirection direction) {
-		return queryFromOrAfter(query, streamId, limit, after, false, direction);
-	}
-	
-	public Stream<StoredEvent> queryFromOrAfter(EventQuery query, Optional<EventStreamId> streamId, Limit limit, EventReference reference, boolean includeReference, QueryDirection direction ) {
 		// Handle the case where query matches none - return empty stream
 		if (query.isMatchNone()) {
 			return Stream.empty();
 		}
-		
+
 		StringBuilder sqlBuilder = new StringBuilder();
 		sqlBuilder.append(
 			"""
-				SELECT event_position, event_tx::text, event_id, stream_context, stream_purpose, event_type, event_timestamp, event_data, event_erasable_data, event_tags 
-				FROM %sevents 
-				WHERE event_tx < pg_snapshot_xmin(pg_current_snapshot()) 
+				SELECT event_position, event_tx::text, event_id, stream_context, stream_purpose, event_type, event_timestamp, event_data, event_erasable_data, event_tags
+				FROM %sevents
+				WHERE event_tx < pg_snapshot_xmin(pg_current_snapshot())
 			""".formatted(prefix)
 			);
 		// pg_snapshot_xmin(pg_current_snapshot()) makes sure we don't read data committed by transaction that were started
 		// after ones that are still running (race condition which would drop some events otherwise)
-		// great insight found in the blogpost by Oskar Dudycz (https://event-driven.io/en/ordering_in_postgres_outbox/)  
-		
+		// great insight found in the blogpost by Oskar Dudycz (https://event-driven.io/en/ordering_in_postgres_outbox/)
+
 		List<Object> parameters = new ArrayList<>();
-		
-		// Add position filtering if reference is provided
-		if (reference != null ) {
-			if (includeReference) {
-				if ( direction == QueryDirection.FORWARD ) {
-					sqlBuilder.append(" AND ((event_tx>?::xid8) OR (event_tx = ?::xid8 AND event_position >= ?))");
-				} else {
-					sqlBuilder.append(" AND ((event_tx<?::xid8) OR (event_tx = ?::xid8 AND event_position <= ?))");
-				}
+
+		// Add position filtering if reference is provided (exclusive - events after the reference)
+		if (after != null ) {
+			if ( direction == QueryDirection.FORWARD ) {
+				sqlBuilder.append(" AND ((event_tx>?::xid8) OR (event_tx = ?::xid8 AND event_position > ?))");
 			} else {
-				if ( direction == QueryDirection.FORWARD ) {
-					sqlBuilder.append(" AND ((event_tx>?::xid8) OR (event_tx = ?::xid8 AND event_position > ?))");
-				} else {
-					sqlBuilder.append(" AND ((event_tx<?::xid8) OR (event_tx = ?::xid8 AND event_position < ?))");
-				}
+				sqlBuilder.append(" AND ((event_tx<?::xid8) OR (event_tx = ?::xid8 AND event_position < ?))");
 			}
-			parameters.add(Long.toUnsignedString(reference.tx()));
-			parameters.add(Long.toUnsignedString(reference.tx()));
-			parameters.add(reference.position());
+			parameters.add(Long.toUnsignedString(after.tx()));
+			parameters.add(Long.toUnsignedString(after.tx()));
+			parameters.add(after.position());
 		}
 		
 		if ( query.until() != null ) {

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -566,14 +566,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 		
 		// Add stream filtering
-		if (streamId.isPresent()) {
-			if (!streamId.get().isAnyContext()) {
+		if (stream.isPresent()) {
+			if (!stream.get().isAnyContext()) {
 				sqlBuilder.append(" AND stream_context = ?");
-				parameters.add(streamId.get().context());
+				parameters.add(stream.get().context());
 			}
-			if (!streamId.get().isAnyPurpose()) {
+			if (!stream.get().isAnyPurpose()) {
 				sqlBuilder.append(" AND stream_purpose = ?");
-				parameters.add(streamId.get().purpose());
+				parameters.add(stream.get().purpose());
 			}
 		}
 		


### PR DESCRIPTION
## Summary

Cherry-pick of #51 (which was accidentally merged into main) onto develop.

- Removed unused `queryFrom`, `queryAfter` wrapper, and `queryFromOrAfter` dispatch method from both InMemory and Postgres implementations
- Inlined query logic directly into `query()`, removing the `includeReference` flag that was always `false`
- Renamed `from` → `after` parameter in `EventStorage` interface to match actual exclusive semantics
- Fixed `streamId` → `stream` variable references after inlining

https://claude.ai/code/session_01EL1VnTutGL4rm5cPDHjfum