### PR TITLE
Extract JSON serialization logic into dedicated codec classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
 		<module>sliceworkz-eventstore-api</module>
 		<module>sliceworkz-eventstore-impl</module>
 
+		<!-- serialization -->
+		<module>sliceworkz-eventstore-serialization-json</module>
+
 		<!-- examples -->
 		<module>sliceworkz-eventstore-examples</module>
 

--- a/sliceworkz-eventstore-bom/pom.xml
+++ b/sliceworkz-eventstore-bom/pom.xml
@@ -48,9 +48,14 @@
 			</dependency>		
 			<dependency>
 				<groupId>org.sliceworkz</groupId>
+				<artifactId>sliceworkz-eventstore-serialization-json</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.sliceworkz</groupId>
 				<artifactId>sliceworkz-eventstore-infra-inmem</artifactId>
 				<version>${project.version}</version>
-			</dependency>		
+			</dependency>
 			<dependency>
 				<groupId>org.sliceworkz</groupId>
 				<artifactId>sliceworkz-eventstore-infra-inmem-fs</artifactId>

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -20,37 +20,28 @@ package org.sliceworkz.eventstore.infra.inmem.fs;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
-import org.sliceworkz.eventstore.events.Tag;
 import org.sliceworkz.eventstore.events.Tags;
-import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.serialization.json.JsonBookmark;
+import org.sliceworkz.eventstore.serialization.json.JsonBookmarkCodec;
+import org.sliceworkz.eventstore.serialization.json.JsonEventCodec;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.spi.EventStorageException;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStreamId;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * In-memory event storage with filesystem persistence.
@@ -65,15 +56,14 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 	private final EventStorage delegate;
 	private final Path eventsDir;
 	private final Path bookmarksDir;
