### PR TITLE
Fix race condition in OptimizingApendListenerDecorator

### DIFF
--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/OptimizingApendListenerDecorator.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/OptimizingApendListenerDecorator.java
@@ -88,27 +88,43 @@ public class OptimizingApendListenerDecorator implements EventStreamEventuallyCo
             return atLeastUntil;
         }
 
-        // Update target to the latest event reference seen
+        // Update target to the latest event reference seen. Registering it before taking the lock is
+        // what makes handing the work off safe: a thread that is about to decide it has nothing left
+        // to do makes that decision while holding the lock, so it either sees this target, or has
+        // already released the lock by the time we take it below.
         nextEventReference.updateAndGet(current -> (current == null || current.happenedBefore(atLeastUntil))? atLeastUntil:current);
-        
-        if (!lock.tryLock()) {
-            return atLeastUntil; // Someone else is handling it
-        }
-        
+
+        // Wait for the lock rather than giving up on it. Returning early instead -- assuming whoever
+        // holds it will pick up the target just registered -- loses notifications: the holder may
+        // already have read nextEventReference and decided to stop, in which case nobody delivers this
+        // one and the listener never hears about the append. The wait is short, since the lock is
+        // released around the delegate call.
+        lock.lock();
+
         try {
             if (updateInProgress) {
-                return atLeastUntil; // Update in progress, target already registered
+                return atLeastUntil; // a delivery is running; it re-reads the target and will pick this up
             }
-            
+
             notifyDecoratedListener();
-            
+
         } finally {
             lock.unlock();
         }
-        
+
         return atLeastUntil;
     }
     
