### PR TITLE
Implement lifecycle management for EventStore and EventStorage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,48 @@ EventStorage storage = PostgresEventStorage.newBuilder()
 
 PostgreSQL requires a `db.properties` file with connection settings. The DataSourceFactory searches for this file in the current directory and up to 2 parent directories.
 
+### Lifecycle: closing a store
+
+Both `EventStorage` and `EventStore` extend `AutoCloseable`. A store that lives as long as the process
+needs no explicit close; one created per tenant, per test or per hot reload does — the Postgres backend
+runs two LISTEN/NOTIFY monitor threads, each holding a JDBC connection, and those threads keep the whole
+storage reachable, so a dropped-but-unclosed storage is not reclaimed by GC.
+
+```java
+try ( EventStore eventStore = PostgresEventStorage.newBuilder().buildStore() ) {
+    ...
+}   // stops the monitors and closes the pools the builder created
+```
+
+The contract every backend implements (documented on `EventStorage.close()`):
+
+- **Idempotent** — later calls do nothing and never throw.
+- **Blocks, bounded** — when `close()` returns, the background threads have finished and released their
+  connections. On Postgres the monitors poll for notifications in 100ms slices, so they notice the stop
+  within that, UNLISTEN, and hand their connections back to the pool healthy: closing takes ~100ms and
+  logs nothing. A monitor that fails to stop on its own within 2s is interrupted instead (hard bound 5s);
+  that path breaks its connection under the driver, so the pool logs "connection marked as broken" — an
+  interrupted shutdown, not a normal one.
+- **Ownership** — a `DataSource` you passed to `.dataSource(...)` is never closed; one the builder
+  created from `db.properties` is. If you supply the pool, close the storage *before* closing the pool —
+  the other order leaves the monitors retrying against a dead pool, which they cannot distinguish from a
+  database outage.
+- **Terminal** — no reopening; `start()` on a closed storage throws.
+- **Operations throw afterwards** — every read and write throws `EventStorageClosedException`; `name()`
+  keeps working. A closed storage does not keep serving reads while its notifications are dead, which
+  would strand projections silently.
+- **Closing an `EventStore` does *not* close a storage you gave it.** A storage can back several stores
+  and usually outlives them, so closing it is the caller's job — after closing the stores built on it.
+  The exception is the store from `buildStore()`: it created the storage and hands back nothing else, so
+  it closes both (via `EventStore.owning(store, storage)`, which you can use for the same purpose when
+  you build the pair yourself). Closing a store is safe for its siblings: they keep working.
+- **A closed `EventStore`'s streams throw too**, for the same reason a closed storage's operations do —
+  its notifications have stopped, so letting it keep reading would strand its subscribers silently.
+
+`PostgresEventStorageImpl.stop()` still exists, deprecated, and delegates to `close()`. Prefer `close()`:
+it is on the interface, so no downcast, and it works for framework integration (Spring infers `close` as
+the destroy method for a `@Bean`; CDI `@Disposes`; try-with-resources).
+
 ### Typical Usage Pattern
 
 ```java
@@ -310,6 +352,11 @@ Tests extend `AbstractEventStoreTest`, which provides:
 - `waitBecauseOfEventualConsistency(BooleanSupplier)`: Awaitility helper for async listener assertions
 - `dataSource()`: direct database access, where the backend is SQL-backed
 - automatic setup/teardown via JUnit 5 lifecycle
+
+Teardown goes through `EventStoreBackend.destroyEventStorage`, which defaults to `storage.close()` —
+the SPI contract already requires that to release everything the storage created and to block until it
+has, so a backend only overrides it to release something *it* handed the storage, such as a pool the
+storage deliberately will not close.
 
 **Running against every backend:**
 Annotate scenarios `@ForEachBackend` instead of `@Test`. Each runs once per registered

--- a/README.md
+++ b/README.md
@@ -19,6 +19,37 @@ Supports all features described described by the [DCB Specification](https://dcb
 Step-by-step introduction with the [quickstart guide](https://sliceworkz.github.io/posts/eventstore-quickstart/) or the [documentation](https://sliceworkz.github.io/categories/eventstore-documentation/)
 
 
+# Shutting a store down
+
+`EventStore` and `EventStorage` are `AutoCloseable`. A store that lives as long as the process needs
+nothing; one created per tenant, per test or per hot reload should be closed, because the Postgres
+backend runs two LISTEN/NOTIFY threads holding JDBC connections — and those threads keep the storage
+alive, so dropping the reference does not help.
+
+```java
+try ( EventStore eventStore = PostgresEventStorage.newBuilder().buildStore() ) {
+    ...
+}   // monitors stopped, and pools the builder created are closed
+```
+
+Closing blocks until the background threads have really stopped, is idempotent and terminal, and never
+closes a `DataSource` you supplied yourself. Afterwards every operation throws
+`EventStorageClosedException` rather than half-working with dead notifications. The full contract is on
+`EventStorage.close()`; `PostgresEventStorageImpl.stop()` is deprecated and delegates to it.
+
+Closing an `EventStore` shuts down that store, not the storage under it — a storage can back several
+stores and usually outlives them, so you close it yourself once the stores built on it are closed. The
+store from `buildStore()` is the exception: it created the storage and hands you nothing else, so it
+closes both. When you build the pair yourself and want one handle, compose it the same way:
+
+```java
+EventStorage storage = PostgresEventStorage.newBuilder().build();
+try ( EventStore eventStore = EventStore.owning(EventStoreFactory.get().eventStore(storage), storage) ) {
+    ...
+}
+```
+
+
 # Moving events between stores
 
 `EventStoreImporter` copies events from one storage backend into another, keeping each event's id,

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/EventStore.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/EventStore.java
@@ -20,6 +20,7 @@ package org.sliceworkz.eventstore;
 import java.util.Collections;
 import java.util.Set;
 
+import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.stream.EventStream;
 import org.sliceworkz.eventstore.stream.EventStreamId;
 
@@ -46,11 +47,76 @@ import org.sliceworkz.eventstore.stream.EventStreamId;
  * List<Event<CustomerEvent>> events = stream.query(EventQuery.matchAll()).toList();
  * }</pre>
  *
+ * <h2>Lifecycle:</h2>
+ * An EventStore owns background machinery of its own, and — when obtained from a storage builder's
+ * {@code buildStore()} — is the only handle on the storage backing it. {@link #close() Close} it when
+ * the application is done with it, either explicitly or with try-with-resources:
+ * <pre>{@code
+ * try ( EventStore eventStore = PostgresEventStorage.newBuilder().buildStore() ) {
+ *     ...
+ * }
+ * }</pre>
+ * A store that lives as long as the process needs no explicit close; one created per tenant, per test
+ * or per reload does.
+ *
  * @see EventStoreFactory
  * @see EventStream
  * @see EventStreamId
  */
-public interface EventStore {
+public interface EventStore extends AutoCloseable {
+
+	/**
+	 * Closes this event store, shutting down the notification machinery it started.
+	 * <p>
+	 * <b>The {@link org.sliceworkz.eventstore.spi.EventStorage} is not closed.</b> An EventStore is
+	 * always handed a storage it did not create, and the storage is the expensive object — connection
+	 * pool, notification threads — which can back several stores and usually outlives them. Closing it
+	 * is the caller's business, once every store built on it has been closed.
+	 * <p>
+	 * The single exception is a store obtained from a storage builder's {@code buildStore()}: that one
+	 * created the storage and hands back no other reference to it, so closing it closes both. See
+	 * {@link #owning(EventStore, EventStorage)}, which is how such a store is composed.
+	 * <p>
+	 * Idempotent, and bounded: it waits briefly for in-flight listener notifications rather than
+	 * abandoning them. After closing, {@link #getEventStream} and every operation on streams already
+	 * obtained from this store throw {@link org.sliceworkz.eventstore.spi.EventStorageClosedException} —
+	 * a store whose notifications have stopped must not keep serving reads as if nothing happened, since
+	 * that strands anything subscribed to it. Streams from <em>other</em> stores on the same storage are
+	 * unaffected.
+	 * <p>
+	 * Declared without a checked exception, unlike {@link AutoCloseable#close()}, so that
+	 * try-with-resources needs no catch block. The default implementation does nothing.
+	 */
+	@Override
+	default void close ( ) {
+		// no resources to release
+	}
+
+	/**
+	 * Returns an EventStore that behaves exactly like {@code eventStore}, but also closes
+	 * {@code eventStorage} when it is closed.
+	 * <p>
+	 * Closing an EventStore never closes a storage handed to it, for the reasons on {@link #close()}.
+	 * This composes the two into a single handle for the one case where that reasoning does not apply:
+	 * a {@code buildStore()} that created both and returns only the store, leaving the caller nothing
+	 * else to close. The storage builders use it for exactly that; application code can use it wherever
+	 * it wants one closable handle for a storage and store it created together:
+	 * <pre>{@code
+	 * EventStorage storage = PostgresEventStorage.newBuilder().build();
+	 * try ( EventStore eventStore = EventStore.owning(EventStoreFactory.get().eventStore(storage), storage) ) {
+	 *     ...
+	 * }   // store shut down, then storage closed
+	 * }</pre>
+	 * Both closes are idempotent, so closing the result and the parts, in any order, is harmless.
+	 *
+	 * @param eventStore the store to delegate to; must not be null
+	 * @param eventStorage the storage to close along with it; must not be null
+	 * @return an EventStore that closes both
+	 * @throws IllegalArgumentException if either argument is null
+	 */
+	static EventStore owning ( EventStore eventStore, EventStorage eventStorage ) {
+		return new OwningEventStore(eventStore, eventStorage);
+	}
 
 	/**
 	 * Retrieves an event stream with full configuration for event types and historical event types.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/OwningEventStore.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/OwningEventStore.java
@@ -1,0 +1,68 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore;
+
+import java.util.Set;
+
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+/**
+ * An {@link EventStore} that closes its {@link EventStorage} along with itself.
+ * <p>
+ * Created by {@link EventStore#owning(EventStore, EventStorage)}, which is where the reasoning for this
+ * class lives. Everything but {@link #close()} is delegated unchanged.
+ */
+final class OwningEventStore implements EventStore {
+
+	private final EventStore eventStore;
+	private final EventStorage eventStorage;
+
+	OwningEventStore ( EventStore eventStore, EventStorage eventStorage ) {
+		if ( eventStore == null ) {
+			throw new IllegalArgumentException("eventStore cannot be null");
+		}
+		if ( eventStorage == null ) {
+			throw new IllegalArgumentException("eventStorage cannot be null");
+		}
+		this.eventStore = eventStore;
+		this.eventStorage = eventStorage;
+	}
+
+	@Override
+	public <DOMAIN_EVENT_TYPE> EventStream<DOMAIN_EVENT_TYPE> getEventStream ( EventStreamId eventStreamId, Set<Class<?>> eventRootClasses, Set<Class<?>> historicalEventRootClasses ) {
+		return eventStore.getEventStream(eventStreamId, eventRootClasses, historicalEventRootClasses);
+	}
+
+	/**
+	 * Closes the store, then the storage. Both are idempotent, so closing this more than once — or
+	 * closing the storage separately as well — is harmless.
+	 */
+	@Override
+	public void close ( ) {
+		eventStore.close();
+		eventStorage.close();
+	}
+
+	@Override
+	public String toString ( ) {
+		return "%s owning storage '%s'".formatted(eventStore, eventStorage.name());
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -58,7 +58,14 @@ import org.sliceworkz.eventstore.stream.EventStreamId;
  *   <li>Manage reader bookmarks for tracking event processing progress</li>
  *   <li>Notify listeners when new events are appended or bookmarks are placed</li>
  *   <li>Handle both forward and backward queries with proper ordering</li>
+ *   <li>Release everything they created when {@link #close()} is called — see the contract there</li>
  * </ul>
+ *
+ * <h2>Lifecycle:</h2>
+ * An EventStorage is usable from the moment its builder returns it, and stays usable until it is
+ * {@link #close() closed}. Backends without background resources need do nothing: {@code close()}
+ * defaults to a no-op. Backends that start threads, hold connections or open files must implement it
+ * and honour the contract documented on {@link #close()}.
  *
  * <h2>Thread Safety:</h2>
  * Implementations should be thread-safe and support concurrent reads and writes.
@@ -122,7 +129,52 @@ import org.sliceworkz.eventstore.stream.EventStreamId;
  * @see EventQuery
  * @see org.sliceworkz.eventstore.stream.OptimisticLockingException
  */
-public interface EventStorage {
+public interface EventStorage extends AutoCloseable {
+
+	/**
+	 * Releases everything this storage created, and stops all background activity it started.
+	 * <p>
+	 * The default implementation does nothing, which is correct for a backend that holds no resources
+	 * beyond the objects it was handed. A backend that starts threads, checks out connections or opens
+	 * files must override it and honour the following contract, which callers and the
+	 * {@link org.sliceworkz.eventstore.EventStore} rely on:
+	 * <ol>
+	 *   <li><b>Idempotent.</b> The second and later calls do nothing and never throw.</li>
+	 *   <li><b>Blocking and bounded.</b> {@code close()} returns only once background activity has
+	 *       actually ceased: no thread it started may still be running, no connection it checked out
+	 *       may still be held. It must return within an implementation-defined bound; if that bound
+	 *       expires it logs and returns rather than throwing or hanging.</li>
+	 *   <li><b>Ownership.</b> It releases only what the implementation created. A DataSource,
+	 *       connection pool, thread pool or file handle supplied by the caller is left untouched —
+	 *       closing that is the caller's business. Conversely, a caller who supplies such a resource
+	 *       must close this storage <em>before</em> closing the resource.</li>
+	 *   <li><b>Terminal.</b> A closed storage cannot be reopened.</li>
+	 *   <li><b>Operations throw afterwards.</b> {@link #query}, {@link #append}, {@link #importEvents},
+	 *       {@link #getEventById}, {@link #subscribe}, {@link #bookmark}, {@link #getBookmark},
+	 *       {@link #getBookmarks} and {@link #removeBookmark} throw
+	 *       {@link EventStorageClosedException} once the storage is closed. Continuing to serve reads
+	 *       and writes while notifications are dead is not an acceptable alternative: it strands
+	 *       projections silently. {@link #name()} keeps working, so logging and diagnostics do not
+	 *       break.</li>
+	 *   <li><b>No more notifications.</b> No {@link AppendsToEventStoreNotification} or
+	 *       {@link BookmarkPlacedNotification} is delivered to any listener after {@code close()}
+	 *       returns.</li>
+	 * </ol>
+	 * <p>
+	 * Declared without a checked exception, unlike {@link AutoCloseable#close()}, so that
+	 * try-with-resources stays pleasant:
+	 * <pre>{@code
+	 * try ( EventStorage storage = PostgresEventStorage.newBuilder().build() ) {
+	 *     ...
+	 * }
+	 * }</pre>
+	 *
+	 * @see org.sliceworkz.eventstore.EventStore#close()
+	 */
+	@Override
+	default void close ( ) {
+		// no resources to release
+	}
 
 	/**
 	 * Returns the name of this event storage implementation.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorageClosedException.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorageClosedException.java
@@ -1,0 +1,48 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.spi;
+
+/**
+ * Thrown when an operation is attempted on an {@link EventStorage} or
+ * {@link org.sliceworkz.eventstore.EventStore} that has been closed.
+ * <p>
+ * Closing is terminal: there is no reopening, so this exception always indicates a lifecycle bug in
+ * the calling code — a storage closed too early, or a reference kept past its owner's shutdown —
+ * rather than a transient condition worth retrying.
+ * <p>
+ * Backends must throw this rather than silently continuing to work. A storage whose notification
+ * machinery has been shut down can often still read and write (its connection pool may belong to the
+ * caller and still be open), but any projection or subscriber attached to it has stopped receiving
+ * events. Failing loudly turns that silent stall into an immediate, locatable error.
+ *
+ * @see EventStorage#close()
+ */
+public class EventStorageClosedException extends EventStorageException {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Constructs a new EventStorageClosedException with the specified detail message.
+	 *
+	 * @param message the detail message, naming the storage and the attempted operation where possible
+	 */
+	public EventStorageClosedException ( String message ) {
+		super(message);
+	}
+
+}

--- a/sliceworkz-eventstore-benchmark/src/main/java/org/sliceworkz/eventstore/benchmark/BenchmarkApplication.java
+++ b/sliceworkz-eventstore-benchmark/src/main/java/org/sliceworkz/eventstore/benchmark/BenchmarkApplication.java
@@ -220,6 +220,7 @@ public class BenchmarkApplication {
 		}
 		
 		javalin.stop();
+		eventStore.close(); // stops the LISTEN/NOTIFY monitors and closes the pools the builder created
 
 		LOGGER.info("exited.");
 		

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -48,6 +50,7 @@ import org.sliceworkz.eventstore.query.EventFilterItem;
 import org.sliceworkz.eventstore.query.EventTypesFilter;
 import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorageClosedException;
 import org.sliceworkz.eventstore.spi.EventStorage.AppendsToEventStoreNotification;
 import org.sliceworkz.eventstore.spi.EventStorage.BookmarkPlacedNotification;
 import org.sliceworkz.eventstore.spi.EventStorage.EventStoreListener;
@@ -108,7 +111,9 @@ import io.micrometer.core.instrument.Timer;
  * @see EventPayloadSerializerDeserializer
  */
 public class EventStoreImpl implements EventStore {
-	
+
+	private static final Logger STORE_LOGGER = LoggerFactory.getLogger(EventStoreImpl.class);
+
 	static {
 		Banner.printBanner();
 	}
@@ -136,7 +141,20 @@ public class EventStoreImpl implements EventStore {
 	 * Used to track event store operations such as event stream creation, appends, and queries.
 	 */
 	private final MeterRegistry meterRegistry;
-	
+
+	/**
+	 * Guards {@link #close()} so that it runs once, and marks this store as unusable afterwards.
+	 */
+	private final AtomicBoolean closed = new AtomicBoolean();
+
+	/**
+	 * How long {@link #close()} waits for each notification executor to finish before logging and
+	 * moving on. The tasks are short-lived listener callbacks, so this only covers a listener that
+	 * ignores interruption.
+	 */
+	private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
+
+
 	/**
 	 * Constructs a new EventStoreImpl instance backed by the specified storage with observability support.
 	 * <p>
@@ -171,10 +189,46 @@ public class EventStoreImpl implements EventStore {
 		this.executorServiceForBookmarkUpdates = Executors.newSingleThreadExecutor(threadFactory);
 	}
 
+	/**
+	 * Shuts down this store's notification executors, leaving the storage open.
+	 * <p>
+	 * Idempotent, and bounded: the executors are interrupted and awaited briefly. The storage was handed
+	 * to this store rather than created by it, and may well be backing other stores, so closing it is
+	 * not this store's call — see {@link EventStore#close()}. A store that must close its storage is
+	 * composed with {@link EventStore#owning(EventStore, EventStorage)}, which is what the storage
+	 * builders' {@code buildStore()} returns.
+	 * <p>
+	 * Once closed, this store's streams stop working and its listeners fall silent, but nothing it does
+	 * disturbs another store on the same storage.
+	 */
+	@Override
+	public void close ( ) {
+		if ( !closed.compareAndSet(false, true) ) {
+			return;
+		}
+		shutdown(executorServiceForEventAppends);
+		shutdown(executorServiceForBookmarkUpdates);
+	}
+
+	private void shutdown ( ExecutorService executorService ) {
+		executorService.shutdownNow();
+		try {
+			if ( !executorService.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS) ) {
+				STORE_LOGGER.warn("notification threads of event store '{}' did not terminate within {}s", eventStorage.name(), SHUTDOWN_TIMEOUT_SECONDS);
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
 	@Override
 	public <EVENT_TYPE> EventStream<EVENT_TYPE> getEventStream(EventStreamId eventStreamId, Set<Class<?>> eventRootClasses, Set<Class<?>> historicalEventRootClasses ) {
-		
-		EventPayloadSerializerDeserializer serde; 
+
+		if ( closed.get() ) {
+			throw new EventStorageClosedException("event store on storage '%s' is closed".formatted(eventStorage.name()));
+		}
+
+		EventPayloadSerializerDeserializer serde;
 		if ( eventRootClasses != null && eventRootClasses.size() > 0 ) {
 			// use typed event payloads, mapped to Java objects
 			serde = EventPayloadSerializerDeserializer.typed();
@@ -245,6 +299,17 @@ public class EventStoreImpl implements EventStore {
 			meterRegistry.counter("sliceworkz.eventstore.stream.create", baseTags).increment();
 		}
 		
+		/**
+		 * Throws if the store this stream came from has been closed. A stream outliving its store would
+		 * otherwise keep reading and writing — the storage may still be open, serving other stores —
+		 * while silently receiving no notifications, which is exactly how a projection stalls unnoticed.
+		 */
+		private void checkStoreNotClosed ( ) {
+			if ( closed.get() ) {
+				throw new EventStorageClosedException("the event store this stream (%s) came from is closed".formatted(eventStreamId));
+			}
+		}
+
 		@Override
 		public EventStreamId id() {
 			return eventStreamId;
@@ -252,21 +317,25 @@ public class EventStoreImpl implements EventStore {
 
 		@Override
 		public void subscribe(EventStreamEventuallyConsistentAppendListener eventuallyConsistentSubscriber) {
+			checkStoreNotClosed();
 			this.eventuallyConsistentSubscribers.add(new OptimizingApendListenerDecorator(eventuallyConsistentSubscriber));
 		}
 
 		@Override
 		public void subscribe(EventStreamConsistentAppendListener<EVENT_TYPE> consistentSubscriber) {
+			checkStoreNotClosed();
 			this.consistentSubscribers.add(consistentSubscriber);
 		}
 
 		@Override
 		public void subscribe(EventStreamEventuallyConsistentBookmarkListener listener) {
+			checkStoreNotClosed();
 			this.bookmarkSubscribers.add(listener);
 		}
 
 		@Override
 		public Stream<Event<EVENT_TYPE>> query(EventQuery query, EventReference cursor, Limit limit, Consumer<EventReference> storedEventCursorTracker ) {
+			checkStoreNotClosed();
 			meterQuery.increment(); // one query done
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
 			EventFilter originalFilter = query.filter();
@@ -319,6 +388,7 @@ public class EventStoreImpl implements EventStore {
 		}
 		@Override
 		public List<Event<EVENT_TYPE>> append(AppendCriteria appendCriteria, List<EphemeralEvent<? extends EVENT_TYPE>> events, EventStreamId streamToAppendTo) {
+			checkStoreNotClosed();
 			
 			if ( !streamToAppendTo.canAppendTo(eventStreamId)) {
 				throw new IllegalArgumentException("cannot append to eventstream %s using streamId %s".formatted(eventStreamId, streamToAppendTo));
@@ -389,6 +459,14 @@ public class EventStoreImpl implements EventStore {
 
 		@Override
 		public void notify(AppendsToEventStoreNotification newEventsInStore) {
+			// A storage outlives the stores built on it, and keeps notifying every stream ever registered
+			// with it -- including ours, after our store was closed and its executors shut down. Dropping
+			// the notification here is what keeps a closed store from poisoning the storage it shares:
+			// submitting to a terminated executor throws RejectedExecutionException into whoever is
+			// notifying, which on Postgres is the LISTEN/NOTIFY monitor thread, and would kill it.
+			if ( closed.get() ) {
+				return;
+			}
 			// if the events are in the logical stream we care about...
 			if ( newEventsInStore.isRelevantFor(eventStreamId) ) {
 				LOGGER.debug("Must asynchronously notify {} eventually consistent clients of stream {} about append up until at least {}", eventuallyConsistentSubscribers.size(), eventStreamId, newEventsInStore.atLeastUntil());
@@ -403,6 +481,9 @@ public class EventStoreImpl implements EventStore {
 
 		@Override
 		public void notify(BookmarkPlacedNotification bookmarkPlaced) {
+			if ( closed.get() ) {
+				return; // see notify(AppendsToEventStoreNotification)
+			}
 			LOGGER.debug("Must asynchronously notify {} eventually consistent bookmark listeners on {} of update for {} to {}", eventuallyConsistentSubscribers.size(), eventStreamId, bookmarkPlaced.reader(), bookmarkPlaced.bookmark());
 			
 			// schedule for execution on different thread to notify/interrupt any waiting eventual consistent processors 
@@ -414,12 +495,14 @@ public class EventStoreImpl implements EventStore {
 
 		@Override
 		public void placeBookmark(String reader, EventReference reference, Tags tags) {
+			checkStoreNotClosed();
 			meterBookmarkPlace.increment();
 			eventStorage.bookmark(reader, reference, tags);
 		}
 
 		@Override
 		public Optional<EventReference> removeBookmark(String reader) {
+			checkStoreNotClosed();
 			Optional<EventReference> result = getBookmark(reader);
 			if ( result.isPresent() ) {
 				eventStorage.removeBookmark(reader);
@@ -429,18 +512,21 @@ public class EventStoreImpl implements EventStore {
 
 		@Override
 		public Optional<EventReference> getBookmark(String reader) {
+			checkStoreNotClosed();
 			meterBookmarkGet.increment();
 			return eventStorage.getBookmark(reader.toString());
 		}
 
 		@Override
 		public List<Bookmark> getBookmarks() {
+			checkStoreNotClosed();
 			meterBookmarkList.increment();
 			return eventStorage.getBookmarks();
 		}
 
 		@Override
 		public List<Event<EVENT_TYPE>> getEventById(EventId eventId) {
+			checkStoreNotClosed();
 			meterGetEvent.increment();
 			// filters out events that can not be read by this stream, then upcasts via enrich
 			return eventStorage.getEventById(eventId)

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -461,18 +462,16 @@ public class EventStoreImpl implements EventStore {
 		public void notify(AppendsToEventStoreNotification newEventsInStore) {
 			// A storage outlives the stores built on it, and keeps notifying every stream ever registered
 			// with it -- including ours, after our store was closed and its executors shut down. Dropping
-			// the notification here is what keeps a closed store from poisoning the storage it shares:
-			// submitting to a terminated executor throws RejectedExecutionException into whoever is
-			// notifying, which on Postgres is the LISTEN/NOTIFY monitor thread, and would kill it.
+			// the notification is what keeps a closed store from poisoning the storage it shares.
 			if ( closed.get() ) {
 				return;
 			}
 			// if the events are in the logical stream we care about...
 			if ( newEventsInStore.isRelevantFor(eventStreamId) ) {
 				LOGGER.debug("Must asynchronously notify {} eventually consistent clients of stream {} about append up until at least {}", eventuallyConsistentSubscribers.size(), eventStreamId, newEventsInStore.atLeastUntil());
-				
-				// schedule for execution on different thread to notify/interrupt any waiting eventual consistent processors 
-				executorServiceForEventAppends.execute( ( ) -> {
+
+				// schedule for execution on different thread to notify/interrupt any waiting eventual consistent processors
+				submitOrDropIfClosed(executorServiceForEventAppends, ( ) -> {
 						LOGGER.debug("Notifying {} eventually consistent clients of stream {} about append up until at least {}", eventuallyConsistentSubscribers.size(), eventStreamId, newEventsInStore.atLeastUntil());
 						eventuallyConsistentSubscribers.stream().forEach(s->s.eventsAppended(newEventsInStore.atLeastUntil()));
 				});
@@ -485,12 +484,29 @@ public class EventStoreImpl implements EventStore {
 				return; // see notify(AppendsToEventStoreNotification)
 			}
 			LOGGER.debug("Must asynchronously notify {} eventually consistent bookmark listeners on {} of update for {} to {}", eventuallyConsistentSubscribers.size(), eventStreamId, bookmarkPlaced.reader(), bookmarkPlaced.bookmark());
-			
-			// schedule for execution on different thread to notify/interrupt any waiting eventual consistent processors 
-			executorServiceForBookmarkUpdates.execute( ( ) -> {
+
+			// schedule for execution on different thread to notify/interrupt any waiting eventual consistent processors
+			submitOrDropIfClosed(executorServiceForBookmarkUpdates, ( ) -> {
 					LOGGER.debug("Notifying {} eventually consistent bookmark listeners on {} of update for {} to {}", eventuallyConsistentSubscribers.size(), eventStreamId, bookmarkPlaced.reader(), bookmarkPlaced.bookmark());
 					bookmarkSubscribers.stream().forEach(s->s.bookmarkUpdated(bookmarkPlaced.reader(), bookmarkPlaced.bookmark()));
 			});
+		}
+
+		/**
+		 * Hands a notification to an executor, dropping it if this store was closed in the meantime.
+		 * <p>
+		 * The {@code closed} check in the callers is only an early out: it cannot close the window, since
+		 * {@link #close()} can shut the executors down between that check and this submit. Whoever is
+		 * notifying must not see the rejection either way — on Postgres that is the LISTEN/NOTIFY monitor
+		 * thread, shared by every store on the storage, and an exception escaping it kills notifications
+		 * for all of them. Dropping the notification is exactly what closing the store asked for.
+		 */
+		private void submitOrDropIfClosed ( ExecutorService executorService, Runnable notification ) {
+			try {
+				executorService.execute(notification);
+			} catch ( RejectedExecutionException closedWhileNotifying ) {
+				LOGGER.debug("event store closed while notifying stream {}; notification dropped", eventStreamId);
+			}
 		}
 
 		@Override

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorage.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorage.java
@@ -169,7 +169,10 @@ public interface InMemoryFsEventStorage {
 		 * @return a new EventStore instance backed by file-persisted in-memory storage
 		 */
 		public EventStore buildStore ( ) {
-			return EventStoreFactory.get().eventStore(build(), meterRegistry);
+			// the storage is created here and never handed to the caller, so the returned store owns it:
+			// closing that store is the only way this storage will ever be closed
+			EventStorage eventStorage = build();
+			return EventStore.owning(EventStoreFactory.get().eventStore(eventStorage, meterRegistry), eventStorage);
 		}
 	}
 

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -160,6 +160,18 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 		deleteBookmark(reader);
 	}
 
+	/**
+	 * Closes this storage by closing its in-memory delegate.
+	 * <p>
+	 * Nothing is buffered on this side: every event and bookmark is written to its own file with a
+	 * single {@code Files.writeString} as it is appended, so there is nothing to flush and no handle to
+	 * release. Closing only stops further operations, per the contract on {@link EventStorage#close()}.
+	 */
+	@Override
+	public void close ( ) {
+		delegate.close();
+	}
+
 	// --- persistence: writing ---
 
 	private void persistEvent ( StoredEvent event ) {

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorage.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorage.java
@@ -295,7 +295,10 @@ public interface InMemoryEventStorage {
 		 * @see EventStoreFactory#eventStore(EventStorage)
 		 */
 		public EventStore buildStore ( ) {
-			return EventStoreFactory.get().eventStore(build(), meterRegistry);
+			// the storage is created here and never handed to the caller, so the returned store owns it:
+			// closing that store is the only way this storage will ever be closed
+			EventStorage eventStorage = build();
+			return EventStore.owning(EventStoreFactory.get().eventStore(eventStorage, meterRegistry), eventStorage);
 		}
 	}
 	

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -35,6 +35,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
@@ -103,6 +105,8 @@ import tools.jackson.databind.json.JsonMapper;
  * @see InMemoryEventStorage.Builder
  */
 public class InMemoryEventStorageImpl implements EventStorage {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryEventStorageImpl.class);
 
 	private String name;
 	private List<StoredEvent> eventlog = new CopyOnWriteArrayList<>();
@@ -339,7 +343,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 			    .values()
 			    .forEach(notification->listeners.forEach(listener->{
 			    	if (listener.get()!=null){
-			    		listener.get().notify(notification);
+			    		notifyQuietly(listener.get(), notification);
 			    	};
 			    }));
 	}
@@ -488,7 +492,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		BookmarkPlacedNotification notification = new BookmarkPlacedNotification(reader, eventReference);
 		listeners.forEach(l->{
 			if ( l.get() != null ) {
-				l.get().notify(notification);
+				notifyQuietly(l.get(), notification);
 			}
 		});
 	}
@@ -536,6 +540,32 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 *
 	 * @return the unique name of this storage instance
 	 */
+	/**
+	 * Notifies one listener, containing its failure.
+	 * <p>
+	 * Listeners are notified inline here, on the thread that appended or bookmarked, so a listener
+	 * throwing would otherwise fail an operation that has already succeeded — the event is stored, and
+	 * reporting it as failed invites the caller to append it twice. It would also rob every listener
+	 * after it in the list of the notification. A backend delivering on a thread of its own has the
+	 * same duty for a starker reason: there, one listener's throwable kills notifications for
+	 * everybody.
+	 */
+	private void notifyQuietly ( EventStoreListener listener, AppendsToEventStoreNotification notification ) {
+		try {
+			listener.notify(notification);
+		} catch ( Exception e ) {
+			LOGGER.error("event store listener failed handling an append notification: {}", e.getMessage(), e);
+		}
+	}
+
+	private void notifyQuietly ( EventStoreListener listener, BookmarkPlacedNotification notification ) {
+		try {
+			listener.notify(notification);
+		} catch ( Exception e ) {
+			LOGGER.error("event store listener failed handling a bookmark notification: {}", e.getMessage(), e);
+		}
+	}
+
 	@Override
 	public String name() {
 		return name;

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +43,7 @@ import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventImportConflictException;
 import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorageClosedException;
 import org.sliceworkz.eventstore.spi.EventStorageException;
 import org.sliceworkz.eventstore.spi.EventToImport;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
@@ -116,6 +118,11 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	private JsonMapper jsonMapper;
 	private Limit absoluteLimit;
 	private long txCounter;
+	// This backend holds no threads, connections or file handles, so close() has nothing to release.
+	// It still marks itself closed, so that the post-close behaviour required by EventStorage.close()
+	// is the same here as on a backend that does — code that outlives its storage fails the same way
+	// against every backend, in tests as in production.
+	private final AtomicBoolean closed = new AtomicBoolean();
 
 	/**
 	 * Constructs a new in-memory event storage instance with the specified name and absolute query limit.
@@ -202,6 +209,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 */
 	@Override
 	public synchronized Stream<StoredEvent> query(EventQuery query, Optional<EventStreamId> stream, EventReference after, Limit limit, QueryDirection direction ) {
+		checkNotClosed();
 		Stream<StoredEvent> on;
 
 		switch ( direction ) {
@@ -256,6 +264,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 */
 	@Override
 	public synchronized List<StoredEvent> append(AppendCriteria appendCriteria, Optional<EventStreamId> streamId, List<EventToStore> events) {
+		checkNotClosed();
 		
 		verifyPersistableJson(events);
 		
@@ -359,6 +368,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 */
 	@Override
 	public synchronized List<StoredEvent> importEvents ( List<EventToImport> events, ImportMode mode ) {
+		checkNotClosed();
 		if ( events == null ) {
 			throw new IllegalArgumentException("events to import must not be null");
 		}
@@ -441,32 +451,38 @@ public class InMemoryEventStorageImpl implements EventStorage {
 
 	@Override
 	public synchronized Optional<StoredEvent> getEventById(EventId eventId) {
+		checkNotClosed();
 		return Optional.ofNullable(eventsById.get(eventId));
 	}
 
 	@Override
 	public void subscribe(EventStoreListener listener) {
+		checkNotClosed();
 		listeners.add(new WeakReference<>(listener));
 		listeners.removeIf(ref -> ref.get() == null);
 	}
 
 	@Override
 	public synchronized Optional<EventReference> getBookmark(String reader) {
+		checkNotClosed();
 		return Optional.ofNullable(bookmarks.get(reader)).map(Bookmark::reference);
 	}
 
 	@Override
 	public synchronized List<Bookmark> getBookmarks() {
+		checkNotClosed();
 		return List.copyOf(bookmarks.values());
 	}
 
 	@Override
 	public synchronized void removeBookmark(String reader) {
+		checkNotClosed();
 		bookmarks.remove(reader);
 	}
 
 	@Override
 	public synchronized void bookmark(String reader, EventReference eventReference, Tags tags ) {
+		checkNotClosed();
 		Tags effectiveTags = tags == null ? Tags.none() : tags;
 		bookmarks.put(reader, new Bookmark(reader, eventReference, effectiveTags, Instant.now()));
 		BookmarkPlacedNotification notification = new BookmarkPlacedNotification(reader, eventReference);
@@ -523,6 +539,26 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	@Override
 	public String name() {
 		return name;
+	}
+
+	/**
+	 * Marks this storage closed. There is nothing to release — the events live on the heap and go away
+	 * with the instance — but the post-close contract on {@link EventStorage#close()} still applies, so
+	 * that code which outlives its storage fails identically against every backend.
+	 * <p>
+	 * Idempotent. The events are deliberately not discarded: a closed storage rejects operations rather
+	 * than quietly answering from a half-torn-down state, and dropping the log would only make
+	 * diagnosing a lifecycle bug harder.
+	 */
+	@Override
+	public void close ( ) {
+		closed.set(true);
+	}
+
+	private void checkNotClosed ( ) {
+		if ( closed.get() ) {
+			throw new EventStorageClosedException("event storage '%s' is closed".formatted(name));
+		}
 	}
 
 	/**

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
@@ -81,11 +81,26 @@ import io.micrometer.core.instrument.Metrics;
  * // Using default configuration from db.properties file (default mode is ENSURE)
  * EventStore eventStore = PostgresEventStorage.newBuilder().buildStore();
  *
- * // Test environment: fresh schema every time
- * EventStore eventStore = PostgresEventStorage.newBuilder()
- *     .initializeDatabase()
- *     .buildStore();
+ * // Test environment: fresh schema every time, closed when the block ends
+ * try ( EventStore eventStore = PostgresEventStorage.newBuilder()
+ *         .initializeDatabase()
+ *         .buildStore() ) {
+ *     ...
+ * }
  * }</pre>
+ *
+ * <h2>Lifecycle:</h2>
+ * This storage runs two LISTEN/NOTIFY monitor threads, each holding a JDBC connection, and — unless you
+ * supply a {@link DataSource} yourself — the connection pools behind them. A store that lives as long as
+ * the process needs no explicit shutdown; one created per tenant, per test or per reload must be
+ * {@link EventStorage#close() closed}, or its threads, connections and pools stay alive for good: the
+ * running monitor threads keep the storage reachable, so garbage collection will not clean up after you.
+ * <p>
+ * Closing an {@link EventStore} does not close a storage you handed to it — a storage can back several
+ * stores and usually outlives them. The store returned by {@link Builder#buildStore()} is the exception:
+ * it created the storage and returns no other handle on it, so closing it closes both. A DataSource you
+ * passed in is never closed; one this builder created is. See {@link EventStorage#close()} for the full
+ * contract.
  *
  * <h2>Advanced Configuration Example:</h2>
  * <pre>{@code
@@ -425,6 +440,11 @@ public interface PostgresEventStorage {
 		 * <p>
 		 * The returned EventStorage can be passed to {@link EventStoreFactory#eventStore(EventStorage)}
 		 * to create an EventStore instance.
+		 * <p>
+		 * The returned storage is already started: its LISTEN/NOTIFY monitor threads are running and
+		 * holding connections. Close it with {@link EventStorage#close()} when done — and note that if no
+		 * {@link #dataSource(DataSource)} was supplied, this method also creates the connection pools, and
+		 * closing the storage is then the only thing that will ever close them.
 		 *
 		 * @return a configured EventStorage instance backed by PostgreSQL
 		 * @throws RuntimeException if database configuration cannot be loaded or schema operations fail
@@ -432,11 +452,15 @@ public interface PostgresEventStorage {
 		 * @see EventStoreFactory#eventStore(EventStorage)
 		 */
 		public EventStorage build ( ) {
+			// a DataSource we create here belongs to the storage, and is closed by EventStorage.close();
+			// one the caller passed in stays the caller's, and is never touched
+			boolean createdDataSources = false;
 			if ( dataSource == null ) {
 				Properties dbProperties = DataSourceFactory.loadProperties();
 				if ( dataSource == null ) {
 					dataSource = DataSourceFactory.fromConfiguration(dbProperties, "pooled");
 					monitoringDataSource = DataSourceFactory.fromConfiguration(dbProperties, "nonpooled");
+					createdDataSources = true;
 				}
 				if ( monitoringDataSource == null ) {
 					monitoringDataSource = dataSource;
@@ -458,22 +482,43 @@ public interface PostgresEventStorage {
 				}
 			}
 
-			boolean nativeUuidv7 = detectsNativeUuidv7Support(dataSource);
+			try {
+				boolean nativeUuidv7 = detectsNativeUuidv7Support(dataSource);
 
-			PostgresEventStorageImpl result = nativeUuidv7
-				? new PostgresEventStorageImpl(name, dataSource, monitoringDataSource, limit, prefix)
-				: new PostgresLegacyEventStorageImpl(name, dataSource, monitoringDataSource, limit, prefix);
+				PostgresEventStorageImpl result = nativeUuidv7
+					? new PostgresEventStorageImpl(name, dataSource, monitoringDataSource, limit, prefix, createdDataSources)
+					: new PostgresLegacyEventStorageImpl(name, dataSource, monitoringDataSource, limit, prefix, createdDataSources);
 
-			switch ( databaseInitMode ) {
-				case NONE       -> { }
-				case VALIDATE   -> result.validateDatabase();
-				case ENSURE     -> result.ensureDatabase();
-				case INITIALIZE -> result.initializeDatabase();
+				switch ( databaseInitMode ) {
+					case NONE       -> { }
+					case VALIDATE   -> result.validateDatabase();
+					case ENSURE     -> result.ensureDatabase();
+					case INITIALIZE -> result.initializeDatabase();
+				}
+				// if we didn't fail until here, then we can start the executor threads
+				result.start();
+				return result;
+			} catch (RuntimeException e) {
+				// version detection or schema handling failed: don't strand the pools we just created
+				if ( createdDataSources ) {
+					closeQuietly(dataSource);
+					if ( monitoringDataSource != dataSource ) {
+						closeQuietly(monitoringDataSource);
+					}
+				}
+				throw e;
 			}
-			// if we didn't fail until here, then we can start the executor threads
-			result.start();
-			return result;
 
+		}
+
+		private static void closeQuietly ( DataSource dataSource ) {
+			if ( dataSource instanceof AutoCloseable closeable ) {
+				try {
+					closeable.close();
+				} catch (Exception e) {
+					LOGGER.warn("failed to close a DataSource after a failed build(): {}", e.getMessage(), e);
+				}
+			}
 		}
 
 		/**
@@ -488,6 +533,11 @@ public interface PostgresEventStorage {
 		 * EventStorage storage = builder.build();
 		 * EventStore eventStore = EventStoreFactory.get().eventStore(storage);
 		 * }</pre>
+		 * <p>
+		 * The returned EventStore is the only handle on the storage this creates, so it is also the only
+		 * way to shut it down: {@link EventStore#close()} stops the monitor threads and closes the
+		 * connection pools created here. Use try-with-resources unless the store is meant to live as long
+		 * as the process.
 		 *
 		 * @return a fully configured EventStore backed by PostgreSQL
 		 * @throws RuntimeException if database configuration cannot be loaded or schema initialization fails
@@ -495,7 +545,10 @@ public interface PostgresEventStorage {
 		 * @see EventStoreFactory#eventStore(EventStorage)
 		 */
 		public EventStore buildStore ( ) {
-			return EventStoreFactory.get().eventStore(build(), meterRegistry);
+			// the storage is created here and never handed to the caller, so the returned store owns it:
+			// closing that store is the only way this storage will ever be closed
+			EventStorage eventStorage = build();
+			return EventStore.owning(EventStoreFactory.get().eventStore(eventStorage, meterRegistry), eventStorage);
 		}
 
 		/**

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -50,6 +50,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import javax.sql.DataSource;
@@ -71,6 +73,7 @@ import org.sliceworkz.eventstore.query.EventFilterItem;
 import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventImportConflictException;
 import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorageClosedException;
 import org.sliceworkz.eventstore.spi.EventStorageException;
 import org.sliceworkz.eventstore.spi.EventToImport;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
@@ -139,14 +142,44 @@ public class PostgresEventStorageImpl implements EventStorage {
 	private final DataSource monitoringDataSource;
 	private final Limit absoluteLimit;
 
+	/**
+	 * Whether the DataSources were created by {@link PostgresEventStorage.Builder} rather than supplied
+	 * by the caller, and must therefore be closed by {@link #close()}. A caller-supplied pool is never
+	 * touched — closing someone else's pool is worse than leaking our own.
+	 */
+	private final boolean ownsDataSources;
+
 	private final List<WeakReference<EventStoreListener>> listeners = new CopyOnWriteArrayList<>();
 	private final ExecutorService executorService;
-	private volatile boolean stopped;
+	private final AtomicBoolean stopped = new AtomicBoolean();
 
 	private static final JsonMapper JSONMAPPER = JsonMapper.builder().build();
 
-	private static final int THIRTY_SECONDS = 30*1000;
-	public static final int WAIT_FOR_NOTIFICATIONS_TIMEOUT = THIRTY_SECONDS;
+	/**
+	 * How long a single {@code getNotifications} call blocks before returning empty-handed.
+	 * <p>
+	 * This is a polling slice, not a deadline: the monitors loop on it, so it costs one parked socket
+	 * read per interval and nothing else, and notification delivery is unaffected — a notification
+	 * returns the call immediately. It is short because it doubles as how quickly a monitor notices it
+	 * has been stopped: the monitor then finishes on its own, UNLISTENs, and hands its connection back
+	 * to the pool intact. Interrupting it instead would be faster, but it closes the socket underneath
+	 * the driver, so the pool discards the connection and logs a stack trace about it on every shutdown.
+	 */
+	public static final int WAIT_FOR_NOTIFICATIONS_TIMEOUT = 100;
+
+	/**
+	 * How long {@link #close()} waits for the monitors to finish by themselves before resorting to
+	 * interrupting them. Comfortably more than {@link #WAIT_FOR_NOTIFICATIONS_TIMEOUT} plus an UNLISTEN
+	 * round trip, so the tidy path is the one that normally happens.
+	 */
+	private static final long GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS = 2_000;
+
+	/**
+	 * How long {@link #close()} waits for the monitor threads to finish after interrupting them, before
+	 * giving up and logging. Only reached when a monitor is wedged somewhere it did not notice being
+	 * stopped — inside a listener callback that ignores interruption, for instance.
+	 */
+	private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
 
 	private static final long INITIAL_RETRY_DELAY_MS = 1_000;
 	private static final long MAX_RETRY_DELAY_MS = 30_000;
@@ -173,11 +206,32 @@ public class PostgresEventStorageImpl implements EventStorage {
 	 * @see PostgresEventStorage.Builder#build()
 	 */
 	public PostgresEventStorageImpl ( String name, DataSource dataSource, DataSource monitoringDataSource, Limit absoluteLimit, String prefix ) {
+		this(name, dataSource, monitoringDataSource, absoluteLimit, prefix, false);
+	}
+
+	/**
+	 * Constructs a new PostgreSQL-backed event storage instance, stating who owns the DataSources.
+	 * <p>
+	 * This constructor is used by {@link PostgresEventStorage.Builder} and should not be called
+	 * directly. It exists so that {@link #close()} can close a pool the builder created without ever
+	 * closing one the caller supplied.
+	 *
+	 * @param name the logical name for this storage instance (used in logging and monitoring)
+	 * @param dataSource the main JDBC DataSource for event operations
+	 * @param monitoringDataSource the JDBC DataSource for LISTEN/NOTIFY operations
+	 * @param absoluteLimit the absolute limit on query results, or {@link Limit#none()} for no limit
+	 * @param prefix the table name prefix (validated, or empty string for no prefix)
+	 * @param ownsDataSources {@code true} if the DataSources were created for this storage and should
+	 *                        be closed by {@link #close()}; {@code false} if they belong to the caller
+	 * @see PostgresEventStorage.Builder#build()
+	 */
+	public PostgresEventStorageImpl ( String name, DataSource dataSource, DataSource monitoringDataSource, Limit absoluteLimit, String prefix, boolean ownsDataSources ) {
 		this.prefix = validatePrefix(prefix);
 		this.name = name;
 		this.dataSource = dataSource;
 		this.monitoringDataSource = monitoringDataSource;
 		this.absoluteLimit = absoluteLimit;
+		this.ownsDataSources = ownsDataSources;
 
 		this.executorService = Executors.newVirtualThreadPerTaskExecutor();
 	}
@@ -540,7 +594,18 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 	}
 	
+	/**
+	 * Starts the LISTEN/NOTIFY monitor threads and blocks until both have registered their listener.
+	 * <p>
+	 * Called by {@link PostgresEventStorage.Builder#build()}; a storage handed to application code is
+	 * always already started. A stopped storage is terminal and cannot be started again.
+	 *
+	 * @throws IllegalStateException if this storage has been stopped
+	 */
 	public void start ( ) {
+		if ( stopped.get() ) {
+			throw new IllegalStateException("event storage '%s' has been stopped and cannot be started again".formatted(name));
+		}
 		CountDownLatch eventMonitorReady = new CountDownLatch(1);
 		CountDownLatch bookmarkMonitorReady = new CountDownLatch(1);
 		this.executorService.execute(new NewEventsAppendedMonitor("event-append-listener/" + name, listeners, monitoringDataSource, eventMonitorReady));
@@ -552,14 +617,106 @@ public class PostgresEventStorageImpl implements EventStorage {
 			Thread.currentThread().interrupt();
 		}
 	}
-	
+
+	/**
+	 * Closes this storage: stops the LISTEN/NOTIFY monitor threads, then closes the DataSources if —
+	 * and only if — they were created by the builder rather than supplied by the caller.
+	 * <p>
+	 * Implements the contract on {@link EventStorage#close()}: idempotent, blocking until the monitor
+	 * threads have actually finished and released their connections (typically within
+	 * {@value #WAIT_FOR_NOTIFICATIONS_TIMEOUT}ms, bounded), terminal, and after it every operation on
+	 * this storage throws {@link EventStorageClosedException}.
+	 * <p>
+	 * A caller who supplied the DataSource must close this storage <em>before</em> closing that pool.
+	 * The other order leaves the monitors alive against a dead pool, where they cannot tell a closed
+	 * pool from a database outage and will retry with backoff, logging as they go.
+	 */
+	@Override
+	public void close ( ) {
+		boolean wasRunning = stopMonitors();
+		if ( wasRunning && ownsDataSources ) {
+			closeDataSource(dataSource);
+			if ( monitoringDataSource != dataSource ) {
+				closeDataSource(monitoringDataSource);
+			}
+		}
+	}
+
+	private void closeDataSource ( DataSource dataSourceToClose ) {
+		if ( dataSourceToClose instanceof AutoCloseable closeable ) {
+			try {
+				closeable.close();
+			} catch (Exception e) {
+				LOGGER.warn("failed to close the DataSource created for event storage '{}': {}", name, e.getMessage(), e);
+			}
+		}
+	}
+
+	/**
+	 * Stops the LISTEN/NOTIFY monitor threads and waits for them to finish.
+	 * <p>
+	 * The monitors poll for notifications in {@value #WAIT_FOR_NOTIFICATIONS_TIMEOUT}ms slices, so they
+	 * see the stop flag within that and wind themselves up: UNLISTEN, then the connection returns to the
+	 * pool healthy and no shutdown noise is logged. Only if that has not happened within
+	 * {@value #GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS}ms are they interrupted, which is abrupt — it closes the
+	 * socket underneath the driver, so the pool discards the connection and logs a "marked as broken"
+	 * warning about it.
+	 * <p>
+	 * Idempotent: only the first call does anything, later calls return immediately. When this method
+	 * returns, no monitor thread of this storage is running any more (unless the bounded wait expired,
+	 * which is logged).
+	 *
+	 * @deprecated use {@link #close()} instead, which is on the {@link EventStorage} interface and so
+	 *             needs no downcast, and which additionally closes DataSources the builder created.
+	 *             This method now simply delegates to it.
+	 */
+	@Deprecated(since = "0.10.0", forRemoval = true)
 	public void stop ( ) {
-		this.stopped = true;
+		close();
+	}
+
+	/**
+	 * Interrupts the monitor threads and waits for them to finish.
+	 *
+	 * @return {@code true} if this call was the one that stopped them, {@code false} if they were
+	 *         already stopped
+	 */
+	private boolean stopMonitors ( ) {
+		if ( !stopped.compareAndSet(false, true) ) {
+			return false;
+		}
 		executorService.shutdown();
+		try {
+			// the monitors check the flag every WAIT_FOR_NOTIFICATIONS_TIMEOUT and wind themselves up
+			// cleanly: UNLISTEN, then the connection goes back to the pool healthy
+			if ( !executorService.awaitTermination(GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS) ) {
+				// a monitor is stuck somewhere it cannot see the flag; interrupt it, accepting that this
+				// breaks its connection under the driver and that the pool will say so
+				LOGGER.debug("monitor threads of event storage '{}' did not stop on their own, interrupting them", name);
+				executorService.shutdownNow();
+				if ( !executorService.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS) ) {
+					LOGGER.warn("monitor threads of event storage '{}' did not terminate within {}s", name, SHUTDOWN_TIMEOUT_SECONDS);
+				}
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		return true;
+	}
+
+	/**
+	 * Throws if this storage has been closed. Called at the top of every operation, so that a closed
+	 * storage fails immediately and locatably instead of half-working with dead notifications.
+	 */
+	private void checkNotClosed ( ) {
+		if ( stopped.get() ) {
+			throw new EventStorageClosedException("event storage '%s' is closed".formatted(name));
+		}
 	}
 
 	@Override
 	public Stream<StoredEvent> query(EventQuery query, Optional<EventStreamId> stream, EventReference after, Limit limit, QueryDirection direction ) {
+		checkNotClosed();
 		// Handle the case where query matches none - return empty stream
 		if (query.isMatchNone()) {
 			return Stream.empty();
@@ -746,6 +903,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 	@Override
 	public List<StoredEvent> append(AppendCriteria appendCriteria, Optional<EventStreamId> streamId, List<EventToStore> events) {
+		checkNotClosed();
 		List<StoredEvent> storedEvents = new ArrayList<>();
 
 		if ( events.size() != 0 ) {
@@ -904,6 +1062,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 	@Override
 	public List<StoredEvent> importEvents ( List<EventToImport> events, ImportMode mode ) {
+		checkNotClosed();
 		if ( events == null ) {
 			throw new IllegalArgumentException("events to import must not be null");
 		}
@@ -1109,6 +1268,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 	@Override
 	public Optional<StoredEvent> getEventById(EventId eventId) {
+		checkNotClosed();
 		if ( eventId != null ) {
 			String sql = """
 				SELECT event_position, event_tx::text, event_id, stream_context, stream_purpose, event_type, event_timestamp, event_data, event_erasable_data, event_tags, idempotency_key
@@ -1194,7 +1354,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 			String unlistenStatement = "UNLISTEN %sevent_appended;".formatted(prefix);
 
 			long retryDelayMs = INITIAL_RETRY_DELAY_MS;
-			while ( !stopped ) {
+			while ( !stopped.get() ) {
 
 				try ( Connection monitorConnection = monitoringDataSource.getConnection(); Statement stmt = monitorConnection.createStatement() ){
 					// Ensure connection is in the right state for LISTEN
@@ -1209,11 +1369,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 					retryDelayMs = INITIAL_RETRY_DELAY_MS;
 
-					while ( !stopped ) { // loop using a single connnection without returning it to the pool
+					while ( !stopped.get() ) { // loop using a single connnection without returning it to the pool
 
 						LOGGER.debug("checking for notifications...");
 
-						PGNotification[] notifications = pgConn.getNotifications(WAIT_FOR_NOTIFICATIONS_TIMEOUT); // wait at max so long for new notifications, then ask new connection and start waiting again
+						PGNotification[] notifications = pgConn.getNotifications(WAIT_FOR_NOTIFICATIONS_TIMEOUT); // returns as soon as a notification arrives, otherwise empty-handed after the poll slice
 
 					    if (notifications != null) {
 					        for (PGNotification notification : notifications) {
@@ -1244,15 +1404,17 @@ public class PostgresEventStorageImpl implements EventStorage {
 					}
 
 				} catch (SQLException e) {
-					if ( !stopped ) {
-						LOGGER.error(e.getMessage(), e);
-						try {
-							Thread.sleep(retryDelayMs);
-							retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
-						} catch (InterruptedException ie) {
-							Thread.currentThread().interrupt();
-							return;
-						}
+					if ( stopped.get() || Thread.currentThread().isInterrupted() ) {
+						// shutting down: the connection was closed underneath us on purpose, nothing to report
+						return;
+					}
+					LOGGER.error(e.getMessage(), e);
+					try {
+						Thread.sleep(retryDelayMs);
+						retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						return;
 					}
 				} finally {
 					LOGGER.debug("loop done.");
@@ -1290,7 +1452,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 			JsonMapper jsonMapper = JsonMapper.builder().build();
 
 			long retryDelayMs = INITIAL_RETRY_DELAY_MS;
-			while ( !stopped ) {
+			while ( !stopped.get() ) {
 
 				try ( Connection monitorConnection = monitoringDataSource.getConnection(); Statement stmt = monitorConnection.createStatement() ){
 					// Ensure connection is in the right state for LISTEN
@@ -1305,11 +1467,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 					retryDelayMs = INITIAL_RETRY_DELAY_MS;
 
-					while ( !stopped ) { // reuse single connection without returing in tot the pool
+					while ( !stopped.get() ) { // reuse single connection without returing in tot the pool
 
 						LOGGER.debug("checking for notifications...");
 
-						PGNotification[] notifications = pgConn.getNotifications(WAIT_FOR_NOTIFICATIONS_TIMEOUT); // wait at for new notifications, then ask new connection and start waiting again
+						PGNotification[] notifications = pgConn.getNotifications(WAIT_FOR_NOTIFICATIONS_TIMEOUT); // returns as soon as a notification arrives, otherwise empty-handed after the poll slice
 					    if (notifications != null) {
 					        for (PGNotification notification : notifications) {
 					            LOGGER.debug("Received: " + notification.getParameter());
@@ -1340,15 +1502,17 @@ public class PostgresEventStorageImpl implements EventStorage {
 					}
 
 				} catch (SQLException e) {
-					if ( !stopped ) {
-						LOGGER.error(e.getMessage(), e);
-						try {
-							Thread.sleep(retryDelayMs);
-							retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
-						} catch (InterruptedException ie) {
-							Thread.currentThread().interrupt();
-							return;
-						}
+					if ( stopped.get() || Thread.currentThread().isInterrupted() ) {
+						// shutting down: the connection was closed underneath us on purpose, nothing to report
+						return;
+					}
+					LOGGER.error(e.getMessage(), e);
+					try {
+						Thread.sleep(retryDelayMs);
+						retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						return;
 					}
 				} finally {
 					LOGGER.debug("loop done.");
@@ -1375,12 +1539,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 	@Override
 	public void subscribe(EventStoreListener listener) {
+		checkNotClosed();
 		listeners.add(new WeakReference<>(listener));
 		listeners.removeIf(ref -> ref.get() == null);
 	}
 
 	@Override
 	public Optional<EventReference> getBookmark(String reader) {
+		checkNotClosed();
 		String sql = """
 			SELECT event_position, event_id, event_tx::text
 			FROM %sbookmarks
@@ -1413,6 +1579,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 	@Override
 	public List<Bookmark> getBookmarks() {
+		checkNotClosed();
 		String sql = """
 			SELECT reader, event_position, event_id, event_tx::text, updated_at, updated_tags
 			FROM %sbookmarks
@@ -1453,6 +1620,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 	
 	@Override
 	public void bookmark(String reader, EventReference eventReference, Tags tags ) {
+		checkNotClosed();
 		if ( eventReference == null ) {
 			removeBookmark(reader);
 		} else {
@@ -1509,6 +1677,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 	
 	@Override
 	public void removeBookmark(String reader ) {
+		checkNotClosed();
 		String sql = """
 			DELETE FROM %sbookmarks  
 			WHERE reader = ?

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -1385,7 +1385,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 									listeners.forEach(l -> {
 										EventStoreListener listener = l.get();
 										if (listener != null) {
-											listener.notify(aesn);
+											// one listener misbehaving must not kill this monitor: it is the only one this
+											// storage has, so its death silently stops notifications for every store,
+											// listener and projection attached to the storage
+											try {
+												listener.notify(aesn);
+											} catch (Exception e) {
+												LOGGER.error("event store listener failed handling a notification: {}", e.getMessage(), e);
+											}
 										}
 									});
 
@@ -1483,7 +1490,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 									listeners.forEach(l -> {
 										EventStoreListener listener = l.get();
 										if (listener != null) {
-											listener.notify(bpn);
+											// one listener misbehaving must not kill this monitor: it is the only one this
+											// storage has, so its death silently stops notifications for every store,
+											// listener and projection attached to the storage
+											try {
+												listener.notify(bpn);
+											} catch (Exception e) {
+												LOGGER.error("event store listener failed handling a notification: {}", e.getMessage(), e);
+											}
 										}
 									});
 

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresLegacyEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresLegacyEventStorageImpl.java
@@ -44,6 +44,10 @@ public class PostgresLegacyEventStorageImpl extends PostgresEventStorageImpl {
 		super(name, dataSource, monitoringDataSource, absoluteLimit, prefix);
 	}
 
+	public PostgresLegacyEventStorageImpl ( String name, DataSource dataSource, DataSource monitoringDataSource, Limit absoluteLimit, String prefix, boolean ownsDataSources ) {
+		super(name, dataSource, monitoringDataSource, absoluteLimit, prefix, ownsDataSources);
+	}
+
 	@Override
 	protected String appendValuesRowFragment ( ) {
 		return "(?::uuid, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?) ";

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageInitialisationTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageInitialisationTest.java
@@ -48,7 +48,7 @@ public class PostgresEventStorageInitialisationTest {
 				.initializeDatabase()
 				.build();
 
-			((PostgresEventStorageImpl)storage).stop();
+			storage.close();
 
 			// second time, should drop/create once again
 
@@ -59,7 +59,7 @@ public class PostgresEventStorageInitialisationTest {
 				.initializeDatabase()
 				.build();
 
-			((PostgresEventStorageImpl)storage).stop();
+			storage.close();
 
 			PostgresContainer.closeDataSource(image);
 		}
@@ -74,7 +74,7 @@ public class PostgresEventStorageInitialisationTest {
 				.ensureDatabase()
 				.build();
 
-			((PostgresEventStorageImpl)storage).stop();
+			storage.close();
 
 			// second time: ensure leaves existing objects untouched
 			storage = PostgresEventStorage.newBuilder()
@@ -84,7 +84,7 @@ public class PostgresEventStorageInitialisationTest {
 				.ensureDatabase()
 				.build();
 
-			((PostgresEventStorageImpl)storage).stop();
+			storage.close();
 
 			PostgresContainer.closeDataSource(image);
 		}
@@ -113,7 +113,7 @@ public class PostgresEventStorageInitialisationTest {
 				.dataSource(PostgresContainer.dataSource(image))
 				.build();
 
-			((PostgresEventStorageImpl)storage).stop();
+			storage.close();
 
 			PostgresContainer.closeDataSource(image);
 		}

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageVersionDetectionTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageVersionDetectionTest.java
@@ -79,7 +79,7 @@ class PostgresEventStorageVersionDetectionTest {
 				assertInstanceOf(PostgresLegacyEventStorageImpl.class, storage,
 					"PG17 should be served by PostgresLegacyEventStorageImpl");
 			} finally {
-				((PostgresEventStorageImpl) storage).stop();
+				storage.close();
 				PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG17);
 			}
 		}
@@ -98,7 +98,7 @@ class PostgresEventStorageVersionDetectionTest {
 				UUID id = UUID.fromString(stored.get(0).reference().id().value());
 				assertEquals(7, id.version(), "expected UUIDv7");
 			} finally {
-				((PostgresEventStorageImpl) storage).stop();
+				storage.close();
 				PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG17);
 			}
 		}
@@ -128,7 +128,7 @@ class PostgresEventStorageVersionDetectionTest {
 				assertFalse(storage instanceof PostgresLegacyEventStorageImpl,
 					"PG18 must not use the legacy implementation");
 			} finally {
-				((PostgresEventStorageImpl) storage).stop();
+				storage.close();
 				PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG18);
 			}
 		}
@@ -148,7 +148,7 @@ class PostgresEventStorageVersionDetectionTest {
 				assertEquals(7, id.version(), "PG18 uuidv7() must produce UUID version 7");
 				assertTrue(id.variant() == 2, "RFC 4122 variant expected, got " + id.variant());
 			} finally {
-				((PostgresEventStorageImpl) storage).stop();
+				storage.close();
 				PostgresContainer.closeDataSource(PostgresContainer.IMAGE_PG18);
 			}
 		}

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresLifecycleTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresLifecycleTest.java
@@ -1,0 +1,228 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorageClosedException;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * The parts of the lifecycle contract that only a backend holding real resources can be asked about.
+ * <p>
+ * The backend-agnostic half — idempotent, terminal, operations throwing afterwards — is asserted for
+ * every storage by {@code EventStorageLifecycleTest} in the TCK. What is left here is what makes this
+ * backend expensive: two LISTEN/NOTIFY threads holding a JDBC connection each, and connection pools
+ * that either belong to the caller or were built by the builder and belong to the storage.
+ */
+class PostgresLifecycleTest {
+
+	/** what a store looks like to a scenario: one context, typed events */
+	public record Ping ( String message ) { }
+
+	abstract static class Tests {
+
+		final String image;
+
+		Tests ( String image ) {
+			this.image = image;
+		}
+
+		@AfterEach
+		void closeBorrowedPool ( ) {
+			// after the storage using it has been closed by the test itself: that order is the one the
+			// contract prescribes, since a storage left running against a closed pool cannot tell that
+			// from a database outage and retries
+			PostgresContainer.closeDataSource(image);
+		}
+
+		private EventStorage storageOn ( DataSource dataSource ) {
+			return PostgresEventStorage.newBuilder()
+					.name("lifecycle-test")
+					.dataSource(dataSource)
+					.initializeDatabase()
+					.build();
+		}
+
+		@Test
+		void testCloseReleasesTheMonitorConnectionsBeforeItReturns ( ) {
+			HikariDataSource dataSource = (HikariDataSource) PostgresContainer.dataSource(image);
+			EventStorage storage = storageOn(dataSource);
+
+			assertEquals(2, dataSource.getHikariPoolMXBean().getActiveConnections(),
+				"the two LISTEN/NOTIFY monitors should each hold a connection while the storage is open");
+
+			storage.close();
+
+			// the contract says close() blocks until background activity has ceased: no polling here,
+			// the connections must already be back the moment close() returns
+			assertEquals(0, dataSource.getHikariPoolMXBean().getActiveConnections(),
+				"close() must not return while the monitor threads still hold their connections");
+		}
+
+		@Test
+		void testCloseLeavesACallerSuppliedDataSourceAlone ( ) {
+			HikariDataSource dataSource = (HikariDataSource) PostgresContainer.dataSource(image);
+			EventStorage storage = storageOn(dataSource);
+
+			storage.close();
+
+			assertFalse(dataSource.isClosed(), "a DataSource supplied by the caller must never be closed by the storage");
+			assertTrue(usable(dataSource), "a DataSource supplied by the caller must still hand out connections after close()");
+		}
+
+		@Test
+		void testCloseLogsNothingWhenTheMonitorsStopOnTheirOwn ( ) {
+			HikariDataSource dataSource = (HikariDataSource) PostgresContainer.dataSource(image);
+			EventStorage storage = storageOn(dataSource);
+
+			storage.close();
+
+			// the monitors were left to notice the stop and unwind: had they been interrupted instead,
+			// their connections would have been broken under the driver and evicted by the pool
+			assertEquals(0, dataSource.getHikariPoolMXBean().getActiveConnections());
+			assertTrue(usable(dataSource), "the pool must still be healthy, not emptied by evicted connections");
+		}
+
+		@Test
+		@SuppressWarnings("removal")
+		void testDeprecatedStopBehavesLikeClose ( ) {
+			EventStorage storage = storageOn(PostgresContainer.dataSource(image));
+
+			((PostgresEventStorageImpl) storage).stop();
+
+			assertThrows(EventStorageClosedException.class, storage::getBookmarks,
+				"the deprecated stop() must have the same effect as close()");
+		}
+
+		private boolean usable ( DataSource dataSource ) {
+			try ( var connection = dataSource.getConnection() ) {
+				return connection.isValid(2);
+			} catch ( Exception e ) {
+				return false;
+			}
+		}
+
+	}
+
+	@Nested
+	class OnPostgres17 extends Tests {
+
+		OnPostgres17 ( ) { super(PostgresContainer.IMAGE_PG17); }
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG17); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG17); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG17); }
+	}
+
+	@Nested
+	class OnPostgres18 extends Tests {
+
+		OnPostgres18 ( ) { super(PostgresContainer.IMAGE_PG18); }
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG18); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG18); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18); }
+	}
+
+	/**
+	 * The pools the builder makes for itself, which no caller ever gets a handle on: if closing the
+	 * EventStore does not close them, nothing will.
+	 */
+	@Nested
+	class OnBuilderCreatedDataSource {
+
+		@BeforeAll
+		static void startContainer ( ) { PostgresContainer.start(PostgresContainer.IMAGE_PG18); }
+
+		@AfterAll
+		static void stopContainer ( ) { PostgresContainer.stop(PostgresContainer.IMAGE_PG18); PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18); }
+
+		@Test
+		void testBuildStoreCallerCanShutEverythingDownThroughTheEventStore ( ) {
+			PostgresContainer.writeDbProperties(PostgresContainer.IMAGE_PG18);
+
+			EventStore eventStore = PostgresEventStorage.newBuilder()
+					.name("lifecycle-owned")
+					.prefix("owned_")
+					.initializeDatabase()
+					.buildStore();
+
+			EventStream<Ping> stream = eventStore.getEventStream(EventStreamId.forContext("lifecycle"), Ping.class);
+			stream.append(AppendCriteria.none(), Event.of(new Ping("owned pool"), Tags.none()));
+			assertEquals(1, stream.query(EventQuery.matchAll()).count());
+
+			assertFalse(PostgresContainer.backendsOfSelfBuiltPools(PostgresContainer.IMAGE_PG18).isEmpty(),
+				"the builder should have opened its own pool");
+
+			eventStore.close();
+
+			// the pools are closed by the time close() returns; the server's view of a disconnect can
+			// trail it by a moment, so allow for that rather than asserting on the very same instant
+			assertTrue(awaitNoSelfBuiltBackends(),
+				"closing the EventStore must close the pools the builder created — there is no other handle on them, still open: "
+					+ PostgresContainer.backendsOfSelfBuiltPools(PostgresContainer.IMAGE_PG18));
+			assertThrows(EventStorageClosedException.class, () -> stream.query(EventQuery.matchAll()).count());
+		}
+
+		private boolean awaitNoSelfBuiltBackends ( ) {
+			long deadline = System.currentTimeMillis() + 5_000;
+			while ( System.currentTimeMillis() < deadline ) {
+				List<String> open = PostgresContainer.backendsOfSelfBuiltPools(PostgresContainer.IMAGE_PG18);
+				if ( open.isEmpty() ) {
+					return true;
+				}
+				try {
+					Thread.sleep(100);
+				} catch ( InterruptedException e ) {
+					Thread.currentThread().interrupt();
+					return false;
+				}
+			}
+			return PostgresContainer.backendsOfSelfBuiltPools(PostgresContainer.IMAGE_PG18).isEmpty();
+		}
+
+	}
+
+}

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresStreamSchemaTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresStreamSchemaTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.stream.EventStreamId;
 
 /**
@@ -61,7 +62,7 @@ public class PostgresStreamSchemaTest {
 			String prefix = "purposedefault_";
 			DataSource dataSource = PostgresContainer.dataSource(image);
 
-			PostgresEventStorageImpl storage = (PostgresEventStorageImpl) PostgresEventStorage.newBuilder()
+			EventStorage storage = PostgresEventStorage.newBuilder()
 				.name("unit-test")
 				.prefix(prefix)
 				.dataSource(dataSource)
@@ -106,7 +107,7 @@ public class PostgresStreamSchemaTest {
 				assertTrue(contextStream.canRead(new EventStreamId(context, storedPurpose)),
 					"a context-scoped stream id must be able to read a row written via the SQL default purpose");
 			} finally {
-				storage.stop();
+				storage.close();
 				PostgresContainer.closeDataSource(image);
 			}
 		}
@@ -116,7 +117,7 @@ public class PostgresStreamSchemaTest {
 			String prefix = "streamtagsidx_";
 			DataSource dataSource = PostgresContainer.dataSource(image);
 
-			PostgresEventStorageImpl storage = (PostgresEventStorageImpl) PostgresEventStorage.newBuilder()
+			EventStorage storage = PostgresEventStorage.newBuilder()
 				.name("unit-test")
 				.prefix(prefix)
 				.dataSource(dataSource)
@@ -129,7 +130,7 @@ public class PostgresStreamSchemaTest {
 				assertTrue(extensionExists(connection, "btree_gin"),
 					"btree_gin extension must be present to support the combined stream+tags index");
 			} finally {
-				storage.stop();
+				storage.close();
 				PostgresContainer.closeDataSource(image);
 			}
 		}

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
@@ -17,6 +17,16 @@
  */
 package org.sliceworkz.eventstore.infra.postgres.util;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -86,6 +96,78 @@ public class PostgresContainer {
 		if ( dataSource != null && !dataSource.isClosed() ) {
 			dataSource.close();
 		}
+	}
+
+	/**
+	 * Marker put in {@code application_name} of the pools the builder creates for itself, so a test can
+	 * tell those connections apart from the ones it opened.
+	 */
+	public static final String SELF_BUILT_POOL_MARKER = "eventstore-selfbuilt";
+
+	/**
+	 * Points {@link org.sliceworkz.eventstore.infra.postgres.DataSourceFactory} at this container by
+	 * writing a {@code db.properties} for it and setting {@code eventstore.db.config}.
+	 * <p>
+	 * Needed to exercise the path where the builder creates the connection pools itself — the path
+	 * where nobody but the storage has a handle on them.
+	 */
+	public static void writeDbProperties ( String image ) {
+		PostgreSQLContainer container = CONTAINERS.get(image);
+		if ( container == null ) {
+			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
+		}
+		try {
+			Path file = Files.createTempFile("eventstore-db", ".properties");
+			file.toFile().deleteOnExit();
+			// the ApplicationName goes in the URL: with a jdbcUrl-based HikariConfig that is what
+			// actually reaches the server. A "datasource." property is still needed for
+			// HikariConfigurationUtil to consider the section present at all.
+			String url = container.getJdbcUrl() + (container.getJdbcUrl().contains("?") ? "&" : "?");
+			Files.writeString(file, """
+				db.pooled.url=%1$sApplicationName=%2$s-pooled
+				db.pooled.username=%3$s
+				db.pooled.password=%4$s
+				db.pooled.maximumPoolSize=3
+				db.pooled.datasource.ApplicationName=%2$s-pooled
+				db.nonpooled.url=%1$sApplicationName=%2$s-nonpooled
+				db.nonpooled.username=%3$s
+				db.nonpooled.password=%4$s
+				db.nonpooled.maximumPoolSize=3
+				db.nonpooled.datasource.ApplicationName=%2$s-nonpooled
+				""".formatted(url, SELF_BUILT_POOL_MARKER, container.getUsername(), container.getPassword()));
+			System.setProperty("eventstore.db.config", file.toString());
+		} catch ( IOException e ) {
+			throw new IllegalStateException("could not write a db.properties for " + image, e);
+		}
+	}
+
+	/**
+	 * Returns the server-side connections currently held by pools the builder created for itself,
+	 * identified by {@link #SELF_BUILT_POOL_MARKER}. Empty means those pools are really gone — asked of
+	 * the database rather than of the pool object, since the point is that nobody holds that object.
+	 *
+	 * @param image the container image whose database to ask
+	 * @return one entry per open backend, describing it for assertion messages
+	 */
+	public static List<String> backendsOfSelfBuiltPools ( String image ) {
+		PostgreSQLContainer container = CONTAINERS.get(image);
+		if ( container == null ) {
+			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
+		}
+		List<String> result = new ArrayList<>();
+		try ( Connection connection = DriverManager.getConnection(container.getJdbcUrl(), container.getUsername(), container.getPassword());
+			  PreparedStatement statement = connection.prepareStatement(
+				  "select pid, application_name, state from pg_stat_activity where application_name like ?") ) {
+			statement.setString(1, SELF_BUILT_POOL_MARKER + "%");
+			try ( ResultSet rs = statement.executeQuery() ) {
+				while ( rs.next() ) {
+					result.add("%d/%s/%s".formatted(rs.getInt(1), rs.getString(2), rs.getString(3)));
+				}
+			}
+		} catch ( SQLException e ) {
+			throw new IllegalStateException("could not inspect pg_stat_activity of " + image, e);
+		}
+		return result;
 	}
 
 }

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/AbstractEventStoreTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/AbstractEventStoreTest.java
@@ -85,10 +85,16 @@ public abstract class AbstractEventStoreTest {
 
 	@AfterEach
 	public void tearDown ( ) {
+		// the store first, then the storage under it: that is the order the lifecycle contract
+		// prescribes, and dropping the store's reference instead would leak its notification
+		// executors -- a pair of them per test method
+		if ( eventStore != null ) {
+			eventStore.close();
+			eventStore = null;
+		}
 		if ( eventStorage != null ) {
 			destroyEventStorage(eventStorage);
 			eventStorage = null;
-			eventStore = null;
 		}
 	}
 

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/EventStoreBackend.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/EventStoreBackend.java
@@ -63,11 +63,17 @@ public interface EventStoreBackend {
 
 	/**
 	 * Releases a store handed out by {@link #createEventStorage(StorageOptions)}. Called after
-	 * every test method. The default does nothing.
+	 * every test method.
+	 * <p>
+	 * The default closes it, which is all most backends need: {@link EventStorage#close()} is
+	 * contractually required to release everything the storage created and to block until it has.
+	 * Override only to release something the backend itself created around the store — a pool it
+	 * handed in, say, which the storage will deliberately not close.
 	 *
 	 * @param storage the storage to release; never {@code null}
 	 */
 	default void destroyEventStorage ( EventStorage storage ) {
+		storage.close();
 	}
 
 	/**

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/AbstractPostgresBackend.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/AbstractPostgresBackend.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.sql.DataSource;
 
 import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
-import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorageImpl;
 import org.sliceworkz.eventstore.spi.EventStorage;
 import org.sliceworkz.eventstore.testing.EventStoreBackend;
 import org.sliceworkz.eventstore.testing.StorageOptions;
@@ -117,18 +116,16 @@ public abstract class AbstractPostgresBackend implements EventStoreBackend {
 
 	@Override
 	public void destroyEventStorage ( EventStorage storage ) {
-		// the single place in the suite that needs to know the concrete storage type: EventStorage
-		// has no close()/stop(), and leaving the executor running leaks a thread per test
-		if ( storage instanceof PostgresEventStorageImpl postgres ) {
-			postgres.stop();
-		}
+		// close() returns once the store's LISTEN/NOTIFY monitors have stopped and handed their
+		// connections back, so the pool below is free the moment this returns
+		storage.close();
 		liveStorages.remove(storage);
 
-		// Once the test's last store is stopped, drop the pool with it. stop() above returns while
-		// that store's LISTEN/NOTIFY monitors still hold a connection each — they only let go when
-		// their 30-second getNotifications(...) wait returns — so a pool kept across tests would be
-		// starved within a handful of them. Waiting for the last store matters because a scenario
-		// may hold two at once (an import needs a source and a target) and they share this pool.
+		// Drop the pool once the test's last store is gone. It is this backend's pool, not the
+		// store's, so no store will ever close it. Waiting for the last one matters because a
+		// scenario may hold two at once (an import needs a source and a target) and they share it;
+		// closing it under a live store would leave that store's monitors retrying against a dead
+		// pool, which they cannot tell from a database outage.
 		if ( liveStorages.isEmpty() ) {
 			PostgresContainer.close(image);
 		}

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/PostgresContainer.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/PostgresContainer.java
@@ -94,15 +94,12 @@ public final class PostgresContainer {
 	 * Closes the connection pool for {@code image}; the next {@link #dataSource(String)} builds a new
 	 * one. The container itself is left to Ryuk.
 	 * <p>
-	 * This runs after <em>every test</em>, not once at the end of the run, and that is load-bearing.
-	 * A store's LISTEN/NOTIFY monitors each hold a connection for their whole life and take it from
-	 * the monitoring DataSource, which defaults to this very pool.
-	 * {@code PostgresEventStorageImpl.stop()} sets a flag and calls {@code shutdown()} without
-	 * interrupting, so a monitor keeps its connection until its 30-second
-	 * {@code getNotifications(...)} wait returns. Against a pool that outlives the test those
-	 * connections accumulate two per test, exhaust the default maximum of ten, and every later
-	 * {@code getConnection()} — including the next test's own monitors — blocks for 30 seconds
-	 * waiting for one to be released. Dropping the pool releases them immediately instead.
+	 * This runs after <em>every test</em>, not once at the end of the run. A store's LISTEN/NOTIFY
+	 * monitors each hold a connection for their whole life, taken from the monitoring DataSource,
+	 * which defaults to this very pool. {@code EventStorage.close()} gives those connections back
+	 * before it returns, so a pool outliving the test would no longer be starved by them — but it is
+	 * still dropped per test, so that a leaked store, or one a scenario forgot to close, shows up as a
+	 * failure in the test that caused it rather than as connection exhaustion several tests later.
 	 *
 	 * @param image the PostgreSQL image tag
 	 */

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStorageLifecycleTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStorageLifecycleTest.java
@@ -19,14 +19,18 @@ package org.sliceworkz.eventstore.testing.tck;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.EventStoreFactory;
@@ -156,6 +160,125 @@ public class EventStorageLifecycleTest extends AbstractEventStoreTest {
 			() -> eventStore().getEventStream(EventStreamId.forContext("lifecycle"), MockDomainEvent.class));
 
 		eventStore().close(); // idempotent on this side too
+	}
+
+	/** rounds of "close a store while notifications are in flight"; the window is small, so drive it */
+	private static final int RACE_ROUNDS = 60;
+
+	/** streams the doomed store holds on the appended-to stream, widening the window per notification */
+	private static final int RACE_STREAMS_PER_ROUND = 20;
+
+	/** how long each round lets notifications flow before closing the store mid-flight */
+	private static final long RACE_PAUSE_MILLIS = 1;
+
+	@ForEachBackend
+	void closingAStoreWhileNotificationsAreInFlightLeavesTheStorageIntact ( ) throws InterruptedException {
+		EventStore survivingStore = EventStoreFactory.get().eventStore(eventStorage());
+		EventStream<MockDomainEvent> survivingStream = stream(survivingStore);
+		AtomicInteger notifications = new AtomicInteger();
+		survivingStream.subscribe((EventStreamEventuallyConsistentAppendListener) reference -> {
+			notifications.incrementAndGet();
+			return reference;
+		});
+
+		// Appends run throughout, so every close below lands in live notification traffic rather than
+		// before or after it. Closing between two notifications proves nothing: the window this pins is
+		// the one inside a single notification, between a store noticing it is still open and handing
+		// the notification to its executors.
+		AtomicReference<Throwable> notifyingFailure = new AtomicReference<>();
+		AtomicBoolean keepAppending = new AtomicBoolean(true);
+		Thread appender = new Thread(( ) -> {
+			while ( keepAppending.get() ) {
+				try {
+					append(survivingStream, "in flight");
+				} catch ( Throwable t ) {
+					notifyingFailure.compareAndSet(null, t);
+				}
+			}
+		}, "lifecycle-race-appender");
+		appender.start();
+
+		try {
+			for ( int round = 0; round < RACE_ROUNDS; round++ ) {
+				// a store about to be closed, holding several streams on the stream being appended to:
+				// each registers itself as a listener, so one notification walks a long list, and a
+				// close has that many chances to land in the middle of it. The list is per round, and
+				// dropped with it — holding every round's streams would leave the storage notifying
+				// hundreds of dead ones, which slows notifications down and narrows the very window
+				// this is trying to hit.
+				EventStore closingStore = EventStoreFactory.get().eventStore(eventStorage());
+				List<EventStream<MockDomainEvent>> doomedStreams = new ArrayList<>();
+				for ( int i = 0; i < RACE_STREAMS_PER_ROUND; i++ ) {
+					doomedStreams.add(stream(closingStore)); // held, so the storage's weak refs survive
+				}
+
+				Thread.sleep(RACE_PAUSE_MILLIS); // let notifications reach those streams...
+				closingStore.close();            // ... and pull the store out from under them
+				doomedStreams.clear();
+			}
+		} finally {
+			keepAppending.set(false);
+			appender.join();
+		}
+
+		// In-memory backends notify on the appending thread, so a rejected submit surfaces there — in
+		// an append that has nothing to do with the store being closed.
+		assertNull(notifyingFailure.get(),
+			"closing a store must never surface in another store's append: " + notifyingFailure.get());
+
+		// Postgres delivers on the storage's single LISTEN/NOTIFY monitor thread, where an escaping
+		// rejection kills the monitor outright: appends would keep working and notifications would
+		// simply stop, for every store on the storage. So ask the survivor whether it is still being
+		// told about appends.
+		int before = notifications.get();
+		append(survivingStream, "after the races");
+		waitBecauseOfEventualConsistency(( ) -> notifications.get() > before);
+
+		survivingStore.close();
+	}
+
+	@ForEachBackend
+	void aListenerThatThrowsBreaksNeitherTheAppendNorTheOtherListeners ( ) {
+		EventStorage storage = eventStorage();
+		AtomicInteger reachedAfterTheThrowingOne = new AtomicInteger();
+
+		storage.subscribe(new EventStorage.EventStoreListener() {
+			@Override
+			public void notify ( EventStorage.AppendsToEventStoreNotification newEventsInStore ) {
+				throw new IllegalStateException("this listener is having a bad day");
+			}
+
+			@Override
+			public void notify ( EventStorage.BookmarkPlacedNotification bookmarkPlaced ) {
+				throw new IllegalStateException("this listener is having a bad day");
+			}
+		});
+		storage.subscribe(new EventStorage.EventStoreListener() {
+			@Override
+			public void notify ( EventStorage.AppendsToEventStoreNotification newEventsInStore ) {
+				reachedAfterTheThrowingOne.incrementAndGet();
+			}
+
+			@Override
+			public void notify ( EventStorage.BookmarkPlacedNotification bookmarkPlaced ) {
+				// not what this scenario asserts
+			}
+		});
+
+		EventStream<MockDomainEvent> stream = stream(eventStore());
+		append(stream, "listener throws on this one");
+
+		// the append succeeded: reporting it as failed because a listener misbehaved would invite the
+		// caller to append the same event twice
+		assertEquals(1, stream.query(EventQuery.matchAll()).count());
+		// and the listener behind the failing one was still told
+		waitBecauseOfEventualConsistency(( ) -> reachedAfterTheThrowingOne.get() >= 1);
+
+		// notifications keep flowing afterwards -- on a backend delivering from a thread of its own,
+		// an escaping throwable would have killed that thread and ended them for good
+		int before = reachedAfterTheThrowingOne.get();
+		append(stream, "and the next one still arrives");
+		waitBecauseOfEventualConsistency(( ) -> reachedAfterTheThrowingOne.get() > before);
 	}
 
 	@ForEachBackend

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStorageLifecycleTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStorageLifecycleTest.java
@@ -1,0 +1,199 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.EventStoreFactory;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorage.ImportMode;
+import org.sliceworkz.eventstore.spi.EventStorage.QueryDirection;
+import org.sliceworkz.eventstore.spi.EventStorageClosedException;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamEventuallyConsistentAppendListener;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.EventStoreBackend.Capability;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
+
+/**
+ * The lifecycle contract on {@link EventStorage#close()}, which every backend must honour.
+ * <p>
+ * A storage that holds nothing satisfies most of this for free; one that runs threads or holds
+ * connections has to work for it. Both are asserted the same way here, so that code outliving its
+ * storage — a projection, a stream held past a tenant's shutdown — fails identically everywhere
+ * rather than depending on which backend is underneath.
+ * <p>
+ * Closing the storage inside a scenario is safe: the contract requires {@code close()} to be
+ * idempotent, and the backend closes it again during teardown.
+ */
+public class EventStorageLifecycleTest extends AbstractEventStoreTest {
+
+	/** close() must be bounded; this is a generous ceiling, not a performance assertion */
+	private static final long CLOSE_BUDGET_MS = 5_000;
+
+	private EventStream<MockDomainEvent> stream ( EventStore eventStore ) {
+		return eventStore.getEventStream(EventStreamId.forContext("lifecycle"), MockDomainEvent.class);
+	}
+
+	private void append ( EventStream<MockDomainEvent> stream, String payload ) {
+		stream.append(AppendCriteria.none(), Collections.singletonList(Event.of(new FirstDomainEvent(payload), Tags.none())));
+	}
+
+	@ForEachBackend
+	void closeIsIdempotent ( ) {
+		eventStorage().close();
+		eventStorage().close();
+		eventStorage().close();
+	}
+
+	@ForEachBackend
+	void closeBlocksUntilItIsDoneAndReturnsWithinItsBudget ( ) {
+		long start = System.nanoTime();
+		eventStorage().close();
+		long tookMs = (System.nanoTime() - start) / 1_000_000;
+
+		assertTrue(tookMs < CLOSE_BUDGET_MS,
+			"close() must return within %dms, took %dms".formatted(CLOSE_BUDGET_MS, tookMs));
+	}
+
+	@ForEachBackend
+	void everyOperationThrowsAfterClose ( ) {
+		EventStorage storage = eventStorage();
+		storage.close();
+
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.query(EventQuery.matchAll(), Optional.empty(), null, Limit.none(), QueryDirection.FORWARD));
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.append(AppendCriteria.none(), Optional.empty(), Collections.emptyList()));
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.getEventById(EventId.of(UUID.randomUUID().toString())));
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.getBookmark("some-reader"));
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.getBookmarks());
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.removeBookmark("some-reader"));
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.bookmark("some-reader", null, Tags.none()));
+	}
+
+	@ForEachBackend(requires = Capability.IMPORT)
+	void importThrowsAfterClose ( ) {
+		EventStorage storage = eventStorage();
+		storage.close();
+
+		assertThrows(EventStorageClosedException.class,
+			() -> storage.importEvents(Collections.emptyList(), ImportMode.FAIL_ON_EXISTING_ID));
+	}
+
+	@ForEachBackend
+	void nameKeepsWorkingAfterClose ( ) {
+		String name = eventStorage().name();
+		eventStorage().close();
+
+		assertEquals(name, eventStorage().name(),
+			"name() must keep working after close, so logging and diagnostics do not break");
+	}
+
+	@ForEachBackend
+	void closeNeedsNoCatchBlockInTryWithResources ( ) {
+		// compiles only because close() narrows away the checked exception of AutoCloseable.close()
+		try ( EventStorage storage = eventStorage() ) {
+			assertNotNull(storage.name());
+		}
+	}
+
+	@ForEachBackend
+	void closingTheEventStoreLeavesTheStorageItWasGivenOpen ( ) {
+		EventStream<MockDomainEvent> stream = stream(eventStore());
+		append(stream, "before close");
+
+		eventStore().close();
+
+		// the storage was handed to the store, not created by it, so it stays open and usable
+		List<EventStorage.StoredEvent> stored = eventStorage()
+				.query(EventQuery.matchAll(), Optional.empty(), null, Limit.none(), QueryDirection.FORWARD)
+				.toList();
+		assertEquals(1, stored.size(), "closing an EventStore must not close a storage it was given");
+
+		// the closed store is done, though: its notifications have stopped, so it must not read on
+		assertThrows(EventStorageClosedException.class, () -> stream.query(EventQuery.matchAll()).count());
+		assertThrows(EventStorageClosedException.class,
+			() -> eventStore().getEventStream(EventStreamId.forContext("lifecycle"), MockDomainEvent.class));
+
+		eventStore().close(); // idempotent on this side too
+	}
+
+	@ForEachBackend
+	void closingOneStoreLeavesItsSiblingsWorking ( ) {
+		EventStore closedStore = EventStoreFactory.get().eventStore(eventStorage());
+		EventStore survivingStore = EventStoreFactory.get().eventStore(eventStorage());
+
+		EventStream<MockDomainEvent> closedStream = stream(closedStore);
+		EventStream<MockDomainEvent> survivingStream = stream(survivingStore);
+
+		// listeners on both: the closed store's stream stays registered with the storage, so the
+		// storage keeps offering it notifications it must now quietly decline rather than reject
+		AtomicInteger notificationsAfterClose = new AtomicInteger();
+		closedStream.subscribe((EventStreamEventuallyConsistentAppendListener) reference -> {
+			notificationsAfterClose.incrementAndGet();
+			return reference;
+		});
+		AtomicInteger survivorNotifications = new AtomicInteger();
+		survivingStream.subscribe((EventStreamEventuallyConsistentAppendListener) reference -> {
+			survivorNotifications.incrementAndGet();
+			return reference;
+		});
+
+		closedStore.close();
+
+		append(survivingStream, "after the sibling closed");
+		assertEquals(1, survivingStream.query(EventQuery.matchAll()).count(),
+			"a store sharing the storage must keep working after another store on it is closed");
+		survivingStream.placeBookmark("reader",
+			survivingStream.query(EventQuery.matchAll()).toList().getLast().reference(), Tags.none());
+
+		// wait for the surviving store's listener, which proves the notification round trip completed;
+		// the closed store's listener must have been passed over rather than notified
+		waitBecauseOfEventualConsistency(() -> survivorNotifications.get() >= 1);
+		assertEquals(0, notificationsAfterClose.get(),
+			"a closed store must stop delivering notifications, without disturbing the storage");
+
+		survivingStore.close();
+	}
+
+}

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/spi/EventImportRoundTripTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/spi/EventImportRoundTripTest.java
@@ -29,7 +29,6 @@ import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
 import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
-import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorageImpl;
 import org.sliceworkz.eventstore.migration.EventStoreImporter;
 import org.sliceworkz.eventstore.migration.ImportReport;
 import org.sliceworkz.eventstore.query.EventQuery;
@@ -114,7 +113,7 @@ class EventImportRoundTripTest {
 			// the erasable payload really made the trip rather than being merged away
 			assertNotNull(returned.get(2).erasableData());
 		} finally {
-			((PostgresEventStorageImpl)postgres).stop();
+			postgres.close();
 			PostgresContainer.close(PostgresContainer.IMAGE_PG18);
 		}
 	}


### PR DESCRIPTION
## Summary

Implements proper lifecycle management for `EventStore` and `EventStorage` by making both `AutoCloseable` and adding comprehensive shutdown semantics. This ensures that background resources (LISTEN/NOTIFY monitor threads, connection pools, notification executors) are properly released when stores are closed, preventing resource leaks in multi-tenant, test, and hot-reload scenarios.

## Key Changes

### API Changes
- **EventStore** now extends `AutoCloseable` with a `close()` method that shuts down notification executors without closing the underlying storage
- **EventStorage** now extends `AutoCloseable` with a `close()` method contract requiring idempotent, bounded, terminal behavior
- Added `EventStorageClosedException` exception thrown when operations are attempted on closed storage
- Added `OwningEventStore` wrapper that closes both the store and its storage (used by builder's `buildStore()`)
- Added `EventStore.owning(EventStore, EventStorage)` factory method to compose a store that owns its storage

### PostgreSQL Backend
- Implemented `close()` in `PostgresEventStorageImpl` with graceful monitor shutdown:
  - Stops LISTEN/NOTIFY monitor threads by setting `stopped` flag
  - Waits up to 2 seconds for monitors to notice and unwind gracefully
  - Falls back to interrupting threads if they don't stop in time (hard 5-second bound)
  - Closes DataSources only if created by the builder (never closes caller-supplied pools)
- Changed `stopped` from volatile boolean to `AtomicBoolean` for safer concurrent access
- Reduced `WAIT_FOR_NOTIFICATIONS_TIMEOUT` from 30 seconds to 100ms (polling interval, not deadline)
- Added `ownsDataSources` flag to track whether storage should close the pools
- Added new constructor accepting `ownsDataSources` parameter

### In-Memory Backend
- Implemented `close()` in `InMemoryEventStorageImpl` to mark storage as closed
- Added `closed` flag to ensure post-close behavior matches other backends (operations throw `EventStorageClosedException`)

### EventStore Implementation
- Implemented `close()` in `EventStoreImpl` with executor shutdown:
  - Idempotent via `AtomicBoolean` guard
  - Shuts down both event append and bookmark update executors
  - Waits up to 5 seconds for executors to terminate
  - Logs warning if executors don't finish within timeout

### Testing
- Added comprehensive `EventStorageLifecycleTest` TCK test class covering:
  - Idempotency of `close()`
  - Bounded execution time
  - All operations throwing `EventStorageClosedException` after close
  - `name()` continuing to work after close
  - Try-with-resources compatibility
  - EventStore close not closing supplied storage
  - Race conditions with notifications in flight during close
- Added `PostgresLifecycleTest` for backend-specific resource management:
  - Monitor connections released before `close()` returns
  - Caller-supplied DataSources never closed
  - Pool health maintained after close
  - Deprecated `stop()` method behaves like `close()`
  - Builder-created pools are properly closed

### Builder Updates
- Updated `PostgresEventStorage.Builder.build()` to return started storage
- Updated `buildStore()` to return `OwningEventStore` that closes both store and storage
- Updated `InMemoryEventStorage.Builder.buildStore()` similarly
- Updated `InMemoryFsEventStorage.Builder.buildStore()` similarly

### Documentation
- Updated README and CLAUDE.md with lifecycle guidance
- Added comprehensive JavaDoc on `EventStorage.close()` contract
- Added lifecycle section to `PostgresEventStorage` class documentation
- Documented that closing EventStore does not close supplied storage

## Notable Implementation Details

- **Graceful shutdown pattern**: Postgres monitors poll for notifications in 100ms slices, allowing them to notice the stop flag and unwind cleanly without interruption, which keeps connections healthy in the pool
- **Resource ownership tracking**: `ownsDataSources` flag ensures only pools created by the builder are closed, respecting caller-supplied DataSources
- **Idempotent close**: Both `AtomicBoolean

https://claude.ai/code/session_01SHpFps1CGbh8FWXzXx6UgF