-	private final ObjectMapper objectMapper;
+	private final JsonEventCodec eventCodec;
+	private final JsonBookmarkCodec bookmarkCodec;
 
 	InMemoryFsEventStorageImpl ( Path baseDirectory, String name, Limit limit ) {
 		this.eventsDir = baseDirectory.resolve("events");
 		this.bookmarksDir = baseDirectory.resolve("bookmarks");
-		this.objectMapper = new ObjectMapper();
-		this.objectMapper.registerModule(new JavaTimeModule());
-		this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-		this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		this.eventCodec = new JsonEventCodec();
+		this.bookmarkCodec = new JsonBookmarkCodec();
 
 		createDirectories();
 
@@ -151,47 +141,9 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 
 	private void persistEvent ( StoredEvent event ) {
 		try {
-			ObjectNode node = objectMapper.createObjectNode();
-
-			ObjectNode streamNode = objectMapper.createObjectNode();
-			streamNode.put("context", event.stream().context());
-			streamNode.put("purpose", event.stream().purpose());
-			node.set("stream", streamNode);
-
-			node.put("type", event.type().name());
-
-			ObjectNode refNode = objectMapper.createObjectNode();
-			refNode.put("id", event.reference().id().value());
-			refNode.put("position", event.reference().position());
-			refNode.put("tx", event.reference().tx());
-			refNode.put("index", event.reference().index());
-			node.set("reference", refNode);
-
-			if ( event.immutableData() != null ) {
-				node.set("immutableData", objectMapper.readTree(event.immutableData()));
-			} else {
-				node.putNull("immutableData");
-			}
-			if ( event.erasableData() != null ) {
-				node.set("erasableData", objectMapper.readTree(event.erasableData()));
-			} else {
-				node.putNull("erasableData");
-			}
-
-			ArrayNode tagsArray = objectMapper.createArrayNode();
-			for ( Tag tag : event.tags().tags() ) {
-				ObjectNode tagNode = objectMapper.createObjectNode();
-				tagNode.put("key", tag.key());
-				tagNode.put("value", tag.value());
-				tagsArray.add(tagNode);
-			}
-			node.set("tags", tagsArray);
-
-			node.put("timestamp", event.timestamp().toString());
-
 			String fileName = "%010d-%05d-%d-%s.json".formatted(event.reference().tx(), event.reference().position(), event.reference().index(), TIMESTAMP_FORMAT.format(event.timestamp()));
 			Path filePath = eventsDir.resolve(fileName);
-			Files.writeString(filePath, objectMapper.writeValueAsString(node));
+			Files.writeString(filePath, eventCodec.write(event));
 		} catch ( IOException e ) {
 			throw new EventStorageException("failed to persist event to " + eventsDir, e);
 		}
@@ -199,19 +151,9 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 
 	private void persistBookmark ( String reader, EventReference reference ) {
 		try {
-			ObjectNode node = objectMapper.createObjectNode();
-			node.put("reader", reader);
-
-			ObjectNode refNode = objectMapper.createObjectNode();
-			refNode.put("id", reference.id().value());
-			refNode.put("position", reference.position());
-			refNode.put("tx", reference.tx());
-			refNode.put("index", reference.index());
-			node.set("reference", refNode);
-
 			String fileName = sanitizeFileName(reader) + ".json";
 			Path filePath = bookmarksDir.resolve(fileName);
-			Files.writeString(filePath, objectMapper.writeValueAsString(node));
+			Files.writeString(filePath, bookmarkCodec.write(reader, reference));
 		} catch ( IOException e ) {
 			throw new EventStorageException("failed to persist bookmark for reader " + reader, e);
 		}
@@ -240,7 +182,7 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 						.filter(p -> p.toString().endsWith(".json"))
 						.toList();
 				for ( Path file : jsonFiles ) {
-					events.add(parseEvent(file));
+					events.add(readEvent(file));
 				}
 			}
 		} catch ( IOException e ) {
@@ -255,48 +197,11 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		return events;
 	}
 
-	private StoredEvent parseEvent ( Path file ) {
+	private StoredEvent readEvent ( Path file ) {
 		try {
-			JsonNode node = objectMapper.readTree(Files.readString(file));
-
-			JsonNode streamNode = node.get("stream");
-			EventStreamId stream = EventStreamId.forContext(streamNode.get("context").asText())
-					.withPurpose(streamNode.get("purpose").asText());
-
-			EventType type = EventType.ofType(node.get("type").asText());
-
-			JsonNode refNode = node.get("reference");
-			EventReference reference = EventReference.of(
-					EventId.of(refNode.get("id").asText()),
-					refNode.get("position").asLong(),
-					refNode.get("tx").asLong(),
-					refNode.get("index").asInt());
-
-			String immutableData = node.has("immutableData") && !node.get("immutableData").isNull()
-					? node.get("immutableData").toString()
-					: null;
-			String erasableData = node.has("erasableData") && !node.get("erasableData").isNull()
-					? node.get("erasableData").toString()
-					: null;
-
-			Set<Tag> tagSet = new HashSet<>();
-			JsonNode tagsNode = node.get("tags");
-			if ( tagsNode != null && tagsNode.isArray() ) {
-				for ( JsonNode tagNode : tagsNode ) {
-					String key = tagNode.get("key").asText();
-					String value = tagNode.has("value") && !tagNode.get("value").isNull()
-							? tagNode.get("value").asText()
-							: null;
-					tagSet.add(Tag.of(key, value));
-				}
-			}
-			Tags tags = new Tags(tagSet);
-
-			LocalDateTime timestamp = LocalDateTime.parse(node.get("timestamp").asText());
-
-			return new StoredEvent(stream, type, reference, immutableData, erasableData, tags, timestamp);
+			return eventCodec.read(Files.readString(file));
 		} catch ( IOException e ) {
-			throw new EventStorageException("failed to parse event file " + file, e);
+			throw new EventStorageException("failed to read event file " + file, e);
 		}
 	}
 
@@ -311,7 +216,7 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 						.filter(p -> p.toString().endsWith(".json"))
 						.toList();
 				for ( Path file : jsonFiles ) {
-					parseBookmark(file, bookmarks);
+					readBookmark(file, bookmarks);
 				}
 			}
 		} catch ( IOException e ) {
@@ -320,19 +225,12 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		return bookmarks;
 	}
 
