### PR TITLE
Import events between event stores, preserving id, timestamp and idempotency key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,66 @@ Projector.from(stream).towards(projection).build().run();
 // initQuery finds the last StockCounted, then eventQuery processes only subsequent movements
 ```
 
+### Importing Events Between Stores
+
+`EventStoreImporter` (in `org.sliceworkz.eventstore.migration`, api module) copies events from one
+`EventStorage` into another via the SPI method `EventStorage.importEvents(List<EventToImport>, ImportMode)`.
+
+```java
+ImportReport report = EventStoreImporter.from(sourceStorage).to(targetStorage)
+    .mode(ImportMode.SKIP_EXISTING_ID)                       // default is FAIL_ON_EXISTING_ID
+    .after(previousReport.sourceTo())                        // optional: catch-up run
+    .transform(src -> Optional.of(EventToImport.from(src)    // optional: remap / rewrite / drop
+                        .withStream(archiveStream)))
+    .batchSize(1000)
+    .onProgress(r -> LOGGER.info("{}", r))
+    .run();
+```
+
+**What survives, what does not:**
+- **Preserved**: `EventId`, timestamp, idempotency key, event type, tags, immutable and erasable payloads
+- **Reassigned by the target**: `position` and `tx`. An import reproduces the source *order*, never its
+  ordering numbers. `index` is a read-time upcasting artifact and is always 0 at rest.
+
+**Why it lives at the SPI level.** `EventToImport`/`StoredEvent` carry opaque JSON plus a type name, so an
+import needs no domain classes on the classpath, does no serde round-trip, does not upcast, and does not
+re-split `@Erasable` fields against annotations that may have changed. Going through `EventStream` instead
+would rewrite legacy events into current ones and lose the idempotency key, which the public `Event` record
+does not carry.
+
+**Import modes** (`EventStorage.ImportMode`):
+- `FAIL_ON_EXISTING_ID` (default) — an already-present event id aborts the batch with `EventImportConflictException`
+- `SKIP_EXISTING_ID` — an already-present event id is skipped, matching **on id alone**; no payload is read
+  back or compared. This is the resume mode.
+
+An idempotency key already used by a *different* event on the same stream is fatal in **both** modes — the
+Postgres implementation infers `ON CONFLICT (event_id)` specifically so the stream-scoped idempotency index
+still raises.
+
+**Caveats that matter:**
+- **Atomic per batch only.** A failure part-way leaves earlier batches committed. Re-run with
+  `SKIP_EXISTING_ID` to continue. There is no dry-run mode.
+- **Nothing is verified.** Matching is on id; faithfulness of a migration is the caller's problem.
+- **The transform can rewrite anything** — stream, tags, payload, type, id, timestamp. That makes it a
+  stream-cloning and schema-migration tool, and means it offers no fidelity guarantee of its own.
+  Rewriting ids makes `SKIP_EXISTING_ID` meaningless (nothing stable left to match on).
+- **Reads are always bounded at the source head**, captured before the first write. This is what makes
+  `from(x).to(x)` (cloning inside one store) terminate instead of re-reading its own writes forever. Events
+  appended to the source during the run are excluded; `ImportReport.sourceTo()` fed into a later run's
+  `.after(...)` picks them up in O(new events).
+- **One importer at a time per target** — the conflict check and the insert are not under a common lock.
+- **Listeners are notified** exactly as for appends, so a merge into a live store wakes its projections.
+  Imported events arrive at new (high) positions carrying old timestamps, so "later position implies later
+  timestamp" no longer holds in that store.
+- **Checking a target up front** must be done in **raw mode**
+  (`eventStore.getEventStream(EventStreamId.anyContext())`, no event root classes). With domain classes
+  registered, `getEventById` upcasts, and a legacy event whose upcast yields zero current events comes back
+  as an empty list even though it exists — a false negative.
+
+`EventToImport`'s canonical constructor is public, so it also writes synthetic events with a chosen id and
+timestamp directly into a store — useful for fixtures, but it bypasses `append()` and everything that path
+guarantees.
+
 ## Testing
 
 **Base Test Class:**
@@ -291,3 +351,6 @@ The key insight of DCB is that business decisions are based on querying relevant
 - Requires the `btree_gin` extension (a standard contrib extension, available on the major managed Postgres offerings). Schema initialization runs `CREATE EXTENSION IF NOT EXISTS btree_gin` and schema validation requires `idx_events_stream_tags`, a combined stream+tags GIN index that serves DCB reads scoping by stream *and* filtering by tags in one index. The B-tree indexes are retained for ordered stream replay (GIN cannot serve `ORDER BY`)
 - `stream_purpose` defaults to `'default'` in the DDL, matching `EventStreamId.DEFAULT_PURPOSE`. On a database created before this alignment (default was `''`), operators doing raw SQL inserts should run `ALTER TABLE <prefix>events ALTER COLUMN stream_purpose SET DEFAULT 'default';` — no data migration is needed since all events written through the library bind the purpose explicitly
 - **Idempotency keys are scoped per event stream (context + purpose), not per storage/table.** Uniqueness is enforced by the partial unique index `idx_events_stream_idempotency` on `(stream_context, stream_purpose, idempotency_key) WHERE idempotency_key IS NOT NULL` (schema validation requires it), so the same key used on two unrelated streams does not collide and dedup behaviour does not depend on how storage instances / prefixes are wired at runtime. The `idempotency_key` is persisted and surfaced on `StoredEvent` when reading (it is not exposed on the public `Event` record). A duplicate append is still silently ignored (returns an empty result). On a database created before this change (when `idempotency_key` had a table-wide `UNIQUE`), migrate with: `ALTER TABLE <prefix>events DROP CONSTRAINT <prefix>events_idempotency_key_key; CREATE UNIQUE INDEX <prefix>idx_events_stream_idempotency ON <prefix>events (stream_context, stream_purpose, idempotency_key) WHERE idempotency_key IS NOT NULL;` — no data migration is needed
+- **Importing needed no DDL change**: `event_id` is already a plain `UUID NOT NULL UNIQUE` and `event_timestamp` is nullable with a `CURRENT_TIMESTAMP` default, so both can be supplied explicitly. `importEvents` binds them per row, chunks statements at 5000 rows (9 params/row against the 65535-parameter wire ceiling) inside a single transaction, and matches `RETURNING` rows **by event_id** rather than by row order — with `ON CONFLICT` the returned rows are a subset of the input, so position in the result set means nothing. Conflicts are routed by constraint name from `PSQLException.getServerErrorMessage().getConstraint()`, not by matching message text
+- **Imported event ids must be UUIDs** (the `::uuid` cast); `importEvents` validates this up front to give a clear error rather than an opaque cast failure
+- **`timestamptz` keeps microseconds and rounds anything finer**, so a nanosecond-precision timestamp (as an in-memory store produces) lands up to half a microsecond away from where it started. This is the only lossy part of an inmem → Postgres → inmem round trip; `EventImportRoundTripTest` pins it down

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ Supports all features described described by the [DCB Specification](https://dcb
 Step-by-step introduction with the [quickstart guide](https://sliceworkz.github.io/posts/eventstore-quickstart/) or the [documentation](https://sliceworkz.github.io/categories/eventstore-documentation/)
 
 
+# Moving events between stores
+
+`EventStoreImporter` copies events from one storage backend into another, keeping each event's id,
+timestamp and idempotency key. Position and transaction are always reassigned by the target, so an
+import reproduces the source *order* but not its ordering numbers.
+
+```java
+ImportReport report = EventStoreImporter.from(sourceStorage).to(targetStorage).run();
+```
+
+It works below the serialization layer, so no domain classes are needed and legacy event types are not
+upcasted on the way through. A transformation can remap the stream, retag, or rewrite the payload —
+which also makes it a stream-cloning and schema-migration tool, with no fidelity guarantee beyond what
+the transformation asks for. See the javadoc on `org.sliceworkz.eventstore.migration` for the caveats
+that matter: an import is atomic per batch only, nothing is verified afterwards, and one importer
+should run at a time per target.
+
+
 # Other
 
 ## Contributing

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/migration/EventStoreImporter.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/migration/EventStoreImporter.java
@@ -1,0 +1,319 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.migration;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorage.ImportMode;
+import org.sliceworkz.eventstore.spi.EventStorage.QueryDirection;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.spi.EventToImport;
+
+/**
+ * Copies events from one {@link EventStorage} into another, preserving event identity, timestamps and
+ * idempotency keys.
+ * <p>
+ * The importer streams the source in batches, optionally passes each event through a transformation, and
+ * hands the result to {@link EventStorage#importEvents(List, ImportMode)}. It works purely at the storage
+ * level: payloads travel as opaque JSON, so no domain classes are needed on the classpath, no upcasting
+ * happens, and legacy event types arrive as legacy event types.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * ImportReport report = EventStoreImporter.from(sourceStorage).to(targetStorage)
+ *     .mode(ImportMode.SKIP_EXISTING_ID)
+ *     .transform(src -> Optional.of(EventToImport.from(src)
+ *                          .withStream(EventStreamId.forContext("archive").withPurpose(src.stream().purpose()))))
+ *     .batchSize(1000)
+ *     .onProgress(r -> LOGGER.info("import progress: {}", r))
+ *     .run();
+ * }</pre>
+ *
+ * <h2>What it does and does not guarantee</h2>
+ * <ul>
+ *   <li><b>Order is preserved, ordering numbers are not.</b> Events are read and written in source order,
+ *       but position and transaction are always assigned by the target.</li>
+ *   <li><b>Bounded at the source head.</b> The source's last event is captured before the first read and
+ *       every read is bounded by it, so the run covers a fixed range. Events appended to the source during
+ *       the run are excluded; a later run started {@link #after(EventReference)} that boundary picks them
+ *       up. This is also what makes it safe to import a store into itself.</li>
+ *   <li><b>Not atomic overall.</b> Each batch commits on its own. A failure part-way leaves the batches
+ *       already written in the target. Re-running with {@link ImportMode#SKIP_EXISTING_ID} continues from
+ *       whatever landed.</li>
+ *   <li><b>Nothing is verified.</b> {@link ImportMode#SKIP_EXISTING_ID} matches on identifier alone and no
+ *       payload is ever read back. If a migration needs to be proven faithful, that is a separate job.</li>
+ *   <li><b>One importer at a time per target.</b> The conflict check and the insert are not held under a
+ *       common lock, so concurrent runs against one target can produce spurious conflicts.</li>
+ * </ul>
+ *
+ * <h2>Checking a target up front</h2>
+ * There is no dry-run mode. An application that wants to know in advance whether a target already holds
+ * some of the events can look them up through the public API — but must do so in <em>raw</em> mode:
+ * <pre>{@code
+ * // raw: no event root classes registered, therefore no upcasting
+ * EventStream<?> probe = eventStore.getEventStream(EventStreamId.anyContext());
+ * boolean present = !probe.getEventById(id).isEmpty();
+ * }</pre>
+ * Registering domain classes would run the event through upcasting, and an event whose upcast yields no
+ * current events comes back as an empty list even though it exists — a false negative. Such a check is
+ * also only a snapshot: nothing stops the target changing before the import runs.
+ *
+ * @see EventStorage#importEvents(List, ImportMode)
+ * @see EventToImport
+ * @see ImportReport
+ */
+public final class EventStoreImporter {
+
+	/**
+	 * Events read, transformed and written per batch. Also the transaction granularity of the import,
+	 * since each batch is one {@link EventStorage#importEvents(List, ImportMode)} call.
+	 */
+	public static final int DEFAULT_BATCH_SIZE = 1000;
+
+	private final EventStorage source;
+	private EventStorage target;
+	private ImportMode mode = ImportMode.FAIL_ON_EXISTING_ID;
+	private EventReference after;
+	private Function<StoredEvent,Optional<EventToImport>> transform = storedEvent -> Optional.of(EventToImport.from(storedEvent));
+	private int batchSize = DEFAULT_BATCH_SIZE;
+	private Consumer<ImportReport> onProgress = report -> { };
+
+	private EventStoreImporter ( EventStorage source ) {
+		this.source = source;
+	}
+
+	/**
+	 * Starts configuring an import reading from the given storage.
+	 *
+	 * @param source the storage to read events from (required)
+	 * @return an importer to configure further
+	 * @throws IllegalArgumentException if source is null
+	 */
+	public static EventStoreImporter from ( EventStorage source ) {
+		if ( source == null ) {
+			throw new IllegalArgumentException("source storage is required");
+		}
+		return new EventStoreImporter(source);
+	}
+
+	/**
+	 * Sets the storage to write events into.
+	 * <p>
+	 * May be the same storage as the source, which — combined with a transformation that mints new
+	 * identifiers — clones events within one store.
+	 *
+	 * @param target the storage to import into (required)
+	 * @return this importer
+	 * @throws IllegalArgumentException if target is null
+	 */
+	public EventStoreImporter to ( EventStorage target ) {
+		if ( target == null ) {
+			throw new IllegalArgumentException("target storage is required");
+		}
+		this.target = target;
+		return this;
+	}
+
+	/**
+	 * Sets how the target should treat an event whose identifier it already holds.
+	 * <p>
+	 * Defaults to {@link ImportMode#FAIL_ON_EXISTING_ID}.
+	 *
+	 * @param mode the import mode (required)
+	 * @return this importer
+	 * @throws IllegalArgumentException if mode is null
+	 */
+	public EventStoreImporter mode ( ImportMode mode ) {
+		if ( mode == null ) {
+			throw new IllegalArgumentException("import mode is required");
+		}
+		this.mode = mode;
+		return this;
+	}
+
+	/**
+	 * Starts reading after the given source reference instead of at the beginning of the source.
+	 * <p>
+	 * Pass {@link ImportReport#sourceTo()} of an earlier run to import only what the source has
+	 * accumulated since. Null means start at the beginning.
+	 *
+	 * @param after the source reference to resume after, or null to start at the beginning
+	 * @return this importer
+	 */
+	public EventStoreImporter after ( EventReference after ) {
+		this.after = after;
+		return this;
+	}
+
+	/**
+	 * Sets the transformation applied to each source event on its way to the target.
+	 * <p>
+	 * Returning an empty {@link Optional} drops the event. The default keeps every event exactly as it is.
+	 * The transformation may rewrite anything {@link EventToImport} exposes — stream, tags, payload, type,
+	 * identifier, timestamp — so it doubles as a remapping and schema-migration hook.
+	 * <p>
+	 * Two consequences worth keeping in mind. Rewriting identifiers makes
+	 * {@link ImportMode#SKIP_EXISTING_ID} meaningless, since a re-run recognises nothing. And collapsing
+	 * several source streams onto one target stream can turn idempotency keys that were previously scoped
+	 * apart into a conflict.
+	 *
+	 * @param transform the transformation to apply (required)
+	 * @return this importer
+	 * @throws IllegalArgumentException if transform is null
+	 */
+	public EventStoreImporter transform ( Function<StoredEvent,Optional<EventToImport>> transform ) {
+		if ( transform == null ) {
+			throw new IllegalArgumentException("transform is required, omit the call to keep events unchanged");
+		}
+		this.transform = transform;
+		return this;
+	}
+
+	/**
+	 * Sets how many events are read, transformed and written per batch.
+	 * <p>
+	 * Also the transaction granularity: one batch is one import call on the target, and therefore the unit
+	 * that commits or rolls back together. Defaults to {@link #DEFAULT_BATCH_SIZE}.
+	 *
+	 * @param batchSize the batch size, must be greater than 0
+	 * @return this importer
+	 * @throws IllegalArgumentException if batchSize is not positive
+	 */
+	public EventStoreImporter batchSize ( int batchSize ) {
+		if ( batchSize <= 0 ) {
+			throw new IllegalArgumentException("batch size must be larger than 0");
+		}
+		this.batchSize = batchSize;
+		return this;
+	}
+
+	/**
+	 * Registers a callback invoked after every batch with a running total.
+	 * <p>
+	 * The only progress signal the importer offers: this module carries no logging dependency. The callback
+	 * runs on the importing thread, so it should stay cheap.
+	 *
+	 * @param onProgress the callback to invoke after each batch (required)
+	 * @return this importer
+	 * @throws IllegalArgumentException if onProgress is null
+	 */
+	public EventStoreImporter onProgress ( Consumer<ImportReport> onProgress ) {
+		if ( onProgress == null ) {
+			throw new IllegalArgumentException("progress callback is required, omit the call for no progress reporting");
+		}
+		this.onProgress = onProgress;
+		return this;
+	}
+
+	/**
+	 * Runs the import and returns what it did.
+	 *
+	 * @return the final report
+	 * @throws IllegalStateException if no target storage was configured
+	 * @throws org.sliceworkz.eventstore.spi.EventImportConflictException if the target already holds a conflicting event
+	 * @throws org.sliceworkz.eventstore.spi.EventStorageException if reading or writing fails
+	 * @throws UnsupportedOperationException if the target storage does not support importing
+	 */
+	public ImportReport run ( ) {
+		if ( target == null ) {
+			throw new IllegalStateException("no target storage configured, call to(...) before run()");
+		}
+
+		long startedAt = System.nanoTime();
+
+		// Fix the range before writing anything. Without this an import into its own source would keep
+		// finding the events it just wrote and never terminate.
+		EventReference boundary = headOf(source);
+		EventReference cursor = after;
+
+		long read = 0;
+		long dropped = 0;
+		long imported = 0;
+		long skipped = 0;
+		EventReference firstTargetReference = null;
+		EventReference lastTargetReference = null;
+
+		if ( boundary != null && ( cursor == null || cursor.happenedBefore(boundary) ) ) {
+
+			EventQuery pageQuery = EventQuery.matchAll().until(boundary);
+
+			while ( true ) {
+				List<StoredEvent> page = source.query(pageQuery, Optional.empty(), cursor, Limit.to(batchSize), QueryDirection.FORWARD).toList();
+				if ( page.isEmpty() ) {
+					break;
+				}
+				cursor = page.getLast().reference();
+				read += page.size();
+
+				List<EventToImport> batch = new ArrayList<>(page.size());
+				for ( StoredEvent storedEvent : page ) {
+					Optional<EventToImport> transformed = transform.apply(storedEvent);
+					if ( transformed == null || transformed.isEmpty() ) {
+						dropped++;
+					} else {
+						batch.add(transformed.get());
+					}
+				}
+
+				if ( !batch.isEmpty() ) {
+					List<StoredEvent> written = target.importEvents(batch, mode);
+					imported += written.size();
+					// under SKIP_EXISTING_ID the target returns only what it actually inserted
+					skipped += batch.size() - written.size();
+					if ( !written.isEmpty() ) {
+						if ( firstTargetReference == null ) {
+							firstTargetReference = written.getFirst().reference();
+						}
+						lastTargetReference = written.getLast().reference();
+					}
+				}
+
+				onProgress.accept(new ImportReport(read, dropped, imported, skipped, after, boundary, firstTargetReference, lastTargetReference, elapsedSince(startedAt)));
+			}
+		}
+
+		return new ImportReport(read, dropped, imported, skipped, after, boundary, firstTargetReference, lastTargetReference, elapsedSince(startedAt));
+	}
+
+	/**
+	 * Returns the reference of the last event in the storage, or null when it holds none.
+	 * <p>
+	 * Note the direction is passed explicitly: at the storage level a query's own direction is not
+	 * consulted, so {@link EventQuery#backwards()} alone would be ignored.
+	 */
+	private static EventReference headOf ( EventStorage storage ) {
+		return storage.query(EventQuery.matchAll(), Optional.empty(), null, Limit.to(1), QueryDirection.BACKWARD)
+				.findFirst()
+				.map(StoredEvent::reference)
+				.orElse(null);
+	}
+
+	private static Duration elapsedSince ( long startedAtNanos ) {
+		return Duration.ofNanos(System.nanoTime() - startedAtNanos);
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/migration/ImportReport.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/migration/ImportReport.java
@@ -1,0 +1,72 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.migration;
+
+import java.time.Duration;
+
+import org.sliceworkz.eventstore.events.EventReference;
+
+/**
+ * The outcome of an {@link EventStoreImporter} run.
+ * <p>
+ * Returned when the run completes, and handed to the progress callback after every batch as a running
+ * total. A report is never written anywhere by the importer — recording it is the application's choice.
+ *
+ * <h2>Resuming and catching up</h2>
+ * {@link #sourceTo()} is the boundary the run was bounded by: the source's head at the moment the run
+ * started. Events appended to the source afterwards are deliberately outside the run. Feeding that value
+ * into the next run picks up exactly where this one stopped:
+ * <pre>{@code
+ * ImportReport first = EventStoreImporter.from(source).to(target).run();
+ *
+ * // later, to bring across whatever the source has accumulated since
+ * ImportReport catchUp = EventStoreImporter.from(source).to(target)
+ *     .after(first.sourceTo())
+ *     .run();
+ * }</pre>
+ * Without {@link EventStoreImporter#after(EventReference)} a follow-up run rescans the source from the
+ * beginning, which is correct but costs a full pass.
+ *
+ * @param read number of source events read and offered to the transformation
+ * @param dropped number of events the transformation discarded
+ * @param imported number of events written into the target
+ * @param skipped number of events the target already held, under {@link org.sliceworkz.eventstore.spi.EventStorage.ImportMode#SKIP_EXISTING_ID}
+ * @param sourceFrom the cursor the run started after, or null if it started at the beginning of the source
+ * @param sourceTo the source head the run was bounded by, or null if the source held no events
+ * @param firstTargetReference the reference the first imported event received in the target, or null if nothing was imported
+ * @param lastTargetReference the reference the last imported event received in the target, or null if nothing was imported
+ * @param duration wall-clock time elapsed so far
+ * @see EventStoreImporter
+ */
+public record ImportReport ( long read, long dropped, long imported, long skipped,
+		EventReference sourceFrom, EventReference sourceTo,
+		EventReference firstTargetReference, EventReference lastTargetReference,
+		Duration duration ) {
+
+	/**
+	 * Returns a human-readable one-line summary, handy for a progress callback that just logs.
+	 *
+	 * @return a summary of the counters and the source boundary
+	 */
+	@Override
+	public String toString ( ) {
+		return "read=%d dropped=%d imported=%d skipped=%d sourceFrom=%s sourceTo=%s duration=%s"
+				.formatted(read, dropped, imported, skipped, sourceFrom, sourceTo, duration);
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/migration/package-info.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/migration/package-info.java
@@ -1,0 +1,54 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Moving events between event stores.
+ * <p>
+ * This package holds {@link org.sliceworkz.eventstore.migration.EventStoreImporter}, which copies events
+ * from one {@link org.sliceworkz.eventstore.spi.EventStorage} into another while preserving each event's
+ * identity, timestamp and idempotency key. Position and transaction are always reassigned by the target:
+ * an import reproduces the source <em>order</em>, never the source ordering numbers.
+ *
+ * <h2>Why it works at the storage level</h2>
+ * The importer reads {@link org.sliceworkz.eventstore.spi.EventStorage.StoredEvent}s and writes
+ * {@link org.sliceworkz.eventstore.spi.EventToImport}s, so payloads move as opaque JSON. That means no
+ * domain classes on the classpath, no serialization round-trip, no upcasting, and no re-splitting of
+ * erasable data against annotations that may since have changed. Going through
+ * {@link org.sliceworkz.eventstore.stream.EventStream} instead would rewrite legacy events into current
+ * ones and lose the idempotency key, which the public {@link org.sliceworkz.eventstore.events.Event}
+ * record does not carry.
+ *
+ * <h2>This is a rewriting tool</h2>
+ * The import transformation may change the stream, the tags, the payload, the type, the identifier and
+ * the timestamp. That supports stream remapping, tenant splits, schema migration and cloning — and it
+ * means the importer offers no fidelity guarantee of its own. What arrives in the target is whatever the
+ * transformation asked for. Nothing is verified afterwards.
+ *
+ * <h2>Common uses</h2>
+ * <ul>
+ *   <li><b>Migrating a store</b> — read every event from one backend, write it into another, unchanged</li>
+ *   <li><b>Catching up</b> — a follow-up run started after the previous run's boundary brings across
+ *       whatever the source accumulated since</li>
+ *   <li><b>Remapping</b> — import a source stream into a differently named context or purpose</li>
+ *   <li><b>Cloning</b> — import a store into itself with fresh identifiers to duplicate a stream</li>
+ * </ul>
+ *
+ * @see org.sliceworkz.eventstore.migration.EventStoreImporter
+ * @see org.sliceworkz.eventstore.migration.ImportReport
+ * @see org.sliceworkz.eventstore.spi.EventToImport
+ */
+package org.sliceworkz.eventstore.migration;

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventImportConflictException.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventImportConflictException.java
@@ -1,0 +1,140 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.spi;
+
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+/**
+ * Thrown when an import cannot proceed because the target storage already holds a conflicting event.
+ * <p>
+ * Two distinct conflicts are reported through this exception, distinguished by {@link #kind()}:
+ * <ul>
+ *   <li>{@link Kind#DUPLICATE_EVENT_ID} — an event with the same {@link EventId} already exists. Raised in
+ *       {@link EventStorage.ImportMode#FAIL_ON_EXISTING_ID}; under
+ *       {@link EventStorage.ImportMode#SKIP_EXISTING_ID} such an event is skipped instead.</li>
+ *   <li>{@link Kind#DUPLICATE_IDEMPOTENCY_KEY} — a <em>different</em> event already holds this idempotency key
+ *       on the same stream. Always fatal, in both modes: skipping past it would discard an event that the
+ *       target has never seen.</li>
+ * </ul>
+ * <p>
+ * The batch that raised this exception is rolled back in full. Batches committed before it are not — an
+ * import is atomic per batch, not overall. Re-running under {@link EventStorage.ImportMode#SKIP_EXISTING_ID}
+ * is the supported way to continue after resolving the conflict.
+ *
+ * @see EventStorage#importEvents(java.util.List, EventStorage.ImportMode)
+ */
+public class EventImportConflictException extends EventStorageException {
+
+	private final Kind kind;
+	private final EventId eventId;
+	private final EventStreamId stream;
+	private final String idempotencyKey;
+
+	/**
+	 * The nature of the conflict that stopped the import.
+	 */
+	public enum Kind {
+		/** An event with the same identifier already exists in the target storage. */
+		DUPLICATE_EVENT_ID,
+		/** A different event already holds this idempotency key on the same stream. */
+		DUPLICATE_IDEMPOTENCY_KEY
+	}
+
+	/**
+	 * Constructs a conflict for an event identifier that already exists in the target.
+	 *
+	 * @param eventId the conflicting event identifier, or null if the backend could not determine it
+	 * @param cause the underlying storage exception, or null
+	 * @return a new EventImportConflictException of kind {@link Kind#DUPLICATE_EVENT_ID}
+	 */
+	public static EventImportConflictException duplicateEventId ( EventId eventId, Throwable cause ) {
+		return new EventImportConflictException(
+				Kind.DUPLICATE_EVENT_ID,
+				eventId,
+				null,
+				null,
+				"an event with id %s already exists in the target storage".formatted(eventId == null ? "<unknown>" : eventId.value()),
+				cause);
+	}
+
+	/**
+	 * Constructs a conflict for an idempotency key already in use on the target stream.
+	 *
+	 * @param stream the stream the key collides on, or null if the backend could not determine it
+	 * @param idempotencyKey the conflicting idempotency key, or null if the backend could not determine it
+	 * @param cause the underlying storage exception, or null
+	 * @return a new EventImportConflictException of kind {@link Kind#DUPLICATE_IDEMPOTENCY_KEY}
+	 */
+	public static EventImportConflictException duplicateIdempotencyKey ( EventStreamId stream, String idempotencyKey, Throwable cause ) {
+		return new EventImportConflictException(
+				Kind.DUPLICATE_IDEMPOTENCY_KEY,
+				null,
+				stream,
+				idempotencyKey,
+				"idempotency key %s is already in use on stream %s by a different event".formatted(
+						idempotencyKey == null ? "<unknown>" : idempotencyKey,
+						stream == null ? "<unknown>" : stream.toString()),
+				cause);
+	}
+
+	private EventImportConflictException ( Kind kind, EventId eventId, EventStreamId stream, String idempotencyKey, String message, Throwable cause ) {
+		super(message, cause);
+		this.kind = kind;
+		this.eventId = eventId;
+		this.stream = stream;
+		this.idempotencyKey = idempotencyKey;
+	}
+
+	/**
+	 * Returns what kind of conflict stopped the import.
+	 *
+	 * @return the conflict kind, never null
+	 */
+	public Kind kind ( ) {
+		return kind;
+	}
+
+	/**
+	 * Returns the conflicting event identifier for a {@link Kind#DUPLICATE_EVENT_ID} conflict.
+	 *
+	 * @return the event identifier, or null for other kinds or when the backend could not determine it
+	 */
+	public EventId eventId ( ) {
+		return eventId;
+	}
+
+	/**
+	 * Returns the stream a {@link Kind#DUPLICATE_IDEMPOTENCY_KEY} conflict occurred on.
+	 *
+	 * @return the stream, or null for other kinds or when the backend could not determine it
+	 */
+	public EventStreamId stream ( ) {
+		return stream;
+	}
+
+	/**
+	 * Returns the conflicting idempotency key for a {@link Kind#DUPLICATE_IDEMPOTENCY_KEY} conflict.
+	 *
+	 * @return the idempotency key, or null for other kinds or when the backend could not determine it
+	 */
+	public String idempotencyKey ( ) {
+		return idempotencyKey;
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -225,6 +225,50 @@ public interface EventStorage {
 	List<StoredEvent> append ( AppendCriteria appendCriteria, Optional<EventStreamId> stream, List<EventToStore> events );
 
 	/**
+	 * Imports events into storage, preserving their identity, timestamp and idempotency key.
+	 * <p>
+	 * This is the write path used to move events between storage backends. It is deliberately <em>not</em>
+	 * {@link #append(AppendCriteria, Optional, List)}: an import performs no optimistic locking, accepts a
+	 * caller-supplied {@link EventId} and timestamp, and may span multiple streams in a single call.
+	 * <p>
+	 * What is preserved and what is not:
+	 * <ul>
+	 *   <li><b>Preserved</b> — event id, timestamp, idempotency key, type, tags, immutable and erasable payloads</li>
+	 *   <li><b>Reassigned</b> — position and transaction, which are always allocated by this storage. An import
+	 *       reproduces the source <em>order</em>, never the source ordering numbers. Events are inserted in
+	 *       list order.</li>
+	 * </ul>
+	 * <p>
+	 * Conflict handling depends on {@code mode}. In either mode an idempotency key already used by a different
+	 * event on the same stream is fatal — skipping it would silently discard an event the target has never seen.
+	 * <p>
+	 * <b>Atomicity:</b> a single call is all-or-nothing. A caller importing more events than fit in one call
+	 * gets atomicity per call only; a failure part-way through a sequence of calls leaves the earlier calls
+	 * committed. {@link ImportMode#SKIP_EXISTING_ID} is the supported way to resume such an import.
+	 * <p>
+	 * <b>Concurrency:</b> implementations check the target and insert without holding a lock across both steps.
+	 * Two imports running concurrently against one storage can produce spurious conflicts; run one at a time.
+	 * <p>
+	 * Implementations must reject the batch with {@link IllegalArgumentException} if it contains two events
+	 * sharing an {@link EventId}, and with {@link EventStorageException} if a payload is not valid JSON.
+	 * Listeners are notified of imported events exactly as they are for appended ones.
+	 *
+	 * @param events the events to import, in the order they should be inserted (must not be null)
+	 * @param mode how to treat an event whose id already exists in this storage (must not be null)
+	 * @return the imported events with their preserved ids and newly assigned references; under
+	 *         {@link ImportMode#SKIP_EXISTING_ID} this excludes skipped events, so the caller can derive
+	 *         what was skipped by difference
+	 * @throws EventImportConflictException if the import conflicts with what the target already holds
+	 * @throws EventStorageException if an error occurs during the import
+	 * @throws UnsupportedOperationException if this storage implementation does not support importing
+	 * @see EventToImport
+	 * @see ImportMode
+	 */
+	default List<StoredEvent> importEvents ( List<EventToImport> events, ImportMode mode ) {
+		throw new UnsupportedOperationException("%s does not support importing events".formatted(name()));
+	}
+
+	/**
 	 * Retrieves a specific event by its unique identifier.
 	 * <p>
 	 * This method provides direct access to an event using its {@link EventId}.
@@ -277,6 +321,38 @@ public interface EventStorage {
 		 * Useful for retrieving recent events or working backwards through history.
 		 */
 		BACKWARD
+	}
+
+	/**
+	 * Controls how {@link #importEvents(List, ImportMode)} treats an event whose identifier already
+	 * exists in the target storage.
+	 * <p>
+	 * Neither mode affects idempotency key conflicts: a key already used by a different event on the same
+	 * stream is always fatal.
+	 *
+	 * @see #importEvents(List, ImportMode)
+	 */
+	enum ImportMode {
+
+		/**
+		 * Abort the batch if any event's identifier already exists in the target.
+		 * <p>
+		 * The strict default. Appropriate when the target is known to be free of the events being imported,
+		 * and the safer choice when an unexpected overlap should stop the operation rather than be absorbed.
+		 * Note that a conflict rolls back only the batch that hit it: batches already committed remain.
+		 */
+		FAIL_ON_EXISTING_ID,
+
+		/**
+		 * Skip any event whose identifier already exists in the target, and import the rest.
+		 * <p>
+		 * The resume mode: re-running an interrupted import passes over what already landed and continues
+		 * with what did not. Matching is on identifier alone — the payload already in the target is neither
+		 * read nor compared, so this mode assumes an id identifies the same event. It offers no protection
+		 * against a target whose events were altered after being imported, and it is meaningless if the
+		 * import mints new identifiers, since nothing stable remains to match on.
+		 */
+		SKIP_EXISTING_ID
 	}
 
 	/**

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventToImport.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventToImport.java
@@ -1,0 +1,255 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.spi;
+
+import java.time.LocalDateTime;
+
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+/**
+ * An event offered to {@link EventStorage#importEvents(java.util.List, EventStorage.ImportMode)} for
+ * identity-preserving insertion into a storage backend.
+ * <p>
+ * This is a {@link StoredEvent} minus {@code position}, {@code tx} and {@code index}: exactly the fields
+ * a caller controls. Position and transaction are always assigned by the target storage — an import never
+ * reproduces the source ordering numbers, only the source <em>order</em>. The record shape makes that
+ * explicit, so a caller cannot hand-set a position that would be silently ignored.
+ * <p>
+ * What <em>is</em> preserved, because it is carried on this record:
+ * <ul>
+ *   <li>{@link #id()} — the event's globally unique {@link EventId}</li>
+ *   <li>{@link #timestamp()} — the moment the event was originally stored</li>
+ *   <li>{@link #idempotencyKey()} — the key the event was originally appended with</li>
+ * </ul>
+ *
+ * <h2>Import versus append</h2>
+ * Importing bypasses {@link EventStorage#append(org.sliceworkz.eventstore.stream.AppendCriteria, java.util.Optional, java.util.List)}
+ * entirely: no optimistic locking, no serialization, no upcasting, no re-splitting of erasable data.
+ * The payload moves as opaque JSON, so an import needs no domain classes on the classpath and legacy
+ * event types survive as legacy event types.
+ *
+ * <h2>Rewriting during import</h2>
+ * Every field has a wither, so an import transformation may remap the stream, retag, rewrite the payload,
+ * change the type, mint a new {@link EventId} or restamp the timestamp. That flexibility is deliberate —
+ * it supports stream cloning and schema migration — but it means this type offers <em>no</em> fidelity
+ * guarantee of its own. What arrives in the target is whatever the caller asked for.
+ * <p>
+ * Two rewrites deserve particular care:
+ * <ul>
+ *   <li><b>Rewriting the id</b> makes {@link EventStorage.ImportMode#SKIP_EXISTING_ID} meaningless: there is
+ *       no stable identity left to recognise, so a re-run imports everything a second time.</li>
+ *   <li><b>Keeping the idempotency key while rewriting the id</b> (for instance when cloning a stream) carries
+ *       a key that was minted to deduplicate a different stream. A later legitimate append reusing that key
+ *       against the clone will be silently swallowed.</li>
+ * </ul>
+ *
+ * <h2>Constructing from scratch</h2>
+ * The canonical constructor is public, so this record can also be used to write synthetic events — with a
+ * chosen id and timestamp — directly into a storage backend. That is useful for fixtures and backfills, but
+ * note it bypasses {@code append()} and therefore every guarantee that path provides.
+ *
+ * @param stream the event stream the event belongs to (required)
+ * @param type the event type name (required)
+ * @param id the globally unique event identifier to persist (required)
+ * @param immutableData serialized event data that must be retained permanently (required, must be valid JSON)
+ * @param erasableData serialized event data that may be erased for privacy compliance (optional, may be null)
+ * @param tags key-value pairs for dynamic event retrieval and consistency boundaries (required, use {@link Tags#none()})
+ * @param timestamp the moment the event was stored, always in UTC (required)
+ * @param idempotencyKey the idempotency key to persist, or {@code null} for none
+ * @see EventStorage#importEvents(java.util.List, EventStorage.ImportMode)
+ * @see StoredEvent
+ */
+public record EventToImport ( EventStreamId stream, EventType type, EventId id, String immutableData, String erasableData, Tags tags, LocalDateTime timestamp, String idempotencyKey ) {
+
+	/**
+	 * Constructs an EventToImport, validating everything the storage backends require.
+	 * <p>
+	 * The timestamp is required even though the underlying column is nullable: binding a null timestamp
+	 * overrides the column default rather than falling back to it, and a stored null cannot be read back.
+	 * <p>
+	 * {@code immutableData} is checked for presence only. Whether it is well-formed JSON is enforced by the
+	 * storage backend, since this module carries no JSON parser.
+	 *
+	 * @param stream the event stream (required)
+	 * @param type the event type (required)
+	 * @param id the event identifier (required)
+	 * @param immutableData the immutable payload (required)
+	 * @param erasableData the erasable payload (optional)
+	 * @param tags the tags (required, use {@link Tags#none()} if none)
+	 * @param timestamp the storage timestamp in UTC (required)
+	 * @param idempotencyKey the idempotency key (optional)
+	 * @throws IllegalArgumentException if a required field is null or blank
+	 */
+	public EventToImport {
+		if ( stream == null ) {
+			throw new IllegalArgumentException("stream is required on an event to import");
+		}
+		if ( type == null || type.name() == null || type.name().isBlank() ) {
+			throw new IllegalArgumentException("type is required on an event to import");
+		}
+		if ( id == null ) {
+			throw new IllegalArgumentException("id is required on an event to import: an import preserves event identity");
+		}
+		if ( immutableData == null ) {
+			throw new IllegalArgumentException("immutableData is required on an event to import");
+		}
+		if ( tags == null ) {
+			throw new IllegalArgumentException("tags is required on an event to import, use Tags.none() if there are none");
+		}
+		if ( timestamp == null ) {
+			throw new IllegalArgumentException("timestamp is required on an event to import: a null timestamp cannot be persisted or read back");
+		}
+	}
+
+	/**
+	 * Creates an EventToImport carrying everything the stored event holds except its position and transaction.
+	 * <p>
+	 * This is the starting point for an import transformation: take the source event, adjust what needs
+	 * adjusting via the withers, and hand the result to the target storage.
+	 *
+	 * @param storedEvent the event as read from the source storage (required)
+	 * @return an EventToImport preserving the stored event's id, timestamp, payload, tags and idempotency key
+	 * @throws IllegalArgumentException if the stored event is null or is missing a required field
+	 */
+	public static EventToImport from ( StoredEvent storedEvent ) {
+		if ( storedEvent == null ) {
+			throw new IllegalArgumentException("storedEvent is required");
+		}
+		return new EventToImport(
+				storedEvent.stream(),
+				storedEvent.type(),
+				storedEvent.reference() == null ? null : storedEvent.reference().id(),
+				storedEvent.immutableData(),
+				storedEvent.erasableData(),
+				storedEvent.tags(),
+				storedEvent.timestamp(),
+				storedEvent.idempotencyKey());
+	}
+
+	/**
+	 * Converts this event into a {@link StoredEvent} by pairing its preserved id with the position and
+	 * transaction the target storage assigned.
+	 * <p>
+	 * Called by storage implementations once an import statement has committed. Mirrors
+	 * {@link EventStorage.EventToStore#positionAt(EventReference, LocalDateTime)}, except the timestamp comes
+	 * from the imported event rather than from the storage clock.
+	 *
+	 * @param position the position assigned by the target storage
+	 * @param tx the transaction assigned by the target storage
+	 * @return a StoredEvent with the preserved identity and the newly assigned reference
+	 */
+	public StoredEvent positionAt ( long position, long tx ) {
+		return new StoredEvent(stream, type, EventReference.of(id, position, tx), immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event targeting a different event stream.
+	 * <p>
+	 * The primary remapping operation: import a source stream into a differently named context or purpose.
+	 * Remember that idempotency keys are scoped per stream, so collapsing two source streams onto one target
+	 * stream can turn previously disjoint keys into a conflict.
+	 *
+	 * @param stream the event stream to import into
+	 * @return a new EventToImport for the specified stream
+	 */
+	public EventToImport withStream ( EventStreamId stream ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with a different event type name.
+	 *
+	 * @param type the event type to store
+	 * @return a new EventToImport with the specified type
+	 */
+	public EventToImport withType ( EventType type ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with a different event identifier.
+	 * <p>
+	 * Use this to clone a stream into a new set of events rather than move it. Doing so forfeits
+	 * {@link EventStorage.ImportMode#SKIP_EXISTING_ID}, which has nothing stable left to match on.
+	 *
+	 * @param id the event identifier to store
+	 * @return a new EventToImport with the specified id
+	 */
+	public EventToImport withId ( EventId id ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with a different immutable payload.
+	 *
+	 * @param immutableData the JSON payload to store as immutable data
+	 * @return a new EventToImport with the specified immutable payload
+	 */
+	public EventToImport withImmutableData ( String immutableData ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with a different erasable payload.
+	 *
+	 * @param erasableData the JSON payload to store as erasable data, or null for none
+	 * @return a new EventToImport with the specified erasable payload
+	 */
+	public EventToImport withErasableData ( String erasableData ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with different tags.
+	 *
+	 * @param tags the tags to attach
+	 * @return a new EventToImport with the specified tags
+	 */
+	public EventToImport withTags ( Tags tags ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with a different timestamp.
+	 * <p>
+	 * Preserving the original timestamp is the default and usually the right choice — it is part of the fact.
+	 * Restamping is available for cases where the imported event is genuinely a new fact, such as a clone.
+	 *
+	 * @param timestamp the timestamp to store, in UTC
+	 * @return a new EventToImport with the specified timestamp
+	 */
+	public EventToImport withTimestamp ( LocalDateTime timestamp ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+	/**
+	 * Creates a copy of this event with a different idempotency key.
+	 *
+	 * @param idempotencyKey the idempotency key to store, or null for none
+	 * @return a new EventToImport with the specified idempotency key
+	 */
+	public EventToImport withIdempotencyKey ( String idempotencyKey ) {
+		return new EventToImport(stream, type, id, immutableData, erasableData, tags, timestamp, idempotencyKey);
+	}
+
+}

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -41,6 +41,7 @@ import org.sliceworkz.eventstore.serialization.json.JsonBookmarkCodec;
 import org.sliceworkz.eventstore.serialization.json.JsonEventCodec;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.spi.EventStorageException;
+import org.sliceworkz.eventstore.spi.EventToImport;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStreamId;
 
@@ -109,6 +110,16 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 			persistEvent(event);
 		}
 		return stored;
+	}
+
+	@Override
+	public List<StoredEvent> importEvents ( List<EventToImport> events, ImportMode mode ) {
+		// must persist alongside the delegate, otherwise imported events live only until the next restart
+		List<StoredEvent> imported = delegate.importEvents(events, mode);
+		for ( StoredEvent event : imported ) {
+			persistEvent(event);
+		}
+		return imported;
 	}
 
 	@Override

--- a/sliceworkz-eventstore-infra-inmem-fs/src/test/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImplTest.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/test/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImplTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -238,6 +239,38 @@ public class InMemoryFsEventStorageImplTest {
 		TestEvent data = events.get(0).data();
 		assertTrue(data instanceof TestEvent.CustomerRegistered);
 		assertEquals("John Doe", ((TestEvent.CustomerRegistered) data).name());
+	}
+
+	@Test
+	void testIdempotencyKeyIsStillKnownAfterAReload ( @TempDir Path tempDir ) {
+		EventStreamId streamId = EventStreamId.forContext("ctx").withPurpose("p");
+
+		// First instance: append an event carrying an idempotency key
+		{
+			EventStore store = InMemoryFsEventStorage.newBuilder()
+					.directory(tempDir)
+					.name("idempotency-test")
+					.buildStore();
+
+			EventStream<TestEvent> stream = store.getEventStream(streamId, TestEvent.class);
+			List<Event<TestEvent>> appended = stream.append(AppendCriteria.none(),
+					Collections.singletonList(Event.of(new TestEvent.CustomerRegistered("John"), Tags.none()).withIdempotencyKey("k-1")));
+			assertEquals(1, appended.size());
+		}
+
+		// Second instance: the reloaded store restores its event log from disk, and must restore what it
+		// knows about idempotency along with it — otherwise a retry after a restart writes a duplicate
+		EventStore store2 = InMemoryFsEventStorage.newBuilder()
+				.directory(tempDir)
+				.name("idempotency-test-2")
+				.buildStore();
+
+		EventStream<TestEvent> stream2 = store2.getEventStream(streamId, TestEvent.class);
+		List<Event<TestEvent>> duplicate = stream2.append(AppendCriteria.none(),
+				Collections.singletonList(Event.of(new TestEvent.CustomerRegistered("John"), Tags.none()).withIdempotencyKey("k-1")));
+
+		assertTrue(duplicate.isEmpty(), "an idempotency key used before the reload must still deduplicate");
+		assertEquals(1, stream2.query(EventQuery.matchAll()).toList().size());
 	}
 
 }

--- a/sliceworkz-eventstore-infra-inmem-fs/src/test/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImplTest.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/test/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImplTest.java
@@ -24,8 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -33,10 +35,15 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.EventStoreFactory;
 import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorage.ImportMode;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.spi.EventToImport;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStream;
 import org.sliceworkz.eventstore.stream.EventStreamId;
@@ -271,6 +278,37 @@ public class InMemoryFsEventStorageImplTest {
 
 		assertTrue(duplicate.isEmpty(), "an idempotency key used before the reload must still deduplicate");
 		assertEquals(1, stream2.query(EventQuery.matchAll()).toList().size());
+	}
+
+	@Test
+	void testImportedEventsArePersisted ( @TempDir Path tempDir ) {
+		EventStreamId streamId = EventStreamId.forContext("ctx").withPurpose("p");
+		EventId id = EventId.create();
+		LocalDateTime timestamp = LocalDateTime.of(2020, 1, 2, 3, 4, 5);
+
+		// First instance: import an event straight into storage
+		{
+			EventStorage storage = InMemoryFsEventStorage.newBuilder()
+					.directory(tempDir)
+					.name("import-test")
+					.build();
+
+			storage.importEvents(
+					List.of(new EventToImport(streamId, EventType.ofType("CustomerRegistered"), id,
+							"{\"name\":\"John\"}", null, Tags.of("customer", "42"), timestamp, "imported-key")),
+					ImportMode.FAIL_ON_EXISTING_ID);
+		}
+
+		// Second instance: imports must reach disk like appends do, not live only in memory
+		EventStorage reloaded = InMemoryFsEventStorage.newBuilder()
+				.directory(tempDir)
+				.name("import-test-2")
+				.build();
+
+		Optional<StoredEvent> found = reloaded.getEventById(id);
+		assertTrue(found.isPresent(), "an imported event must survive a restart");
+		assertEquals(timestamp, found.get().timestamp());
+		assertEquals("imported-key", found.get().idempotencyKey());
 	}
 
 }

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -102,6 +102,9 @@ public class InMemoryEventStorageImpl implements EventStorage {
 
 	private String name;
 	private List<StoredEvent> eventlog = new CopyOnWriteArrayList<>();
+	// Lookup index by event id, kept in step with the event log. Backs getEventById in constant time
+	// rather than a linear scan, which matters for imports resolving one id per event.
+	private Map<EventId,StoredEvent> eventsById = new HashMap<>();
 	// Idempotency dedup is scoped to the logical event stream (context + purpose), matching the
 	// Postgres backend's per-stream partial unique index, so the same key on two different streams
 	// does not collide and behaviour does not depend on how storage instances are wired at runtime.
@@ -153,6 +156,20 @@ public class InMemoryEventStorageImpl implements EventStorage {
 				.mapToLong(e -> e.reference().tx())
 				.max()
 				.orElse(0);
+
+		// Seed the derived state from the preloaded events. Without this the idempotency keys of
+		// preloaded events are unknown to the store, so a reloaded store (see the filesystem-backed
+		// storage, which restores its whole event log this way) would append a duplicate for a key it
+		// had already seen instead of deduplicating it.
+		for ( StoredEvent event : initialEvents ) {
+			EventId id = event.reference().id();
+			if ( eventsById.putIfAbsent(id, event) != null ) {
+				throw new IllegalArgumentException("initial events contain more than one event with id %s".formatted(id.value()));
+			}
+			if ( event.idempotencyKey() != null ) {
+				idempotencyKeys.add(new IdempotencyScope(event.stream(), event.idempotencyKey()));
+			}
+		}
 	}
 
 	/**
@@ -294,9 +311,15 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	private List<StoredEvent> addAndNotifyListeners ( List<EventToStore> events ) {
 		long tx = ++txCounter;
 		var addedEvents = events.stream().map(e -> addEventToEventLog(e, tx)).filter(e->e!=null).toList();
-		
-		// notify each Listener about the appends, but if multiple Events were appended, only notify about the last one
-		addedEvents.stream()
+
+		notifyListenersAbout(addedEvents);
+
+		return addedEvents;
+	}
+
+	private void notifyListenersAbout ( List<StoredEvent> storedEvents ) {
+		// notify each Listener about the writes, but if multiple Events landed in one stream, only notify about the last one
+		storedEvents.stream()
 			    .collect(Collectors.toMap(
 			        StoredEvent::stream,
 			        event -> new AppendsToEventStoreNotification(event.stream(), event.reference()),
@@ -308,8 +331,6 @@ public class InMemoryEventStorageImpl implements EventStorage {
 			    		listener.get().notify(notification);
 			    	};
 			    }));
-		
-		return addedEvents;
 	}
 	
 	private StoredEvent addEventToEventLog ( EventToStore event, long tx ) {
@@ -326,12 +347,13 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		EventReference reference = EventReference.create(position, tx);
 		StoredEvent storedEvent = event.positionAt(reference, LocalDateTime.now(ZoneOffset.UTC));
 		eventlog.add(storedEvent);
+		eventsById.put(reference.id(), storedEvent);
 		return storedEvent;
 	}
 
 	@Override
-	public Optional<StoredEvent> getEventById(EventId eventId) {
-		return eventlog.stream().filter(e->e.reference().id().equals(eventId)).findFirst();
+	public synchronized Optional<StoredEvent> getEventById(EventId eventId) {
+		return Optional.ofNullable(eventsById.get(eventId));
 	}
 
 	@Override

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -40,8 +40,10 @@ import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventImportConflictException;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.spi.EventStorageException;
+import org.sliceworkz.eventstore.spi.EventToImport;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStreamId;
 import org.sliceworkz.eventstore.stream.OptimisticLockingException;
@@ -349,6 +351,92 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		eventlog.add(storedEvent);
 		eventsById.put(reference.id(), storedEvent);
 		return storedEvent;
+	}
+
+	/*
+	 *  Synchronized method, so the conflict check and the insertion are one atomic step, and so a rejected
+	 *  batch leaves the event log untouched.
+	 */
+	@Override
+	public synchronized List<StoredEvent> importEvents ( List<EventToImport> events, ImportMode mode ) {
+		if ( events == null ) {
+			throw new IllegalArgumentException("events to import must not be null");
+		}
+		if ( mode == null ) {
+			throw new IllegalArgumentException("import mode must not be null");
+		}
+		if ( events.isEmpty() ) {
+			return Collections.emptyList();
+		}
+
+		// Validate the whole batch before touching any state, so an import either lands completely or not at all
+		Set<EventId> idsInBatch = new HashSet<>();
+		Set<IdempotencyScope> keysInBatch = new HashSet<>();
+		List<EventToImport> toInsert = new ArrayList<>(events.size());
+
+		for ( EventToImport event : events ) {
+
+			if ( !idsInBatch.add(event.id()) ) {
+				throw new IllegalArgumentException("batch to import holds more than one event with id %s".formatted(event.id().value()));
+			}
+
+			verifyImportableJson(event);
+
+			if ( eventsById.containsKey(event.id()) ) {
+				if ( mode == ImportMode.SKIP_EXISTING_ID ) {
+					continue; // already present: skip it, and with it whatever idempotency key it carries
+				}
+				throw EventImportConflictException.duplicateEventId(event.id(), null);
+			}
+
+			if ( event.idempotencyKey() != null ) {
+				IdempotencyScope scope = new IdempotencyScope(event.stream(), event.idempotencyKey());
+				if ( idempotencyKeys.contains(scope) || !keysInBatch.add(scope) ) {
+					throw EventImportConflictException.duplicateIdempotencyKey(event.stream(), event.idempotencyKey(), null);
+				}
+			}
+
+			toInsert.add(event);
+		}
+
+		if ( toInsert.isEmpty() ) {
+			return Collections.emptyList();
+		}
+
+		// One transaction per call, mirroring how a batch of appended events shares a transaction
+		long tx = ++txCounter;
+		List<StoredEvent> imported = new ArrayList<>(toInsert.size());
+		for ( EventToImport event : toInsert ) {
+			// position and tx are assigned here; the id and timestamp travel with the imported event
+			StoredEvent storedEvent = event.positionAt(eventlog.size() + 1, tx);
+			eventlog.add(storedEvent);
+			eventsById.put(storedEvent.reference().id(), storedEvent);
+			if ( event.idempotencyKey() != null ) {
+				idempotencyKeys.add(new IdempotencyScope(event.stream(), event.idempotencyKey()));
+			}
+			imported.add(storedEvent);
+		}
+
+		notifyListenersAbout(imported);
+
+		return imported;
+	}
+
+	/**
+	 * Rejects payloads the Postgres backend would refuse on its {@code ::jsonb} cast, so both backends
+	 * accept exactly the same imports.
+	 */
+	private void verifyImportableJson ( EventToImport event ) {
+		try {
+			if ( jsonMapper.readTree(event.immutableData()).isMissingNode() ) {
+				throw new EventStorageException("event %s to import carries an empty immutable payload".formatted(event.id().value()));
+			}
+			if ( event.erasableData() != null && jsonMapper.readTree(event.erasableData()).isMissingNode() ) {
+				throw new EventStorageException("event %s to import carries an empty erasable payload".formatted(event.id().value()));
+			}
+		} catch (JacksonException e) {
+			throw new EventStorageException("event %s to import does not carry valid JSON".formatted(event.id().value()), e);
+		}
 	}
 
 	@Override

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -29,14 +29,23 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -47,6 +56,7 @@ import javax.sql.DataSource;
 
 import org.postgresql.PGConnection;
 import org.postgresql.PGNotification;
+import org.postgresql.util.PSQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sliceworkz.eventstore.events.Bookmark;
@@ -59,8 +69,10 @@ import org.sliceworkz.eventstore.query.EventFilter;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.EventFilterItem;
 import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventImportConflictException;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.spi.EventStorageException;
+import org.sliceworkz.eventstore.spi.EventToImport;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStreamId;
 import org.sliceworkz.eventstore.stream.OptimisticLockingException;
@@ -875,6 +887,224 @@ public class PostgresEventStorageImpl implements EventStorage {
 		
 		return storedEvents;
 			
+	}
+
+	/**
+	 * Number of events bound into a single INSERT statement.
+	 * <p>
+	 * Bounded by the wire protocol: each row binds 9 parameters against a hard ceiling of 65535 per
+	 * statement, so roughly 7200 rows would fit. 5000 leaves headroom. This is a <em>statement</em>
+	 * boundary only — every statement of one {@code importEvents} call runs in the same transaction,
+	 * so the call stays all-or-nothing however many chunks it takes.
+	 */
+	private static final int IMPORT_CHUNK_SIZE = 5000;
+
+	/** Matches the parenthesised value list Postgres reports in the DETAIL of a unique violation. */
+	private static final Pattern CONFLICT_DETAIL_VALUES = Pattern.compile("\\)=\\((.*)\\) already exists", Pattern.DOTALL);
+
+	@Override
+	public List<StoredEvent> importEvents ( List<EventToImport> events, ImportMode mode ) {
+		if ( events == null ) {
+			throw new IllegalArgumentException("events to import must not be null");
+		}
+		if ( mode == null ) {
+			throw new IllegalArgumentException("import mode must not be null");
+		}
+		if ( events.isEmpty() ) {
+			return Collections.emptyList();
+		}
+
+		validateImportBatch(events);
+
+		List<StoredEvent> imported = new ArrayList<>(events.size());
+
+		try ( Connection writeConnection = dataSource.getConnection() ) {
+			writeConnection.setAutoCommit(false);
+			try {
+				// Statement chunking is a wire-protocol concern; the transaction spans all chunks so the
+				// whole call commits or rolls back as one unit.
+				for ( int from = 0; from < events.size(); from += IMPORT_CHUNK_SIZE ) {
+					List<EventToImport> chunk = events.subList(from, Math.min(from + IMPORT_CHUNK_SIZE, events.size()));
+					imported.addAll(importChunk(writeConnection, chunk, mode));
+				}
+				writeConnection.commit();
+			} catch (SQLException e) {
+				try {
+					writeConnection.rollback();
+				} catch (SQLException rollbackEx) {
+					e.addSuppressed(rollbackEx);
+				}
+				throw classifyImportFailure(e, events);
+			} catch (RuntimeException e) {
+				try {
+					writeConnection.rollback();
+				} catch (SQLException rollbackEx) {
+					e.addSuppressed(rollbackEx);
+				}
+				throw e;
+			}
+		} catch (SQLException e) {
+			throw new EventStorageException("SQLException during import", e);
+		}
+
+		return imported;
+	}
+
+	/**
+	 * Rejects a batch that cannot possibly be inserted, before opening a connection: duplicate identifiers
+	 * within the batch (which the unique index would reject in a way that varies by mode), and identifiers
+	 * that are not UUIDs (which would fail on the {@code ::uuid} cast with an opaque message).
+	 */
+	private void validateImportBatch ( List<EventToImport> events ) {
+		Set<EventId> seen = new HashSet<>();
+		for ( EventToImport event : events ) {
+			if ( !seen.add(event.id()) ) {
+				throw new IllegalArgumentException("batch to import holds more than one event with id %s".formatted(event.id().value()));
+			}
+			try {
+				UUID.fromString(event.id().value());
+			} catch (IllegalArgumentException e) {
+				throw new EventStorageException("event id '%s' cannot be imported: this storage requires event ids to be UUIDs".formatted(event.id().value()), e);
+			}
+		}
+	}
+
+	private List<StoredEvent> importChunk ( Connection writeConnection, List<EventToImport> chunk, ImportMode mode ) throws SQLException {
+
+		StringBuilder sqlBuilder = new StringBuilder();
+		sqlBuilder.append("INSERT INTO %sevents (event_id, idempotency_key, stream_context, stream_purpose, event_type, event_timestamp, event_data, event_erasable_data, event_tags) VALUES ".formatted(prefix));
+		for ( int i = 0; i < chunk.size(); i++ ) {
+			if ( i > 0 ) {
+				sqlBuilder.append(", ");
+			}
+			sqlBuilder.append("(?::uuid, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?)");
+		}
+
+		if ( mode == ImportMode.SKIP_EXISTING_ID ) {
+			// Infer on event_id specifically rather than a bare DO NOTHING: a violation of the stream-scoped
+			// idempotency index must still raise, since skipping it would drop an event the target never saw.
+			sqlBuilder.append(" ON CONFLICT (event_id) DO NOTHING");
+		}
+
+		sqlBuilder.append(" RETURNING event_position, event_tx::text, event_id::text");
+
+		List<Object> parameters = new ArrayList<>(chunk.size() * 9);
+		Map<String,EventToImport> byId = new HashMap<>(chunk.size());
+
+		for ( EventToImport event : chunk ) {
+			byId.put(normalizedId(event.id()), event);
+
+			parameters.add(event.id().value());
+			parameters.add(event.idempotencyKey());
+			parameters.add(event.stream().context());
+			parameters.add(event.stream().purpose());
+			parameters.add(event.type().name());
+			// The timestamp travels with the event. Bound as an OffsetDateTime at UTC so the instant is
+			// unambiguous on the wire, mirroring the read path which renders event_timestamp back to a
+			// UTC LocalDateTime. Note timestamptz keeps microseconds and rounds anything finer, so a
+			// nanosecond-precision source timestamp lands up to half a microsecond off.
+			parameters.add(OffsetDateTime.of(event.timestamp(), ZoneOffset.UTC));
+			parameters.add(event.immutableData());
+			parameters.add(event.erasableData());
+			parameters.add(event.tags().toStrings().toArray(new String[event.tags().tags().size()]));
+		}
+
+		List<StoredEvent> imported = new ArrayList<>(chunk.size());
+
+		try ( PreparedStatement stmt = writeConnection.prepareStatement(sqlBuilder.toString()) ) {
+			for ( int i = 0; i < parameters.size(); i++ ) {
+				Object param = parameters.get(i);
+				if ( param instanceof String[] ) {
+					stmt.setArray(i + 1, writeConnection.createArrayOf("text", (String[]) param));
+				} else {
+					stmt.setObject(i + 1, param);
+				}
+			}
+
+			try ( ResultSet rs = stmt.executeQuery() ) {
+				while ( rs.next() ) {
+					long position = rs.getLong("event_position");
+					long tx = Long.parseUnsignedLong(rs.getString("event_tx"));
+					String returnedId = rs.getString("event_id");
+
+					// Matched on the identifier we supplied rather than on RETURNING row order: with
+					// ON CONFLICT the returned rows are a subset of the input, so position in the result
+					// set carries no meaning.
+					EventToImport event = byId.get(returnedId == null ? null : returnedId.toLowerCase(Locale.ROOT));
+					if ( event == null ) {
+						throw new EventStorageException("import returned event id %s which was not part of the batch".formatted(returnedId));
+					}
+
+					imported.add(event.positionAt(position, tx));
+				}
+			}
+		}
+
+		return imported;
+	}
+
+	private static String normalizedId ( EventId id ) {
+		return id.value().toLowerCase(Locale.ROOT);
+	}
+
+	/**
+	 * Turns a failed import into the most specific exception the server error allows.
+	 * <p>
+	 * A unique violation is routed by constraint name — the stream-scoped idempotency index versus the
+	 * event_id uniqueness constraint — rather than by inspecting the message text. The offending event is
+	 * recovered by matching the values Postgres reports in the error DETAIL against the batch; when the
+	 * server does not supply a parseable DETAIL the conflict is still reported, without the specifics.
+	 */
+	private EventStorageException classifyImportFailure ( SQLException e, List<EventToImport> events ) {
+		if ( !"23505".equals(e.getSQLState()) ) {
+			return new EventStorageException("SQLException during import", e);
+		}
+
+		String constraint = null;
+		String detail = null;
+		if ( e instanceof PSQLException psqlException && psqlException.getServerErrorMessage() != null ) {
+			constraint = psqlException.getServerErrorMessage().getConstraint();
+			detail = psqlException.getServerErrorMessage().getDetail();
+		}
+
+		List<String> conflictingValues = parseConflictValues(detail);
+
+		if ( constraint != null && constraint.contains("idempotency") ) {
+			// DETAIL reports (stream_context, stream_purpose, idempotency_key)=(ctx, purpose, key)
+			EventToImport conflicting = conflictingValues.size() == 3
+					? events.stream()
+						.filter(ev -> ev.stream().context().equals(conflictingValues.get(0))
+								&& ev.stream().purpose().equals(conflictingValues.get(1))
+								&& conflictingValues.get(2).equals(ev.idempotencyKey()))
+						.findFirst().orElse(null)
+					: null;
+			return EventImportConflictException.duplicateIdempotencyKey(
+					conflicting == null ? null : conflicting.stream(),
+					conflicting == null ? null : conflicting.idempotencyKey(),
+					e);
+		}
+
+		// DETAIL reports (event_id)=(uuid)
+		EventId conflictingId = null;
+		if ( conflictingValues.size() == 1 ) {
+			String value = conflictingValues.get(0).toLowerCase(Locale.ROOT);
+			conflictingId = events.stream()
+					.map(EventToImport::id)
+					.filter(id -> normalizedId(id).equals(value))
+					.findFirst().orElse(null);
+		}
+		return EventImportConflictException.duplicateEventId(conflictingId, e);
+	}
+
+	private static List<String> parseConflictValues ( String detail ) {
+		if ( detail == null ) {
+			return List.of();
+		}
+		Matcher matcher = CONFLICT_DETAIL_VALUES.matcher(detail);
+		if ( !matcher.find() ) {
+			return List.of();
+		}
+		return List.of(matcher.group(1).split(", ", -1));
 	}
 
 	@Override

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/spi/EventImportRoundTripTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/spi/EventImportRoundTripTest.java
@@ -1,0 +1,136 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorageImpl;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.migration.EventStoreImporter;
+import org.sliceworkz.eventstore.migration.ImportReport;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventStorage.EventToStore;
+import org.sliceworkz.eventstore.spi.EventStorage.QueryDirection;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Proves the actual migration path: an in-memory store moved into PostgreSQL and back out again,
+ * with every event arriving as the same event.
+ * <p>
+ * Also pins down the one lossy edge. PostgreSQL stores {@code timestamptz} at microsecond resolution
+ * and rounds anything finer, so a nanosecond-precision timestamp comes back up to half a microsecond
+ * away from where it started. Everything else round-trips exactly.
+ */
+class EventImportRoundTripTest {
+
+	private static final JsonMapper JSONMAPPER = JsonMapper.builder().build();
+
+	private static final Duration ONE_MICROSECOND = Duration.ofNanos(1000);
+
+	private final EventStreamId stream = EventStreamId.forContext("app").withPurpose("default");
+
+	@BeforeAll
+	static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG18); }
+
+	@AfterAll
+	static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG18); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18); }
+
+	@Test
+	void testInMemoryToPostgresAndBack ( ) {
+		EventStorage origin = InMemoryEventStorage.newBuilder().name("origin").build();
+		EventStorage postgres = PostgresEventStorage.newBuilder()
+				.name("roundtrip")
+				.prefix("roundtrip_")
+				.dataSource(PostgresContainer.dataSource(PostgresContainer.IMAGE_PG18))
+				.initializeDatabase()
+				.build();
+		EventStorage destination = InMemoryEventStorage.newBuilder().name("destination").build();
+
+		try {
+			origin.append(AppendCriteria.none(), Optional.of(stream), List.of(
+					new EventToStore(stream, EventType.ofType("Plain"), "{\"a\":1}", null, Tags.of("kind", "plain"), null),
+					new EventToStore(stream, EventType.ofType("Keyed"), "{\"b\":2}", null, Tags.none(), "the-key"),
+					new EventToStore(stream, EventType.ofType("Erasable"), "{\"keep\":true}", "{\"secret\":\"pii\"}", Tags.of("kind", "erasable"), null)));
+
+			List<StoredEvent> originals = allEventsIn(origin);
+			assertEquals(3, originals.size());
+
+			ImportReport out = EventStoreImporter.from(origin).to(postgres).run();
+			assertEquals(3, out.imported());
+
+			ImportReport back = EventStoreImporter.from(postgres).to(destination).run();
+			assertEquals(3, back.imported());
+
+			List<StoredEvent> returned = allEventsIn(destination);
+			assertEquals(3, returned.size());
+
+			for ( int i = 0; i < originals.size(); i++ ) {
+				StoredEvent original = originals.get(i);
+				StoredEvent copy = returned.get(i);
+
+				assertEquals(original.reference().id(), copy.reference().id(), "identity survives a full round trip");
+				assertEquals(original.stream(), copy.stream());
+				assertEquals(original.type(), copy.type());
+				assertEquals(original.tags(), copy.tags());
+				assertEquals(original.idempotencyKey(), copy.idempotencyKey());
+
+				// PostgreSQL normalises JSONB (key order, whitespace), so compare semantically
+				assertEquals(JSONMAPPER.readTree(original.immutableData()), JSONMAPPER.readTree(copy.immutableData()));
+				if ( original.erasableData() == null ) {
+					assertEquals(null, copy.erasableData());
+				} else {
+					assertEquals(JSONMAPPER.readTree(original.erasableData()), JSONMAPPER.readTree(copy.erasableData()));
+				}
+
+				// timestamptz keeps microseconds and rounds anything finer, so a nanosecond-precision
+				// source timestamp can come back up to half a microsecond away from where it started
+				assertTrue(Duration.between(original.timestamp(), copy.timestamp()).abs().compareTo(ONE_MICROSECOND) < 0,
+						"timestamp must survive to microsecond resolution, was %s and came back %s".formatted(original.timestamp(), copy.timestamp()));
+			}
+
+			// the erasable payload really made the trip rather than being merged away
+			assertNotNull(returned.get(2).erasableData());
+		} finally {
+			((PostgresEventStorageImpl)postgres).stop();
+			PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG18);
+		}
+	}
+
+	private List<StoredEvent> allEventsIn ( EventStorage storage ) {
+		return storage.query(EventQuery.matchAll(), Optional.empty(), null, Limit.none(), QueryDirection.FORWARD).toList();
+	}
+
+}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/spi/EventImportTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/spi/EventImportTest.java
@@ -1,0 +1,561 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.spi;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorageImpl;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.migration.EventStoreImporter;
+import org.sliceworkz.eventstore.migration.ImportReport;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventStorage.AppendsToEventStoreNotification;
+import org.sliceworkz.eventstore.spi.EventStorage.BookmarkPlacedNotification;
+import org.sliceworkz.eventstore.spi.EventStorage.EventStoreListener;
+import org.sliceworkz.eventstore.spi.EventStorage.EventToStore;
+import org.sliceworkz.eventstore.spi.EventStorage.ImportMode;
+import org.sliceworkz.eventstore.spi.EventStorage.QueryDirection;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+/**
+ * Shared compliance scenarios for {@link EventStorage#importEvents(List, ImportMode)} and
+ * {@link EventStoreImporter}, run against every storage backend so both behave identically.
+ * <p>
+ * These operate purely at the SPI level: events are written with {@link EventToStore} and read back as
+ * {@link StoredEvent}, exactly as an import does. No domain classes, no serde, no upcasting.
+ */
+class EventImportTest {
+
+	abstract static class Tests {
+
+		private EventStorage source;
+		private EventStorage target;
+
+		private final EventStreamId stream = EventStreamId.forContext("app").withPurpose("default");
+		private final EventStreamId otherStream = EventStreamId.forContext("other").withPurpose("default");
+
+		@BeforeEach
+		public void setUp ( ) {
+			this.source = createEventStorage("importsrc");
+			this.target = createEventStorage("importtgt");
+		}
+
+		@AfterEach
+		public void tearDown ( ) {
+			destroyEventStorage(source);
+			destroyEventStorage(target);
+		}
+
+		abstract EventStorage createEventStorage ( String discriminator );
+
+		void destroyEventStorage ( EventStorage storage ) {
+		}
+
+		// --- helpers ---
+
+		private EventToStore event ( EventStreamId stream, String type, String payload, String idempotencyKey ) {
+			return new EventToStore(stream, EventType.ofType(type), payload, null, Tags.of("kind", type), idempotencyKey);
+		}
+
+		private List<StoredEvent> appendTo ( EventStorage storage, EventToStore... events ) {
+			return storage.append(AppendCriteria.none(), Optional.of(events[0].stream()), List.of(events));
+		}
+
+		private List<StoredEvent> allEventsIn ( EventStorage storage ) {
+			return storage.query(EventQuery.matchAll(), Optional.empty(), null, Limit.none(), QueryDirection.FORWARD).toList();
+		}
+
+		private List<EventToImport> toImport ( List<StoredEvent> storedEvents ) {
+			return storedEvents.stream().map(EventToImport::from).toList();
+		}
+
+		private List<String> idsOf ( List<StoredEvent> storedEvents ) {
+			return storedEvents.stream().map(e -> e.reference().id().value()).toList();
+		}
+
+		/** Seeds the source with three events, the middle one carrying an idempotency key. */
+		private List<StoredEvent> seedSource ( ) {
+			appendTo(source, event(stream, "First", "{\"a\":1}", null));
+			appendTo(source, event(stream, "Second", "{\"b\":2}", "key-2"));
+			appendTo(source, event(otherStream, "Third", "{\"c\":3}", null));
+			return allEventsIn(source);
+		}
+
+		// --- storage level: what an import preserves ---
+
+		@Test
+		void testImportPreservesIdentityTimestampTagsAndIdempotencyKey ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			assertEquals(3, sourceEvents.size());
+
+			List<StoredEvent> imported = target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			assertEquals(3, imported.size());
+			for ( int i = 0; i < sourceEvents.size(); i++ ) {
+				StoredEvent original = sourceEvents.get(i);
+				StoredEvent copy = imported.get(i);
+
+				assertEquals(original.reference().id(), copy.reference().id(), "event id must survive the import");
+				assertEquals(original.timestamp(), copy.timestamp(), "timestamp must survive the import");
+				assertEquals(original.idempotencyKey(), copy.idempotencyKey(), "idempotency key must survive the import");
+				assertEquals(original.type(), copy.type());
+				assertEquals(original.stream(), copy.stream());
+				assertEquals(original.tags(), copy.tags());
+			}
+
+			// and reading them back out of the target gives the same thing
+			List<StoredEvent> readBack = allEventsIn(target);
+			assertEquals(idsOf(sourceEvents), idsOf(readBack));
+			assertEquals("key-2", readBack.get(1).idempotencyKey());
+		}
+
+		@Test
+		void testImportAssignsFreshPositions ( ) {
+			// target already holds an event, so imported events cannot land on the source's positions
+			appendTo(target, event(stream, "Existing", "{\"x\":0}", null));
+
+			List<StoredEvent> sourceEvents = seedSource();
+			List<StoredEvent> imported = target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			assertEquals(3, imported.size());
+			for ( int i = 0; i < imported.size(); i++ ) {
+				assertNotEquals(sourceEvents.get(i).reference().position(), imported.get(i).reference().position(),
+						"position is assigned by the target, never copied");
+			}
+			// positions are increasing, so the source order is preserved
+			for ( int i = 1; i < imported.size(); i++ ) {
+				assertTrue(imported.get(i - 1).reference().happenedBefore(imported.get(i).reference()));
+			}
+			assertEquals(4, allEventsIn(target).size());
+		}
+
+		@Test
+		void testImportPreservesErasableData ( ) {
+			appendTo(source, new EventToStore(stream, EventType.ofType("WithErasable"), "{\"keep\":1}", "{\"secret\":\"x\"}", Tags.none(), null));
+			List<StoredEvent> sourceEvents = allEventsIn(source);
+
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			StoredEvent copy = allEventsIn(target).getFirst();
+			assertTrue(copy.immutableData().contains("keep"));
+			assertNotNull(copy.erasableData());
+			assertTrue(copy.erasableData().contains("secret"));
+		}
+
+		@Test
+		void testImportSpansMultipleStreamsInOneCall ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			List<StoredEvent> inApp = target.query(EventQuery.matchAll(), Optional.of(stream), null, Limit.none(), QueryDirection.FORWARD).toList();
+			List<StoredEvent> inOther = target.query(EventQuery.matchAll(), Optional.of(otherStream), null, Limit.none(), QueryDirection.FORWARD).toList();
+			assertEquals(2, inApp.size());
+			assertEquals(1, inOther.size());
+		}
+
+		@Test
+		void testImportedEventIsRetrievableByItsOriginalId ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			EventId originalId = sourceEvents.getFirst().reference().id();
+			Optional<StoredEvent> found = target.getEventById(originalId);
+
+			assertTrue(found.isPresent());
+			assertEquals(originalId, found.get().reference().id());
+		}
+
+		@Test
+		void testImportNotifiesListeners ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			AtomicInteger notifications = new AtomicInteger();
+			EventStoreListener listener = new EventStoreListener() {
+				@Override
+				public void notify ( AppendsToEventStoreNotification newEventsInStore ) {
+					notifications.incrementAndGet();
+				}
+
+				@Override
+				public void notify ( BookmarkPlacedNotification bookmarkPlaced ) {
+				}
+			};
+			target.subscribe(listener);
+
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			// in-memory notifies inline, Postgres delivers over LISTEN/NOTIFY on a monitor thread
+			await().atMost(Duration.ofSeconds(5))
+					.pollInterval(Duration.ofMillis(100))
+					.until(() -> notifications.get() > 0);
+		}
+
+		// --- storage level: conflicts ---
+
+		@Test
+		void testFailOnExistingIdRaisesOnReimport ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			EventImportConflictException conflict = assertThrows(EventImportConflictException.class,
+					() -> target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID));
+
+			assertEquals(EventImportConflictException.Kind.DUPLICATE_EVENT_ID, conflict.kind());
+			assertEquals(3, allEventsIn(target).size(), "a rejected batch must leave nothing behind");
+		}
+
+		@Test
+		void testSkipExistingIdIsIdempotent ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			List<StoredEvent> second = target.importEvents(toImport(sourceEvents), ImportMode.SKIP_EXISTING_ID);
+
+			assertTrue(second.isEmpty(), "everything was already there, so nothing is imported");
+			assertEquals(3, allEventsIn(target).size());
+		}
+
+		@Test
+		void testSkipExistingIdResumesPartialImport ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+
+			// first attempt got only the first two across
+			target.importEvents(toImport(sourceEvents.subList(0, 2)), ImportMode.FAIL_ON_EXISTING_ID);
+
+			List<StoredEvent> resumed = target.importEvents(toImport(sourceEvents), ImportMode.SKIP_EXISTING_ID);
+
+			assertEquals(1, resumed.size(), "only the event that never landed is imported");
+			assertEquals(sourceEvents.get(2).reference().id(), resumed.getFirst().reference().id());
+			assertEquals(idsOf(sourceEvents), idsOf(allEventsIn(target)));
+		}
+
+		@Test
+		void testDuplicateIdempotencyKeyIsFatalInBothModes ( ) {
+			// the target already used this key on this stream, for a completely different event
+			appendTo(target, event(stream, "Other", "{\"z\":9}", "key-2"));
+			List<StoredEvent> sourceEvents = seedSource();
+
+			EventImportConflictException failing = assertThrows(EventImportConflictException.class,
+					() -> target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID));
+			assertEquals(EventImportConflictException.Kind.DUPLICATE_IDEMPOTENCY_KEY, failing.kind());
+
+			// skipping is about identifiers only, so it must not absorb this
+			EventImportConflictException skipping = assertThrows(EventImportConflictException.class,
+					() -> target.importEvents(toImport(sourceEvents), ImportMode.SKIP_EXISTING_ID));
+			assertEquals(EventImportConflictException.Kind.DUPLICATE_IDEMPOTENCY_KEY, skipping.kind());
+
+			assertEquals(1, allEventsIn(target).size(), "nothing of the rejected batch may survive");
+		}
+
+		@Test
+		void testSameIdempotencyKeyOnAnotherStreamDoesNotCollide ( ) {
+			// keys are scoped per stream, so this must not stand in the way of the import
+			appendTo(target, event(otherStream, "Other", "{\"z\":9}", "key-2"));
+			List<StoredEvent> sourceEvents = seedSource();
+
+			target.importEvents(toImport(sourceEvents), ImportMode.FAIL_ON_EXISTING_ID);
+
+			assertEquals(4, allEventsIn(target).size());
+		}
+
+		@Test
+		void testDuplicateIdWithinOneBatchIsRejected ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			List<EventToImport> batch = new ArrayList<>(toImport(sourceEvents));
+			batch.add(batch.getFirst());
+
+			assertThrows(IllegalArgumentException.class, () -> target.importEvents(batch, ImportMode.FAIL_ON_EXISTING_ID));
+			assertTrue(allEventsIn(target).isEmpty());
+		}
+
+		@Test
+		void testInvalidJsonPayloadIsRejected ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+			List<EventToImport> batch = List.of(toImport(sourceEvents).getFirst().withImmutableData("not json at all"));
+
+			assertThrows(EventStorageException.class, () -> target.importEvents(batch, ImportMode.FAIL_ON_EXISTING_ID));
+			assertTrue(allEventsIn(target).isEmpty());
+		}
+
+		@Test
+		void testEmptyImportIsANoOp ( ) {
+			assertTrue(target.importEvents(List.of(), ImportMode.FAIL_ON_EXISTING_ID).isEmpty());
+			assertTrue(allEventsIn(target).isEmpty());
+		}
+
+		// --- importer level ---
+
+		@Test
+		void testImporterCopiesTheWholeStore ( ) {
+			List<StoredEvent> sourceEvents = seedSource();
+
+			ImportReport report = EventStoreImporter.from(source).to(target).run();
+
+			assertEquals(3, report.read());
+			assertEquals(3, report.imported());
+			assertEquals(0, report.dropped());
+			assertEquals(0, report.skipped());
+			assertEquals(sourceEvents.getLast().reference(), report.sourceTo());
+			assertNull(report.sourceFrom());
+			assertNotNull(report.firstTargetReference());
+			assertNotNull(report.lastTargetReference());
+			assertEquals(idsOf(sourceEvents), idsOf(allEventsIn(target)));
+		}
+
+		@Test
+		void testImporterHonoursBatchSizeAndReportsProgress ( ) {
+			IntStream.range(0, 7).forEach(i -> appendTo(source, event(stream, "Bulk", "{\"i\":%d}".formatted(i), null)));
+
+			List<ImportReport> progress = new ArrayList<>();
+			ImportReport report = EventStoreImporter.from(source).to(target)
+					.batchSize(2)
+					.onProgress(progress::add)
+					.run();
+
+			assertEquals(7, report.imported());
+			assertEquals(4, progress.size(), "7 events in batches of 2 means 4 batches");
+			assertEquals(7, progress.getLast().imported());
+			assertEquals(idsOf(allEventsIn(source)), idsOf(allEventsIn(target)));
+		}
+
+		@Test
+		void testImporterRemapsTheStream ( ) {
+			seedSource();
+			EventStreamId archive = EventStreamId.forContext("archive").withPurpose("default");
+
+			EventStoreImporter.from(source).to(target)
+					.transform(src -> Optional.of(EventToImport.from(src).withStream(archive)))
+					.run();
+
+			List<StoredEvent> imported = allEventsIn(target);
+			assertEquals(3, imported.size());
+			assertTrue(imported.stream().allMatch(e -> archive.equals(e.stream())));
+		}
+
+		@Test
+		void testImporterDropsEventsTheTransformationDiscards ( ) {
+			seedSource();
+
+			ImportReport report = EventStoreImporter.from(source).to(target)
+					.transform(src -> "Second".equals(src.type().name()) ? Optional.empty() : Optional.of(EventToImport.from(src)))
+					.run();
+
+			assertEquals(3, report.read());
+			assertEquals(1, report.dropped());
+			assertEquals(2, report.imported());
+			assertEquals(2, allEventsIn(target).size());
+		}
+
+		@Test
+		void testImporterCatchesUpAfterAnEarlierRun ( ) {
+			seedSource();
+
+			ImportReport first = EventStoreImporter.from(source).to(target).run();
+			assertEquals(3, first.imported());
+
+			// source moves on after the first run finished
+			appendTo(source, event(stream, "Fourth", "{\"d\":4}", null));
+			appendTo(source, event(stream, "Fifth", "{\"e\":5}", null));
+
+			ImportReport catchUp = EventStoreImporter.from(source).to(target)
+					.after(first.sourceTo())
+					.run();
+
+			assertEquals(2, catchUp.read(), "only what the source gained since the boundary is read");
+			assertEquals(2, catchUp.imported());
+			assertEquals(first.sourceTo(), catchUp.sourceFrom());
+			assertEquals(idsOf(allEventsIn(source)), idsOf(allEventsIn(target)));
+		}
+
+		@Test
+		void testImporterIsBoundedAtTheSourceHead ( ) {
+			seedSource();
+
+			// nothing new since the head, so a run starting there does no work at all
+			EventReference head = allEventsIn(source).getLast().reference();
+			ImportReport report = EventStoreImporter.from(source).to(target).after(head).run();
+
+			assertEquals(0, report.read());
+			assertEquals(0, report.imported());
+			assertTrue(allEventsIn(target).isEmpty());
+		}
+
+		@Test
+		void testImporterOnAnEmptySourceDoesNothing ( ) {
+			ImportReport report = EventStoreImporter.from(source).to(target).run();
+
+			assertEquals(0, report.read());
+			assertNull(report.sourceTo());
+			assertTrue(allEventsIn(target).isEmpty());
+		}
+
+		@Test
+		void testImporterCanCloneWithinOneStoreWithoutRunningAway ( ) {
+			seedSource();
+			EventStreamId clone = EventStreamId.forContext("clone").withPurpose("default");
+
+			// source and target are the same storage: only the head boundary keeps this from
+			// re-reading the clones it is writing and looping forever
+			ImportReport report = EventStoreImporter.from(source).to(source)
+					.batchSize(2)
+					.transform(src -> Optional.of(EventToImport.from(src)
+							.withId(EventId.create())
+							.withStream(clone)
+							.withIdempotencyKey(null)))
+					.run();
+
+			assertEquals(3, report.read());
+			assertEquals(3, report.imported());
+			assertEquals(6, allEventsIn(source).size());
+
+			List<StoredEvent> cloned = source.query(EventQuery.matchAll(), Optional.of(clone), null, Limit.none(), QueryDirection.FORWARD).toList();
+			assertEquals(3, cloned.size());
+			assertFalse(idsOf(cloned).stream().anyMatch(idsOf(allEventsIn(source).subList(0, 3))::contains),
+					"the clone must carry fresh identifiers");
+		}
+
+		@Test
+		void testImporterResumesAnInterruptedRun ( ) {
+			seedSource();
+
+			// a first run that dies part way: emulated by importing only the first batch
+			EventStoreImporter.from(source).to(target)
+					.batchSize(1)
+					.transform(src -> "First".equals(src.type().name()) ? Optional.of(EventToImport.from(src)) : Optional.empty())
+					.run();
+			assertEquals(1, allEventsIn(target).size());
+
+			ImportReport resumed = EventStoreImporter.from(source).to(target)
+					.mode(ImportMode.SKIP_EXISTING_ID)
+					.run();
+
+			assertEquals(3, resumed.read());
+			assertEquals(2, resumed.imported());
+			assertEquals(1, resumed.skipped());
+			assertEquals(idsOf(allEventsIn(source)), idsOf(allEventsIn(target)));
+		}
+
+		@Test
+		void testImporterRequiresATarget ( ) {
+			assertThrows(IllegalStateException.class, () -> EventStoreImporter.from(source).run());
+		}
+
+	}
+
+	@Nested
+	class OnInMem extends Tests {
+		@Override
+		EventStorage createEventStorage ( String discriminator ) {
+			return InMemoryEventStorage.newBuilder().name(discriminator).build();
+		}
+	}
+
+	@Nested
+	class OnPostgres17 extends Tests {
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG17); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG17); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG17); }
+
+		private DataSource dataSource;
+
+		@Override
+		EventStorage createEventStorage ( String discriminator ) {
+			// one DataSource shared by source and target: asking the container for a second one would
+			// close the first. The two stores are kept apart by their table prefix instead.
+			if ( dataSource == null ) {
+				dataSource = PostgresContainer.dataSource(PostgresContainer.IMAGE_PG17);
+			}
+			return PostgresEventStorage.newBuilder()
+					.name(discriminator)
+					.prefix(discriminator + "_")
+					.dataSource(dataSource)
+					.initializeDatabase()
+					.build();
+		}
+
+		@Override
+		void destroyEventStorage ( EventStorage storage ) {
+			((PostgresEventStorageImpl)storage).stop();
+		}
+	}
+
+	@Nested
+	class OnPostgres18 extends Tests {
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG18); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG18); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18); }
+
+		private DataSource dataSource;
+
+		@Override
+		EventStorage createEventStorage ( String discriminator ) {
+			if ( dataSource == null ) {
+				dataSource = PostgresContainer.dataSource(PostgresContainer.IMAGE_PG18);
+			}
+			return PostgresEventStorage.newBuilder()
+					.name(discriminator)
+					.prefix(discriminator + "_")
+					.dataSource(dataSource)
+					.initializeDatabase()
+					.build();
+		}
+
+		@Override
+		void destroyEventStorage ( EventStorage storage ) {
+			((PostgresEventStorageImpl)storage).stop();
+		}
+	}
+
+}


### PR DESCRIPTION
Adds a storage-to-storage import path: copy events from one `EventStorage` into another while keeping each event's identity, timestamp and idempotency key. Position and transaction are always
  reassigned by the target, so an import reproduces the source *order* but not its ordering numbers.

  ```java
  ImportReport report = EventStoreImporter.from(sourceStorage).to(targetStorage)
      .mode(ImportMode.SKIP_EXISTING_ID)
      .transform(src -> Optional.of(EventToImport.from(src).withStream(archive)))
      .onProgress(r -> LOGGER.info("{}", r))
      .run();
  ```

  Also fixes a pre-existing idempotency bug in the in-memory backend (first commit, independent of the feature).

  ## Why the SPI and not the public API

  `Event` does not carry the idempotency key, so an importer built on `EventStream.query()` → `append()` loses it immediately. Worse, that path runs the serde: it upcasts legacy events into current
  types and re-splits `@Erasable` fields against annotations that may since have changed — silently rewriting history and possibly changing the event count. Working with `StoredEvent`/`EventToImport`
  moves payloads as opaque JSON, so an import needs no domain classes on the classpath and legacy event types survive as legacy event types.

  ## Design notes

  **`EventToImport` is `StoredEvent` minus `position`/`tx`/`index`** — exactly the fields a caller controls. A transformation that hand-set a position the target then ignored would be a footgun; the
  record shape makes it unexpressible. Every field has a wither, so the transformation can also remap streams, retag, rewrite payloads, mint new ids and restamp timestamps. That makes this a
  stream-rewriting tool, not only an importer, and the javadoc says so rather than letting the name imply a fidelity guarantee it does not make.

  **Two conflict modes.** `FAIL_ON_EXISTING_ID` (default) aborts the batch; `SKIP_EXISTING_ID` skips on **id alone**, no payload comparison — that is what makes an interrupted import resumable. An
  idempotency key already used by a *different* event on the same stream is fatal in both modes: skipping it would discard an event the target has never seen.

  **No DDL change.** `event_id` is already `UUID NOT NULL UNIQUE` and `event_timestamp` is nullable with a default, so both can be supplied explicitly.

  **Reads are always bounded at the source head**, captured before the first write. This makes a run a fixed range, and it is what stops `from(x).to(x)` — cloning inside one store — from re-reading
  the events it is writing and never terminating. Events appended to the source during a run are excluded by design; `ImportReport.sourceTo()` fed into a later run's `.after(...)` picks them up in
  O(new events) instead of rescanning from the beginning.

  **The importer lives in `-api`**, next to `Projector`, which is likewise a concrete runtime component rather than a contract. No new module, no new dependency, no bom/publishing wiring. Progress is
  a callback because `-api` carries no logging dependency.

  ## Worth a close look during review

  - **`RETURNING` rows are matched by `event_id`, not by row order.** With `ON CONFLICT` the result is a subset of the input, so row position means nothing. This deliberately avoids extending the 
  positional-zip assumption `append()` currently makes.
  - **`SKIP_EXISTING_ID` infers `ON CONFLICT (event_id)` specifically**, not a bare `DO NOTHING`, so a violation of the stream-scoped idempotency index still raises.
  - **Conflicts are classified by constraint name** from `PSQLException.getServerErrorMessage().getConstraint()` rather than by matching message text.
  - **Statement chunking is not transaction chunking.** Statements are capped at 5000 rows (9 params/row against the 65535-parameter wire ceiling) but all run in one transaction, so an `importEvents`
  call stays all-or-nothing however many chunks it takes.
  - **`getEventById` in the in-memory backend is now an index lookup** rather than a linear scan — a change to an existing hot path.

  ## Known limits, by design

  - **Atomic per batch only.** A failure part-way leaves earlier batches committed; re-run with `SKIP_EXISTING_ID` to continue. There is no dry-run mode — an application that wants to check a target
  up front can do so through the public API in **raw mode** (`getEventStream(EventStreamId.anyContext())`, no root classes). With domain classes registered, `getEventById` upcasts, and a legacy event
  whose upcast yields zero current events comes back empty though it exists — a false negative. Documented.
  - **Nothing is verified.** Matching is on id; proving a migration faithful is the caller's job.
  - **One importer at a time per target** — the conflict check and the insert are not under a common lock.
  - **Listeners are notified** as they are for appends, so a merge into a live store wakes its projections. Imported events land at new (high) positions carrying old timestamps, so "later position
  implies later timestamp" no longer holds there.
  - Rewriting ids makes `SKIP_EXISTING_ID` meaningless (nothing stable to match on). Allowed on purpose — it is how you clone a stream — and documented, not blocked.

  ## Testing

  24 shared scenarios run against in-memory, PG17 and PG18 so all three backends are held to identical semantics: preservation, fresh positions, order, multi-stream batches, both conflict modes,
  batch rollback, resume after a torn import, catch-up, and the same-store clone terminating.

  A separate round-trip test moves an in-memory store through Postgres and back. It pins down the one lossy edge: **`timestamptz` keeps microseconds and *rounds* anything finer**, so a
  nanosecond-precision timestamp returns up to half a microsecond from where it started. Everything else is exact. (This corrected an assumption made while planning — "it truncates" was wrong, and
  the test caught it.)

  The in-memory fix has a regression test in `InMemoryFsEventStorageImplTest`, verified to fail without the fix.

  Full reactor build green: 456 tests in the shared module, no existing test touched.

  ## Commits

  1. `fix(inmem)` — remember idempotency keys of preloaded events (+ index by id)
  2. `feat(spi)` — `importEvents` and the three backend implementations
  3. `feat(migration)` — `EventStoreImporter`, shared tests, docs

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