+    /**
+     * Delivers to the delegate until the registered target has been caught up with.
+     * <p>
+     * Called with the lock held, and returns with it held. The lock is released around the delegate
+     * call, so a slow listener never blocks the threads notifying it — they register their target and
+     * find a delivery already in progress. Because the decision to stop is taken under the lock, and a
+     * target is always registered before its thread takes the lock, no target can be registered
+     * unnoticed: whoever registers one either finds this loop still running, or gets the lock itself
+     * and delivers.
+     */
     private void notifyDecoratedListener() {
         while (true) {
             EventReference target = nextEventReference.get();

--- a/sliceworkz-eventstore-impl/src/test/java/org/sliceworkz/eventstore/impl/OptimizingApendListenerDecoratorTest.java
+++ b/sliceworkz-eventstore-impl/src/test/java/org/sliceworkz/eventstore/impl/OptimizingApendListenerDecoratorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.EventId;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.stream.EventStreamEventuallyConsistentAppendListener;
+
+class OptimizingApendListenerDecoratorTest {
+
+	/**
+	 * Enough pairs to catch a lost notification; the window is narrow, so the count is what makes this
+	 * a net rather than a formality. The defect it guards against showed up about once in 20.000 pairs.
+	 */
+	private static final int RACING_PAIRS = 40_000;
+
+	private static EventReference reference ( long position ) {
+		return EventReference.of(EventId.of(UUID.randomUUID().toString()), position, 1);
+	}
+
+	/**
+	 * Two notifications arriving at once must never lose the later one.
+	 * <p>
+	 * This is what a storage does when one append lands several events: the backend notifies per event,
+	 * and the notifications are handed to the listener on separate threads. If the later one is
+	 * dropped, the listener is left believing the stream ends at the earlier event, and anything
+	 * waiting for it — a projection, a test — waits forever. The failure is invisible from the
+	 * appending side, which succeeded.
+	 */
+	@Test
+	void testLaterOfTwoSimultaneousNotificationsIsNeverLost ( ) throws InterruptedException {
+		int lost = 0;
+		try ( ExecutorService notifiers = Executors.newVirtualThreadPerTaskExecutor() ) {
+			for ( int pair = 0; pair < RACING_PAIRS; pair++ ) {
+				AtomicReference<EventReference> seenByDelegate = new AtomicReference<>();
+				OptimizingApendListenerDecorator decorator = new OptimizingApendListenerDecorator(
+						reference -> {
+							seenByDelegate.set(reference);
+							return reference;
+						});
+
+				EventReference earlier = reference(1);
+				EventReference later = reference(2);
+
+				CountDownLatch bothReady = new CountDownLatch(1);
+				CountDownLatch bothDone = new CountDownLatch(2);
+				for ( EventReference notification : new EventReference[] { earlier, later } ) {
+					notifiers.execute(( ) -> {
+						try {
+							bothReady.await();
+							decorator.eventsAppended(notification);
+						} catch ( InterruptedException e ) {
+							Thread.currentThread().interrupt();
+						} finally {
+							bothDone.countDown();
+						}
+					});
+				}
+				bothReady.countDown();
+				bothDone.await();
+
+				if ( !later.equals(seenByDelegate.get()) ) {
+					lost++;
+				}
+			}
+		}
+
+		assertEquals(0, lost,
+			"the later of two simultaneous notifications was dropped %d times in %d pairs".formatted(lost, RACING_PAIRS));
+	}
+
+	/**
+	 * The point of the decorator: a listener that has already seen a reference is not told again.
+	 */
+	@Test
+	void testNotificationAlreadySeenByTheListenerIsSkipped ( ) {
+		AtomicInteger deliveries = new AtomicInteger();
+		EventStreamEventuallyConsistentAppendListener counting = reference -> {
+			deliveries.incrementAndGet();
+			return reference;
+		};
+		OptimizingApendListenerDecorator decorator = new OptimizingApendListenerDecorator(counting);
+
+		EventReference reference = reference(1);
+		decorator.eventsAppended(reference);
+		decorator.eventsAppended(reference);
+		decorator.eventsAppended(reference(1));
+
+		assertEquals(1, deliveries.get(), "a reference the listener already processed must not be delivered again");
+	}
+
+	/**
+	 * A listener occupied with one notification does not hold up the threads delivering the next: they
+	 * register what they have and leave, and the in-progress delivery picks the newest target up.
+	 */
+	@Test
+	void testSlowListenerDoesNotBlockTheNotifyingThread ( ) throws Exception {
+		CountDownLatch listenerEntered = new CountDownLatch(1);
+		CountDownLatch releaseListener = new CountDownLatch(1);
+		AtomicReference<EventReference> seenByDelegate = new AtomicReference<>();
+
+		OptimizingApendListenerDecorator decorator = new OptimizingApendListenerDecorator(reference -> {
+			listenerEntered.countDown();
+			try {
+				releaseListener.await(5, TimeUnit.SECONDS);
+			} catch ( InterruptedException e ) {
+				Thread.currentThread().interrupt();
+			}
+			seenByDelegate.set(reference);
+			return reference;
+		});
+
+		Thread first = new Thread(( ) -> decorator.eventsAppended(reference(1)));
+		first.start();
+		listenerEntered.await();
+
+		// the listener is still inside the first notification; this one must not block behind it
+		long start = System.nanoTime();
+		decorator.eventsAppended(reference(2));
+		long tookMs = (System.nanoTime() - start) / 1_000_000;
+
+		releaseListener.countDown();
+		first.join();
+
+		assertEquals(true, tookMs < 1_000, "notifying took %dms, so it waited for the listener".formatted(tookMs));
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixed a critical race condition in `OptimizingApendListenerDecorator` where simultaneous notifications could be lost, causing listeners to miss append events and potentially wait indefinitely for updates that were never delivered.

## Changes

- **Changed lock acquisition from `tryLock()` to `lock()`**: The original implementation used non-blocking `tryLock()`, which allowed threads to return early without ensuring their notification was delivered. This created a window where a thread could register a target in `nextEventReference` but exit before acquiring the lock, while the lock-holding thread had already read the target and decided to stop, resulting in the notification being dropped.

- **Added comprehensive documentation**: Clarified the synchronization strategy with detailed comments explaining:
  - Why the target must be registered before attempting to acquire the lock
  - Why blocking `lock()` is necessary instead of `tryLock()`
  - How the loop in `notifyDecoratedListener()` ensures no target goes unnoticed
  - How slow listeners don't block notifying threads (they register and exit; the in-progress delivery picks up the new target)

- **Added comprehensive test suite** (`OptimizingApendListenerDecoratorTest`):
  - `testLaterOfTwoSimultaneousNotificationsIsNeverLost()`: Stress test with 40,000 racing pairs to catch the lost notification defect (which occurred ~1 in 20,000 times with the buggy implementation)
  - `testNotificationAlreadySeenByTheListenerIsSkipped()`: Verifies the decorator's core optimization—duplicate references aren't re-delivered
  - `testSlowListenerDoesNotBlockTheNotifyingThread()`: Confirms that slow listeners don't block notifying threads from registering their targets and returning

## Implementation Details

The fix ensures that:
1. A target is always registered in `nextEventReference` before the thread attempts to acquire the lock
2. The lock-holding thread cannot exit the delivery loop without checking for newly registered targets
3. If a thread finds the lock held, it knows a delivery is already in progress and will pick up its registered target
4. Notifying threads never block waiting for the listener—they register and return; the delivery loop handles the actual notification

https://claude.ai/code/session_01SHpFps1CGbh8FWXzXx6UgF