-	private void parseBookmark ( Path file, Map<String, EventReference> bookmarks ) {
+	private void readBookmark ( Path file, Map<String, EventReference> bookmarks ) {
 		try {
-			JsonNode node = objectMapper.readTree(Files.readString(file));
-			String reader = node.get("reader").asText();
-			JsonNode refNode = node.get("reference");
-			EventReference reference = EventReference.of(
-					EventId.of(refNode.get("id").asText()),
-					refNode.get("position").asLong(),
-					refNode.get("tx").asLong(),
-					refNode.get("index").asInt());
-			bookmarks.put(reader, reference);
+			JsonBookmark parsed = bookmarkCodec.read(Files.readString(file));
+			bookmarks.put(parsed.reader(), parsed.reference());
 		} catch ( IOException e ) {
-			throw new EventStorageException("failed to parse bookmark file " + file, e);
+			throw new EventStorageException("failed to read bookmark file " + file, e);
 		}
 	}
 

--- a/sliceworkz-eventstore-serialization-json/pom.xml
+++ b/sliceworkz-eventstore-serialization-json/pom.xml
@@ -30,29 +30,16 @@
 	</parent>
 
 	<name>${project.artifactId}</name>
-	<description>DCB (Dynamic Consistency Boundary) compliant EventStore (Java/Postgres) - In-memory with filesystem persistence</description>
+	<description>DCB (Dynamic Consistency Boundary) compliant EventStore (Java/Postgres) - JSON serialization codecs</description>
 	<url>https://sliceworkz.github.io/eventstore</url>
 
-	<artifactId>sliceworkz-eventstore-infra-inmem-fs</artifactId>
+	<artifactId>sliceworkz-eventstore-serialization-json</artifactId>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.sliceworkz</groupId>
 			<artifactId>sliceworkz-eventstore-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.sliceworkz</groupId>
-			<artifactId>sliceworkz-eventstore-serialization-json</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.sliceworkz</groupId>
-			<artifactId>sliceworkz-eventstore-infra-inmem</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.sliceworkz</groupId>
-			<artifactId>sliceworkz-eventstore-impl</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmark.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmark.java
@@ -1,0 +1,25 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.serialization.json;
+
+import org.sliceworkz.eventstore.events.EventReference;
+
+/**
+ * Deserialized bookmark payload: the reader identifier and the event reference it points at.
+ */
+public record JsonBookmark ( String reader, EventReference reference ) { }

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodec.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodec.java
@@ -1,0 +1,85 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.serialization.json;
+
+import java.io.IOException;
+
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * JSON codec for reader bookmarks: a reader identifier paired with the
+ * {@link EventReference} it points at.
+ * <pre>
+ * {
+ *   "reader":    "...",
+ *   "reference": { "id": ..., "position": ..., "tx": ..., "index": ... }
+ * }
+ * </pre>
+ */
+public final class JsonBookmarkCodec {
+
+	private final ObjectMapper objectMapper;
+
+	public JsonBookmarkCodec ( ) {
+		this(JsonEventCodec.defaultObjectMapper());
+	}
+
+	public JsonBookmarkCodec ( ObjectMapper objectMapper ) {
+		this.objectMapper = objectMapper;
+	}
+
+	public String write ( String reader, EventReference reference ) {
+		try {
+			ObjectNode node = objectMapper.createObjectNode();
+			node.put("reader", reader);
+
+			ObjectNode refNode = objectMapper.createObjectNode();
+			refNode.put("id", reference.id().value());
+			refNode.put("position", reference.position());
+			refNode.put("tx", reference.tx());
+			refNode.put("index", reference.index());
+			node.set("reference", refNode);
+
+			return objectMapper.writeValueAsString(node);
+		} catch ( IOException e ) {
+			throw new JsonCodecException("failed to serialize bookmark for reader " + reader, e);
+		}
+	}
+
+	public JsonBookmark read ( String json ) {
+		try {
+			JsonNode node = objectMapper.readTree(json);
+			String reader = node.get("reader").asText();
+			JsonNode refNode = node.get("reference");
+			EventReference reference = EventReference.of(
+					EventId.of(refNode.get("id").asText()),
+					refNode.get("position").asLong(),
+					refNode.get("tx").asLong(),
+					refNode.get("index").asInt());
+			return new JsonBookmark(reader, reference);
+		} catch ( IOException e ) {
+			throw new JsonCodecException("failed to deserialize bookmark", e);
+		}
+	}
+
+}

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonCodecException.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonCodecException.java
@@ -1,0 +1,31 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.serialization.json;
+
+/**
+ * Thrown when reading or writing the JSON representation of an event or bookmark fails.
+ */
+public class JsonCodecException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public JsonCodecException ( String message, Throwable cause ) {
+		super(message, cause);
+	}
+
+}

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonEventCodec.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonEventCodec.java
@@ -1,0 +1,177 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.serialization.json;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tag;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * JSON codec for {@link StoredEvent}.
+ * <p>
+ * Produces and consumes a stable shape intended for on-disk persistence and for
+ * future export/import features:
+ * <pre>
+ * {
+ *   "stream":        { "context": ..., "purpose": ... },
+ *   "type":          "...",
+ *   "reference":     { "id": ..., "position": ..., "tx": ..., "index": ... },
+ *   "immutableData": { ... } | null,
+ *   "erasableData":  { ... } | null,
+ *   "tags":          [ { "key": ..., "value": ... }, ... ],
+ *   "timestamp":     "ISO-8601 LocalDateTime"
+ * }
+ * </pre>
+ */
+public final class JsonEventCodec {
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * Creates a codec with a default {@link ObjectMapper}: JSR-310 dates as ISO-8601
+	 * strings, pretty-printed output.
+	 */
+	public JsonEventCodec ( ) {
+		this(defaultObjectMapper());
+	}
+
+	/**
+	 * Creates a codec backed by the caller's {@link ObjectMapper}. The mapper is used
+	 * as-is; callers that want compact output (e.g. for bulk export) can disable
+	 * {@link SerializationFeature#INDENT_OUTPUT}.
+	 */
+	public JsonEventCodec ( ObjectMapper objectMapper ) {
+		this.objectMapper = objectMapper;
+	}
+
+	public static ObjectMapper defaultObjectMapper ( ) {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.enable(SerializationFeature.INDENT_OUTPUT);
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return mapper;
+	}
+
+	public String write ( StoredEvent event ) {
+		try {
+			ObjectNode node = objectMapper.createObjectNode();
+
+			ObjectNode streamNode = objectMapper.createObjectNode();
+			streamNode.put("context", event.stream().context());
+			streamNode.put("purpose", event.stream().purpose());
+			node.set("stream", streamNode);
+
+			node.put("type", event.type().name());
+
+			ObjectNode refNode = objectMapper.createObjectNode();
+			refNode.put("id", event.reference().id().value());
+			refNode.put("position", event.reference().position());
+			refNode.put("tx", event.reference().tx());
+			refNode.put("index", event.reference().index());
+			node.set("reference", refNode);
+
+			if ( event.immutableData() != null ) {
+				node.set("immutableData", objectMapper.readTree(event.immutableData()));
+			} else {
+				node.putNull("immutableData");
+			}
+			if ( event.erasableData() != null ) {
+				node.set("erasableData", objectMapper.readTree(event.erasableData()));
+			} else {
+				node.putNull("erasableData");
+			}
+
+			ArrayNode tagsArray = objectMapper.createArrayNode();
+			for ( Tag tag : event.tags().tags() ) {
+				ObjectNode tagNode = objectMapper.createObjectNode();
+				tagNode.put("key", tag.key());
+				tagNode.put("value", tag.value());
+				tagsArray.add(tagNode);
+			}
+			node.set("tags", tagsArray);
+
+			node.put("timestamp", event.timestamp().toString());
+
+			return objectMapper.writeValueAsString(node);
+		} catch ( IOException e ) {
+			throw new JsonCodecException("failed to serialize event", e);
+		}
+	}
+
+	public StoredEvent read ( String json ) {
+		try {
+			JsonNode node = objectMapper.readTree(json);
+
+			JsonNode streamNode = node.get("stream");
+			EventStreamId stream = EventStreamId.forContext(streamNode.get("context").asText())
+					.withPurpose(streamNode.get("purpose").asText());
+
+			EventType type = EventType.ofType(node.get("type").asText());
+
+			JsonNode refNode = node.get("reference");
+			EventReference reference = EventReference.of(
+					EventId.of(refNode.get("id").asText()),
+					refNode.get("position").asLong(),
+					refNode.get("tx").asLong(),
+					refNode.get("index").asInt());
+
+			String immutableData = node.has("immutableData") && !node.get("immutableData").isNull()
+					? node.get("immutableData").toString()
+					: null;
+			String erasableData = node.has("erasableData") && !node.get("erasableData").isNull()
+					? node.get("erasableData").toString()
+					: null;
+
+			Set<Tag> tagSet = new HashSet<>();
+			JsonNode tagsNode = node.get("tags");
+			if ( tagsNode != null && tagsNode.isArray() ) {
+				for ( JsonNode tagNode : tagsNode ) {
+					String key = tagNode.get("key").asText();
+					String value = tagNode.has("value") && !tagNode.get("value").isNull()
+							? tagNode.get("value").asText()
+							: null;
+					tagSet.add(Tag.of(key, value));
+				}
+			}
+			Tags tags = new Tags(tagSet);
+
+			LocalDateTime timestamp = LocalDateTime.parse(node.get("timestamp").asText());
+
+			return new StoredEvent(stream, type, reference, immutableData, erasableData, tags, timestamp);
+		} catch ( IOException e ) {
+			throw new JsonCodecException("failed to deserialize event", e);
+		}
+	}
+
+}

