### PR TITLE
Add bookmark metadata (tags and updatedAt) to event store

### DIFF
--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Bookmark.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Bookmark.java
@@ -1,0 +1,45 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.events;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A bookmark recording a named reader's position in the event store, together with
+ * the metadata supplied when the bookmark was placed.
+ * <p>
+ * Bookmarks are produced by {@code placeBookmark(reader, reference, tags)} on the
+ * {@link org.sliceworkz.eventstore.stream.EventSource} and surfaced as a list via
+ * {@code getBookmarks()} on both the public API and the storage SPI.
+ *
+ * @param reader    the unique name/identifier of the reader that owns this bookmark
+ * @param reference the event reference the reader has progressed to (the last processed event)
+ * @param tags      tags supplied at placement time; never {@code null} ({@link Tags#none()} when absent)
+ * @param updatedAt the instant at which the bookmark was last placed; never {@code null}
+ */
+public record Bookmark ( String reader, EventReference reference, Tags tags, Instant updatedAt ) {
+
+	public Bookmark {
+		Objects.requireNonNull(reader, "reader must not be null");
+		Objects.requireNonNull(reference, "reference must not be null");
+		Objects.requireNonNull(tags, "tags must not be null (use Tags.none())");
+		Objects.requireNonNull(updatedAt, "updatedAt must not be null");
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.EventType;
@@ -360,6 +361,25 @@ public interface EventStorage {
 	 * @see #getBookmark(String)
 	 */
 	void removeBookmark ( String reader );
+
+	/**
+	 * Retrieves all bookmarks currently held by this storage, including the metadata
+	 * (tags and last-update timestamp) supplied when each bookmark was placed.
+	 * <p>
+	 * Bookmarks are addressed globally by reader name, so the returned list spans the entire
+	 * storage — it is not scoped to any particular event stream. Use this for administrative
+	 * inspection, monitoring reader progress, or building a UI that lists active readers.
+	 * <p>
+	 * The returned list is a snapshot taken at call time and is not live; subsequent
+	 * {@link #bookmark(String, EventReference, Tags)} or {@link #removeBookmark(String)} calls do
+	 * not affect a list that was already returned. Order is unspecified.
+	 *
+	 * @return a snapshot list of all bookmarks; empty if none exist
+	 * @throws EventStorageException if an error occurs while reading bookmarks
+	 * @see Bookmark
+	 * @see #getBookmark(String)
+	 */
+	List<Bookmark> getBookmarks ( );
 
 	/**
 	 * Notification sent when new events are appended to the event store.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
@@ -292,5 +293,23 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	 * @return an Optional containing the previous bookmarked EventReference if one existed, empty otherwise
 	 */
 	Optional<EventReference> removeBookmark ( String reader );
+
+	/**
+	 * Retrieves all bookmarks currently held by the underlying event store, including the
+	 * metadata (tags and last-update timestamp) supplied when each bookmark was placed.
+	 * <p>
+	 * Bookmarks are addressed globally by reader name, so the returned list spans the entire
+	 * event store — it is not scoped to this stream. Use this for administrative inspection,
+	 * monitoring reader progress, or building a UI that lists active readers.
+	 * <p>
+	 * The returned list is a snapshot taken at call time and is not live; subsequent
+	 * {@link #placeBookmark(String, EventReference, Tags)} or {@link #removeBookmark(String)}
+	 * calls do not affect a list that was already returned. Order is unspecified.
+	 *
+	 * @return a snapshot list of all bookmarks; empty if none exist
+	 * @see Bookmark
+	 * @see #getBookmark(String)
+	 */
+	List<Bookmark> getBookmarks ( );
 
 }

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sliceworkz.Banner;
 import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EphemeralEvent;
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.EventId;
@@ -201,6 +202,7 @@ public class EventStoreImpl implements EventStore {
 		private Counter meterGetEvent;
 		private Counter meterBookmarkPlace;
 		private Counter meterBookmarkGet;
+		private Counter meterBookmarkList;
 		private Timer timerQuery;
 		private Timer timerAppend;
 
@@ -231,6 +233,7 @@ public class EventStoreImpl implements EventStore {
 			this.meterGetEvent = meterRegistry.counter("sliceworkz.eventstore.get.event", baseTags);
 			this.meterBookmarkPlace = meterRegistry.counter("sliceworkz.eventstore.bookmark.place", baseTags);
 			this.meterBookmarkGet= meterRegistry.counter("sliceworkz.eventstore.bookmark.get", baseTags);
+			this.meterBookmarkList = meterRegistry.counter("sliceworkz.eventstore.bookmark.list", baseTags);
 
 			this.timerQuery = meterRegistry.timer("sliceworkz.eventstore.query.duration", baseTags);
 			this.timerAppend = meterRegistry.timer("sliceworkz.eventstore.append.duration", baseTags);
@@ -428,6 +431,12 @@ public class EventStoreImpl implements EventStore {
 		public Optional<EventReference> getBookmark(String reader) {
 			meterBookmarkGet.increment();
 			return eventStorage.getBookmark(reader.toString());
+		}
+
+		@Override
+		public List<Bookmark> getBookmarks() {
+			meterBookmarkList.increment();
+			return eventStorage.getBookmarks();
 		}
 
 		@Override

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.Tags;
@@ -68,7 +69,7 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		createDirectories();
 
 		List<StoredEvent> initialEvents = loadEvents();
-		Map<String, EventReference> initialBookmarks = loadBookmarks();
+		Map<String, Bookmark> initialBookmarks = loadBookmarks();
 
 		InMemoryEventStorage.Builder builder = InMemoryEventStorage.newBuilder()
 				.name(name)
@@ -126,9 +127,20 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 	}
 
 	@Override
+	public List<Bookmark> getBookmarks ( ) {
+		return delegate.getBookmarks();
+	}
+
+	@Override
 	public void bookmark ( String reader, EventReference eventReference, Tags tags ) {
 		delegate.bookmark(reader, eventReference, tags);
-		persistBookmark(reader, eventReference);
+		// after delegate.bookmark, the snapshot in the delegate carries the canonical metadata
+		// (effective tags, updatedAt assigned by the delegate); persist that snapshot to disk
+		Bookmark snapshot = delegate.getBookmarks().stream()
+				.filter(b -> b.reader().equals(reader))
+				.findFirst()
+				.orElseThrow(() -> new EventStorageException("bookmark snapshot missing for reader " + reader));
+		persistBookmark(snapshot);
 	}
 
 	@Override
@@ -149,13 +161,13 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		}
 	}
 
-	private void persistBookmark ( String reader, EventReference reference ) {
+	private void persistBookmark ( Bookmark bookmark ) {
 		try {
-			String fileName = sanitizeFileName(reader) + ".json";
+			String fileName = sanitizeFileName(bookmark.reader()) + ".json";
 			Path filePath = bookmarksDir.resolve(fileName);
-			Files.writeString(filePath, bookmarkCodec.write(reader, reference));
+			Files.writeString(filePath, bookmarkCodec.write(bookmark.reader(), bookmark.reference(), bookmark.tags(), bookmark.updatedAt()));
 		} catch ( IOException e ) {
-			throw new EventStorageException("failed to persist bookmark for reader " + reader, e);
+			throw new EventStorageException("failed to persist bookmark for reader " + bookmark.reader(), e);
 		}
 	}
 
@@ -205,8 +217,8 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		}
 	}
 
-	private Map<String, EventReference> loadBookmarks ( ) {
-		Map<String, EventReference> bookmarks = new HashMap<>();
+	private Map<String, Bookmark> loadBookmarks ( ) {
+		Map<String, Bookmark> bookmarks = new HashMap<>();
 		try {
 			if ( !Files.exists(bookmarksDir) ) {
 				return bookmarks;
@@ -225,10 +237,10 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		return bookmarks;
 	}
 
-	private void readBookmark ( Path file, Map<String, EventReference> bookmarks ) {
+	private void readBookmark ( Path file, Map<String, Bookmark> bookmarks ) {
 		try {
 			JsonBookmark parsed = bookmarkCodec.read(Files.readString(file));
-			bookmarks.put(parsed.reader(), parsed.reference());
+			bookmarks.put(parsed.reader(), new Bookmark(parsed.reader(), parsed.reference(), parsed.tags(), parsed.updatedAt()));
 		} catch ( IOException e ) {
 			throw new EventStorageException("failed to read bookmark file " + file, e);
 		}

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorage.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorage.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.EventStoreFactory;
-import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
@@ -150,7 +150,7 @@ public interface InMemoryEventStorage {
 		private MeterRegistry meterRegistry = Metrics.globalRegistry;
 		private String name = "inmem-%s".formatted(System.identityHashCode(this)); // default unique name in case different objects are used
 		private List<StoredEvent> initialEvents = List.of();
-		private Map<String, EventReference> initialBookmarks = Map.of();
+		private Map<String, Bookmark> initialBookmarks = Map.of();
 
 		
 		private Builder ( ) {
@@ -229,10 +229,10 @@ public interface InMemoryEventStorage {
 		 * This is useful for restoring previously persisted bookmarks, for example when wrapping the
 		 * in-memory storage with a file-persistence layer.
 		 *
-		 * @param initialBookmarks a map of reader name to event reference (must not be null)
+		 * @param initialBookmarks a map of reader name to bookmark (must not be null)
 		 * @return this Builder instance for method chaining
 		 */
-		public Builder initialBookmarks ( Map<String, EventReference> initialBookmarks ) {
+		public Builder initialBookmarks ( Map<String, Bookmark> initialBookmarks ) {
 			this.initialBookmarks = initialBookmarks;
 			return this;
 		}

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -18,6 +18,7 @@
 package org.sliceworkz.eventstore.infra.inmem;
 
 import java.lang.ref.WeakReference;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.Tags;
@@ -101,7 +103,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	private List<StoredEvent> eventlog = new CopyOnWriteArrayList<>();
 	private Set<String> idempotencyKeys = new HashSet<>();
 	private List<WeakReference<EventStoreListener>> listeners = new CopyOnWriteArrayList<>();
-	private Map<String,EventReference> bookmarks = new HashMap<>();
+	private Map<String,Bookmark> bookmarks = new HashMap<>();
 	private JsonMapper jsonMapper;
 	private Limit absoluteLimit;
 	private long txCounter;
@@ -129,7 +131,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		this(name, absoluteLimit, List.of(), Map.of());
 	}
 
-	public InMemoryEventStorageImpl ( String name, Limit absoluteLimit, List<StoredEvent> initialEvents, Map<String, EventReference> initialBookmarks ) {
+	public InMemoryEventStorageImpl ( String name, Limit absoluteLimit, List<StoredEvent> initialEvents, Map<String, Bookmark> initialBookmarks ) {
 		if ( name == null || "".equals(name.strip())) {
 			throw new IllegalArgumentException("name must not be empty");
 		}
@@ -331,7 +333,12 @@ public class InMemoryEventStorageImpl implements EventStorage {
 
 	@Override
 	public synchronized Optional<EventReference> getBookmark(String reader) {
-		return Optional.ofNullable(bookmarks.get(reader));
+		return Optional.ofNullable(bookmarks.get(reader)).map(Bookmark::reference);
+	}
+
+	@Override
+	public synchronized List<Bookmark> getBookmarks() {
+		return List.copyOf(bookmarks.values());
 	}
 
 	@Override
@@ -341,11 +348,12 @@ public class InMemoryEventStorageImpl implements EventStorage {
 
 	@Override
 	public synchronized void bookmark(String reader, EventReference eventReference, Tags tags ) {
-		bookmarks.put(reader, eventReference);
+		Tags effectiveTags = tags == null ? Tags.none() : tags;
+		bookmarks.put(reader, new Bookmark(reader, eventReference, effectiveTags, Instant.now()));
 		BookmarkPlacedNotification notification = new BookmarkPlacedNotification(reader, eventReference);
 		listeners.forEach(l->{
 			if ( l.get() != null ) {
-				l.get().notify(notification);				
+				l.get().notify(notification);
 			}
 		});
 	}

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -27,6 +27,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ import org.postgresql.PGConnection;
 import org.postgresql.PGNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.EventType;
@@ -1152,7 +1154,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 			readConnection.setAutoCommit(true);
 			try (PreparedStatement stmt = readConnection.prepareStatement(sql)) {
 				stmt.setString(1, reader);
-				
+
 				try (ResultSet rs = stmt.executeQuery()) {
 					if (rs.next()) {
 						long position = rs.getLong("event_position");
@@ -1168,8 +1170,47 @@ public class PostgresEventStorageImpl implements EventStorage {
 		} catch (SQLException e) {
 			throw new EventStorageException("Failed to close connection", e);
 		}
-		
+
 		return Optional.empty();
+	}
+
+	@Override
+	public List<Bookmark> getBookmarks() {
+		String sql = """
+			SELECT reader, event_position, event_id, event_tx::text, updated_at, updated_tags
+			FROM %sbookmarks
+		""".formatted(prefix);
+
+		List<Bookmark> bookmarks = new ArrayList<>();
+		try ( Connection readConnection = dataSource.getConnection() ) {
+			readConnection.setAutoCommit(true);
+			try ( PreparedStatement stmt = readConnection.prepareStatement(sql);
+			      ResultSet rs = stmt.executeQuery() ) {
+				while ( rs.next() ) {
+					String reader = rs.getString("reader");
+					long position = rs.getLong("event_position");
+					long tx = Long.parseUnsignedLong(rs.getString("event_tx"));
+					EventId eventId = new EventId(rs.getString("event_id"));
+					EventReference reference = EventReference.of(eventId, position, tx);
+
+					String[] tagsArray = new String[0];
+					if ( rs.getArray("updated_tags") != null ) {
+						tagsArray = (String[]) rs.getArray("updated_tags").getArray();
+					}
+					Tags tags = Tags.parse(tagsArray);
+
+					Timestamp updatedAtTs = rs.getTimestamp("updated_at", Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+					Instant updatedAt = updatedAtTs != null ? updatedAtTs.toInstant() : Instant.EPOCH;
+
+					bookmarks.add(new Bookmark(reader, reference, tags, updatedAt));
+				}
+			} catch ( SQLException e ) {
+				throw new EventStorageException("Failed to list bookmarks", e);
+			}
+		} catch ( SQLException e ) {
+			throw new EventStorageException("Failed to close connection", e);
+		}
+		return bookmarks;
 	}
 
 	

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmark.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmark.java
@@ -17,9 +17,17 @@
  */
 package org.sliceworkz.eventstore.serialization.json;
 
+import java.time.Instant;
+
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
 
 /**
- * Deserialized bookmark payload: the reader identifier and the event reference it points at.
+ * Deserialized bookmark payload: the reader identifier, the event reference it points at,
+ * and the metadata (tags, last-update timestamp) supplied when the bookmark was placed.
+ * <p>
+ * {@code tags} and {@code updatedAt} may be absent in legacy on-disk payloads written before
+ * the metadata extension; in that case the codec returns {@link Tags#none()} and an
+ * {@code updatedAt} of {@link Instant#EPOCH}.
  */
-public record JsonBookmark ( String reader, EventReference reference ) { }
+public record JsonBookmark ( String reader, EventReference reference, Tags tags, Instant updatedAt ) { }

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodec.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodec.java
@@ -18,23 +18,35 @@
 package org.sliceworkz.eventstore.serialization.json;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tag;
+import org.sliceworkz.eventstore.events.Tags;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * JSON codec for reader bookmarks: a reader identifier paired with the
- * {@link EventReference} it points at.
+ * {@link EventReference} it points at, plus the metadata (tags and last-update timestamp)
+ * supplied when the bookmark was placed.
  * <pre>
  * {
  *   "reader":    "...",
- *   "reference": { "id": ..., "position": ..., "tx": ..., "index": ... }
+ *   "reference": { "id": ..., "position": ..., "tx": ..., "index": ... },
+ *   "tags":      [ { "key": ..., "value": ... }, ... ],
+ *   "updatedAt": "2026-04-30T12:34:56.789Z"
  * }
  * </pre>
+ * The {@code tags} and {@code updatedAt} fields are optional on read, for backwards
+ * compatibility with payloads written before the metadata extension. Absent fields read as
+ * {@link Tags#none()} and {@link Instant#EPOCH} respectively.
  */
 public final class JsonBookmarkCodec {
 
@@ -49,6 +61,10 @@ public final class JsonBookmarkCodec {
 	}
 
 	public String write ( String reader, EventReference reference ) {
+		return write(reader, reference, Tags.none(), Instant.EPOCH);
+	}
+
+	public String write ( String reader, EventReference reference, Tags tags, Instant updatedAt ) {
 		try {
 			ObjectNode node = objectMapper.createObjectNode();
 			node.put("reader", reader);
@@ -59,6 +75,17 @@ public final class JsonBookmarkCodec {
 			refNode.put("tx", reference.tx());
 			refNode.put("index", reference.index());
 			node.set("reference", refNode);
+
+			ArrayNode tagsArray = objectMapper.createArrayNode();
+			for ( Tag tag : tags.tags() ) {
+				ObjectNode tagNode = objectMapper.createObjectNode();
+				tagNode.put("key", tag.key());
+				tagNode.put("value", tag.value());
+				tagsArray.add(tagNode);
+			}
+			node.set("tags", tagsArray);
+
+			node.put("updatedAt", updatedAt.toString());
 
 			return objectMapper.writeValueAsString(node);
 		} catch ( IOException e ) {
@@ -76,7 +103,25 @@ public final class JsonBookmarkCodec {
 					refNode.get("position").asLong(),
 					refNode.get("tx").asLong(),
 					refNode.get("index").asInt());
-			return new JsonBookmark(reader, reference);
+
+			Set<Tag> tagSet = new HashSet<>();
+			JsonNode tagsNode = node.get("tags");
+			if ( tagsNode != null && tagsNode.isArray() ) {
+				for ( JsonNode tagNode : tagsNode ) {
+					String key = tagNode.get("key").asText();
+					String value = tagNode.has("value") && !tagNode.get("value").isNull()
+							? tagNode.get("value").asText()
+							: null;
+					tagSet.add(Tag.of(key, value));
+				}
+			}
+			Tags tags = new Tags(tagSet);
+
+			Instant updatedAt = node.has("updatedAt") && !node.get("updatedAt").isNull()
+					? Instant.parse(node.get("updatedAt").asText())
+					: Instant.EPOCH;
+
+			return new JsonBookmark(reader, reference, tags, updatedAt);
 		} catch ( IOException e ) {
 			throw new JsonCodecException("failed to deserialize bookmark", e);
 		}

--- a/sliceworkz-eventstore-serialization-json/src/test/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodecTest.java
+++ b/sliceworkz-eventstore-serialization-json/src/test/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodecTest.java
@@ -19,16 +19,19 @@ package org.sliceworkz.eventstore.serialization.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
 
 class JsonBookmarkCodecTest {
 
 	private final JsonBookmarkCodec codec = new JsonBookmarkCodec();
 
 	@Test
-	void roundTripsABookmark ( ) {
+	void roundTripsABookmarkWithoutMetadata ( ) {
 		EventReference reference = EventReference.of(EventId.of("id-1"), 42L, 7L, 3);
 
 		String json = codec.write("my-projection", reference);
@@ -36,6 +39,36 @@ class JsonBookmarkCodecTest {
 
 		assertEquals("my-projection", restored.reader());
 		assertEquals(reference, restored.reference());
+		assertEquals(Tags.none(), restored.tags());
+		assertEquals(Instant.EPOCH, restored.updatedAt());
+	}
+
+	@Test
+	void roundTripsABookmarkWithTagsAndUpdatedAt ( ) {
+		EventReference reference = EventReference.of(EventId.of("id-1"), 42L, 7L, 3);
+		Tags tags = Tags.parse("status:processed", "version:7");
+		Instant updatedAt = Instant.parse("2026-04-30T12:34:56.789Z");
+
+		String json = codec.write("my-projection", reference, tags, updatedAt);
+		JsonBookmark restored = codec.read(json);
+
+		assertEquals("my-projection", restored.reader());
+		assertEquals(reference, restored.reference());
+		assertEquals(tags, restored.tags());
+		assertEquals(updatedAt, restored.updatedAt());
+	}
+
+	@Test
+	void readsLegacyPayloadWithoutTagsOrUpdatedAt ( ) {
+		String legacyJson = """
+				{"reader":"legacy","reference":{"id":"id-1","position":42,"tx":7,"index":3}}
+				""";
+
+		JsonBookmark restored = codec.read(legacyJson);
+
+		assertEquals("legacy", restored.reader());
+		assertEquals(Tags.none(), restored.tags());
+		assertEquals(Instant.EPOCH, restored.updatedAt());
 	}
 
 }

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/BookmarksTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/stream/BookmarksTest.java
@@ -1,0 +1,226 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.EventStoreFactory;
+import org.sliceworkz.eventstore.events.Bookmark;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorageImpl;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.mock.MockDomainEvent.FirstDomainEvent;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorage;
+
+class BookmarksTest {
+
+	abstract static class Tests {
+
+		private EventStorage eventStorage;
+		private EventStore eventStore;
+
+		@BeforeEach
+		public void setUp ( ) {
+			this.eventStorage = createEventStorage();
+			this.eventStore = EventStoreFactory.get().eventStore(eventStorage);
+		}
+
+		@AfterEach
+		public void tearDown ( ) {
+			destroyEventStorage(eventStorage);
+		}
+
+		abstract EventStorage createEventStorage ( );
+
+		void destroyEventStorage ( EventStorage storage ) {
+		}
+
+		private EventStream<MockDomainEvent> stream ( ) {
+			return eventStore.getEventStream(EventStreamId.forContext("a").withPurpose("p"), MockDomainEvent.class);
+		}
+
+		private EventReference appendOne ( ) {
+			EventStream<MockDomainEvent> s = stream();
+			s.append(AppendCriteria.none(), Collections.singletonList(Event.of(new FirstDomainEvent("e"), Tags.none())));
+			return s.query(EventQuery.matchAll().backwards().limit(1)).findFirst().orElseThrow().reference();
+		}
+
+		@Test
+		void emptyStoreReturnsEmptyList ( ) {
+			List<Bookmark> bookmarks = stream().getBookmarks();
+			assertNotNull(bookmarks);
+			assertTrue(bookmarks.isEmpty());
+		}
+
+		@Test
+		void listsAllBookmarksAcrossReaders ( ) {
+			EventReference ref = appendOne();
+			EventStream<MockDomainEvent> s = stream();
+
+			s.placeBookmark("reader-a", ref, Tags.none());
+			s.placeBookmark("reader-b", ref, Tags.parse("k:v"));
+
+			List<Bookmark> bookmarks = s.getBookmarks();
+			assertEquals(2, bookmarks.size());
+
+			Map<String, Bookmark> byReader = bookmarks.stream().collect(java.util.stream.Collectors.toMap(Bookmark::reader, b -> b));
+			assertTrue(byReader.containsKey("reader-a"));
+			assertTrue(byReader.containsKey("reader-b"));
+			assertEquals(ref, byReader.get("reader-a").reference());
+			assertEquals(ref, byReader.get("reader-b").reference());
+		}
+
+		@Test
+		void includesTagsAndUpdatedAt ( ) {
+			EventReference ref = appendOne();
+			Instant before = Instant.now().minusSeconds(2);
+
+			EventStream<MockDomainEvent> s = stream();
+			s.placeBookmark("tagged-reader", ref, Tags.parse("status:processed", "version:7"));
+
+			Bookmark bookmark = s.getBookmarks().stream()
+					.filter(b -> "tagged-reader".equals(b.reader()))
+					.findFirst()
+					.orElseThrow();
+
+			assertEquals(ref, bookmark.reference());
+			assertEquals(Tags.parse("status:processed", "version:7"), bookmark.tags());
+			assertNotNull(bookmark.updatedAt());
+			assertTrue(bookmark.updatedAt().isAfter(before),
+					"updatedAt %s should be after %s".formatted(bookmark.updatedAt(), before));
+		}
+
+		@Test
+		void removeExcludesFromList ( ) {
+			EventReference ref = appendOne();
+			EventStream<MockDomainEvent> s = stream();
+			s.placeBookmark("transient-reader", ref, Tags.none());
+			assertEquals(1, s.getBookmarks().size());
+
+			s.removeBookmark("transient-reader");
+			assertTrue(s.getBookmarks().isEmpty());
+		}
+
+		@Test
+		void rePlacingBookmarkReplacesExistingEntry ( ) {
+			EventReference ref = appendOne();
+			EventStream<MockDomainEvent> s = stream();
+			s.placeBookmark("repeat-reader", ref, Tags.parse("phase:first"));
+			s.placeBookmark("repeat-reader", ref, Tags.parse("phase:second"));
+
+			List<Bookmark> bookmarks = s.getBookmarks();
+			assertEquals(1, bookmarks.size());
+			assertEquals(Tags.parse("phase:second"), bookmarks.get(0).tags());
+		}
+
+		@Test
+		void snapshotIsIndependentOfSubsequentMutations ( ) {
+			EventReference ref = appendOne();
+			EventStream<MockDomainEvent> s = stream();
+			s.placeBookmark("snapshot-reader", ref, Tags.none());
+
+			List<Bookmark> snapshot = s.getBookmarks();
+			s.placeBookmark("other-reader", ref, Tags.none());
+
+			// snapshot may or may not be a copy — if it is mutable, expect 1; if it is live we'd see 2.
+			// the SPI/API contract calls it a snapshot, so we expect it to be unaffected.
+			assertFalse(snapshot.size() > 1, "getBookmarks() should return a snapshot, not a live view");
+		}
+
+	}
+
+	@Nested
+	class OnInMem extends Tests {
+		@Override
+		EventStorage createEventStorage ( ) {
+			return InMemoryEventStorage.newBuilder().build();
+		}
+	}
+
+	@Nested
+	class OnPostgres17 extends Tests {
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG17); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG17); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG17); }
+
+		@Override
+		EventStorage createEventStorage ( ) {
+			return PostgresEventStorage.newBuilder()
+					.name("unit-test")
+					.dataSource(PostgresContainer.dataSource(PostgresContainer.IMAGE_PG17))
+					.initializeDatabase()
+					.build();
+		}
+
+		@Override
+		void destroyEventStorage ( EventStorage storage ) {
+			((PostgresEventStorageImpl)storage).stop();
+			PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG17);
+		}
+	}
+
+	@Nested
+	class OnPostgres18 extends Tests {
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG18); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG18); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18); }
+
+		@Override
+		EventStorage createEventStorage ( ) {
+			return PostgresEventStorage.newBuilder()
+					.name("unit-test")
+					.dataSource(PostgresContainer.dataSource(PostgresContainer.IMAGE_PG18))
+					.initializeDatabase()
+					.build();
+		}
+
+		@Override
+		void destroyEventStorage ( EventStorage storage ) {
+			((PostgresEventStorageImpl)storage).stop();
+			PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG18);
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
Extends the bookmark feature to capture and persist metadata (tags and last-update timestamp) when bookmarks are placed, enabling richer tracking of reader progress and state.

## Key Changes

- **New `Bookmark` record** (`sliceworkz-eventstore-api`): Replaces bare `EventReference` with a rich record containing `reader`, `reference`, `tags`, and `updatedAt` fields
  
- **SPI extension** (`EventStorage`): Added `List<Bookmark> getBookmarks()` method to retrieve all bookmarks with their metadata across the entire storage (not scoped to a single stream)

- **Public API extension** (`EventSource`): Added `List<Bookmark> getBookmarks()` method mirroring the SPI, with documentation clarifying it returns a snapshot

- **JSON codec update** (`JsonBookmarkCodec`): Extended serialization format to include `tags` array and `updatedAt` timestamp; maintains backward compatibility by treating absent fields as `Tags.none()` and `Instant.EPOCH`

- **Storage implementations**:
  - **In-memory** (`InMemoryEventStorageImpl`): Updated internal bookmark map to store `Bookmark` objects; `bookmark()` method now captures effective tags and timestamp
  - **Postgres** (`PostgresEventStorageImpl`): Implemented `getBookmarks()` to query all bookmarks with their metadata from the database
  - **In-memory FS** (`InMemoryFsEventStorageImpl`): Updated to persist full `Bookmark` objects to disk, reading and writing metadata through the codec

- **Metrics** (`EventStoreImpl`): Added `meterBookmarkList` counter to track `getBookmarks()` calls

- **Comprehensive test suite** (`BookmarksTest`): New test class with nested test suites covering in-memory and Postgres (v17, v18) implementations, validating:
  - Empty store behavior
  - Listing bookmarks across readers
  - Tag and timestamp capture
  - Bookmark removal
  - Replacement semantics
  - Snapshot independence

## Implementation Details

- Backward compatibility: Legacy bookmark payloads without metadata fields are read as having `Tags.none()` and `Instant.EPOCH`
- The `bookmark()` method now captures the current timestamp server-side when placing a bookmark
- `getBookmarks()` returns a snapshot (not a live view) to prevent concurrent modification issues
- Bookmarks are globally addressed by reader name across the entire storage, not scoped to individual streams

https://claude.ai/code/session_018BJWDpgJyrDBpxD4eTPvTD