### PR TITLE
Upgrade testcontainers-postgresql to 2.0.5 and update imports

### DIFF
--- a/sliceworkz-eventstore-infra-postgres/pom.xml
+++ b/sliceworkz-eventstore-infra-postgres/pom.xml
@@ -75,7 +75,7 @@
 		
 		<dependency>
 		    <groupId>org.testcontainers</groupId>
-		    <artifactId>postgresql</artifactId>
+		    <artifactId>testcontainers-postgresql</artifactId>
 		    <scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
 
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -41,13 +41,13 @@ public class PostgresContainer {
 	public static final String IMAGE_PG17 = "postgres:17";
 	public static final String IMAGE_PG18 = "postgres:18";
 
-	private static final Map<String, PostgreSQLContainer<?>> CONTAINERS = new ConcurrentHashMap<>();
+	private static final Map<String, PostgreSQLContainer> CONTAINERS = new ConcurrentHashMap<>();
 	private static final Map<String, HikariDataSource> DATASOURCES = new ConcurrentHashMap<>();
 
 	public static synchronized void start ( String image ) {
 		CONTAINERS.computeIfAbsent(image, img -> {
 			@SuppressWarnings("resource")
-			PostgreSQLContainer<?> container = new PostgreSQLContainer<>(img)
+			PostgreSQLContainer container = new PostgreSQLContainer(img)
 				.withDatabaseName("integration-tests-db")
 				.withUsername("sa")
 				.withPassword("pwd");
@@ -65,7 +65,7 @@ public class PostgresContainer {
 	}
 
 	public static DataSource dataSource ( String image ) {
-		PostgreSQLContainer<?> container = CONTAINERS.get(image);
+		PostgreSQLContainer container = CONTAINERS.get(image);
 		if ( container == null ) {
 			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
 		}

--- a/sliceworkz-eventstore-parent-pom/pom.xml
+++ b/sliceworkz-eventstore-parent-pom/pom.xml
@@ -42,7 +42,7 @@
 		<hikari.version>7.0.2</hikari.version>
 		<micrometer.version>1.16.5</micrometer.version>
 		<junit-jupiter.version>6.0.3</junit-jupiter.version>
-		<testcontainers.postgresql.version>1.21.4</testcontainers.postgresql.version>
+		<testcontainers.postgresql.version>2.0.5</testcontainers.postgresql.version>
 	    <awaitility.version>4.3.0</awaitility.version>
 
 		<maven.maven-surefire-plugin.version>3.5.5</maven.maven-surefire-plugin.version>
@@ -117,7 +117,7 @@
 			</dependency>
 			<dependency>
 			    <groupId>org.testcontainers</groupId>
-			    <artifactId>postgresql</artifactId>
+			    <artifactId>testcontainers-postgresql</artifactId>
 			    <version>${testcontainers.postgresql.version}</version>
 			    <scope>test</scope>
 			</dependency>

--- a/sliceworkz-eventstore-tests/pom.xml
+++ b/sliceworkz-eventstore-tests/pom.xml
@@ -68,7 +68,7 @@
 		</dependency>
 		<dependency>
 		    <groupId>org.testcontainers</groupId>
-		    <artifactId>postgresql</artifactId>
+		    <artifactId>testcontainers-postgresql</artifactId>
 		    <scope>test</scope>
 		</dependency>
 		<dependency>

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
 
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -41,13 +41,13 @@ public class PostgresContainer {
 	public static final String IMAGE_PG17 = "postgres:17";
 	public static final String IMAGE_PG18 = "postgres:18";
 
-	private static final Map<String, PostgreSQLContainer<?>> CONTAINERS = new ConcurrentHashMap<>();
+	private static final Map<String, PostgreSQLContainer> CONTAINERS = new ConcurrentHashMap<>();
 	private static final Map<String, HikariDataSource> DATASOURCES = new ConcurrentHashMap<>();
 
 	public static synchronized void start ( String image ) {
 		CONTAINERS.computeIfAbsent(image, img -> {
 			@SuppressWarnings("resource")
-			PostgreSQLContainer<?> container = new PostgreSQLContainer<>(img)
+			PostgreSQLContainer container = new PostgreSQLContainer(img)
 				.withDatabaseName("integration-tests-db")
 				.withUsername("sa")
 				.withPassword("pwd");
@@ -65,7 +65,7 @@ public class PostgresContainer {
 	}
 
 	public static DataSource dataSource ( String image ) {
-		PostgreSQLContainer<?> container = CONTAINERS.get(image);
+		PostgreSQLContainer container = CONTAINERS.get(image);
 		if ( container == null ) {
 			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
 		}


### PR DESCRIPTION
## Summary
Upgrade the testcontainers PostgreSQL library from version 1.21.4 to 2.0.5 and update the codebase to be compatible with the new version's API changes.

## Key Changes
- Updated testcontainers-postgresql dependency version from 1.21.4 to 2.0.5 in parent pom.xml
- Updated artifact ID from `postgresql` to `testcontainers-postgresql` in all pom.xml files
- Updated import statements from `org.testcontainers.containers.PostgreSQLContainer` to `org.testcontainers.postgresql.PostgreSQLContainer` in both PostgresContainer test utility classes
- Removed generic type parameter `<?>` from `PostgreSQLContainer` declarations to match the new API:
  - Changed `PostgreSQLContainer<?>` to `PostgreSQLContainer` in Map type declarations
  - Changed `new PostgreSQLContainer<>(img)` to `new PostgreSQLContainer(img)` in instantiation
  - Updated variable declarations to use non-generic `PostgreSQLContainer` type

## Notable Details
The changes were applied consistently across two modules:
- sliceworkz-eventstore-infra-postgres
- sliceworkz-eventstore-tests

Both modules had identical PostgresContainer utility classes that required the same updates for API compatibility with the new testcontainers version.

https://claude.ai/code/session_01NnrwCymVSBY9NP1e1Dnupz