--- a/sliceworkz-eventstore-serialization-json/src/test/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodecTest.java
+++ b/sliceworkz-eventstore-serialization-json/src/test/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodecTest.java
@@ -1,0 +1,41 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.serialization.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+
+class JsonBookmarkCodecTest {
+
+	private final JsonBookmarkCodec codec = new JsonBookmarkCodec();
+
+	@Test
+	void roundTripsABookmark ( ) {
+		EventReference reference = EventReference.of(EventId.of("id-1"), 42L, 7L, 3);
+
+		String json = codec.write("my-projection", reference);
+		JsonBookmark restored = codec.read(json);
+
+		assertEquals("my-projection", restored.reader());
+		assertEquals(reference, restored.reference());
+	}
+
+}

--- a/sliceworkz-eventstore-serialization-json/src/test/java/org/sliceworkz/eventstore/serialization/json/JsonEventCodecTest.java
+++ b/sliceworkz-eventstore-serialization-json/src/test/java/org/sliceworkz/eventstore/serialization/json/JsonEventCodecTest.java
@@ -1,0 +1,93 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.serialization.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tag;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+class JsonEventCodecTest {
+
+	private final JsonEventCodec codec = new JsonEventCodec();
+
+	@Test
+	void roundTripsAnEvent ( ) {
+		StoredEvent event = new StoredEvent(
+				EventStreamId.forContext("customer").withPurpose("123"),
+				EventType.ofType("CustomerRegistered"),
+				EventReference.of(EventId.of("id-1"), 1L, 1L, 0),
+				"{\"name\":\"John\"}",
+				null,
+				new Tags(Set.of(Tag.of("customer", "123"))),
+				LocalDateTime.parse("2026-04-19T12:34:56.789"));
+
+		String json = codec.write(event);
+		StoredEvent restored = codec.read(json);
+
+		assertEquals(event, restored);
+	}
+
+	@Test
+	void writesHumanReadableShape ( ) {
+		StoredEvent event = new StoredEvent(
+				EventStreamId.forContext("ctx").withPurpose("p"),
+				EventType.ofType("CustomerRegistered"),
+				EventReference.of(EventId.of("id-1"), 1L, 1L, 0),
+				"{\"name\":\"John Doe\"}",
+				null,
+				new Tags(Set.of(Tag.of("customer", "42"))),
+				LocalDateTime.parse("2026-04-19T12:34:56.789"));
+
+		String json = codec.write(event);
+
+		assertTrue(json.contains("\"context\" : \"ctx\""));
+		assertTrue(json.contains("\"purpose\" : \"p\""));
+		assertTrue(json.contains("\"type\" : \"CustomerRegistered\""));
+		assertTrue(json.contains("\"customer\""));
+	}
+
+	@Test
+	void preservesNullImmutableAndErasableData ( ) {
+		StoredEvent event = new StoredEvent(
+				EventStreamId.forContext("ctx").withPurpose("p"),
+				EventType.ofType("NoData"),
+				EventReference.of(EventId.of("id-2"), 2L, 2L, 0),
+				null,
+				null,
+				new Tags(Set.of()),
+				LocalDateTime.parse("2026-04-19T00:00:00"));
+
+		StoredEvent restored = codec.read(codec.write(event));
+
+		assertNull(restored.immutableData());
+		assertNull(restored.erasableData());
+	}
+
+}


### PR DESCRIPTION
## Summary
Refactored JSON serialization/deserialization logic from `InMemoryFsEventStorageImpl` into dedicated, reusable codec classes. This improves code organization, testability, and enables future export/import features.

## Key Changes
- **New module**: `sliceworkz-eventstore-serialization-json` with three main classes:
  - `JsonEventCodec`: Handles serialization/deserialization of `StoredEvent` objects with a stable, documented JSON shape
  - `JsonBookmarkCodec`: Handles serialization/deserialization of reader bookmarks (reader ID + event reference)
  - `JsonCodecException`: Runtime exception for codec failures
  - `JsonBookmark`: Record type for deserialized bookmark data

- **Refactored `InMemoryFsEventStorageImpl`**:
  - Removed ~70 lines of inline JSON serialization logic
  - Replaced with calls to `JsonEventCodec` and `JsonBookmarkCodec`
  - Removed direct `ObjectMapper` usage and Jackson imports
  - Renamed `parseEvent()` → `readEvent()` and `parseBookmark()` → `readBookmark()` for clarity

- **Updated dependencies**:
  - Added `sliceworkz-eventstore-serialization-json` module to parent POM and BOM
  - Added dependency in `sliceworkz-eventstore-infra-inmem-fs`

## Implementation Details
- Codecs use a configurable `ObjectMapper` with sensible defaults (JSR-310 dates as ISO-8601 strings, pretty-printed output)
- JSON shapes are documented in JavaDoc with example structures
- Codecs support null handling for optional data fields (immutableData, erasableData)
- Comprehensive unit tests verify round-trip serialization and null preservation
- Stable JSON format designed for on-disk persistence and future export/import features

https://claude.ai/code/session_01D5kPJPqhrMUi6DuoowA2EA