### PR TITLE
Fix until boundary semantics in queries and append criteria

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ mvn clean install -DskipTests
 - Can match all (`EventFilter.matchAll()`), none (`EventFilter.matchNone()`), or specific criteria
 - Created via `EventFilter.forEvents(eventTypesFilter, tags)`
 - Used by `AppendCriteria` for optimistic locking (where direction/limit are irrelevant)
+- **`until` is an inclusive upper bound over the total `(tx, position, index)` order and is
+  direction-independent**: `.backwards()` returns the same events as forward, newest first. It is part of
+  the filter, so it also bounds a consistency boundary — an event past it is not a new relevant fact and
+  raises no `OptimisticLockingException`. Backends must compare it as the tuple, exactly as they compare
+  the cursor; comparing positions alone drops events whose transaction and position were assigned in
+  different orders. `EventQueryUntilBoundaryTest` pins all of this down per backend
 
 **EventQuery:**
 - Wraps an `EventFilter` together with traversal semantics (direction and limit)

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -293,7 +293,11 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 			// The main eventQuery then starts from that savepoint's reference.
 			// On subsequent run() calls, lastEventReference is already set, so initQuery is skipped.
 			if ( bookmarkReader == null && lastEventReference == null && projection.initQuery() != null && !projection.initQuery().isMatchNone() ) {
-				EventQuery initQuery = projection.initQuery();
+				// The boundary of a bounded run applies to the savepoint too: without it, runUntil() would
+				// initialise the read model from the newest savepoint in the store -- possibly one written
+				// after the requested point in time -- and then start the main query beyond the boundary,
+				// reporting present-day state as a point-in-time projection.
+				EventQuery initQuery = projection.initQuery().untilIfEarlier ( until );
 				queriesDone++;
 				es.query(initQuery).forEach(e -> {
 					eventsStreamed++;

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -207,6 +207,22 @@ public interface EventStorage extends AutoCloseable {
 	 *   <li><b>FORWARD</b> - Events are returned in chronological order (oldest to newest)</li>
 	 *   <li><b>BACKWARD</b> - Events are returned in reverse chronological order (newest to oldest)</li>
 	 * </ul>
+	 * <p>
+	 * The Until Boundary:
+	 * <p>
+	 * {@link EventQuery#until()} is a matching criterion, not a traversal one. It is the <em>inclusive
+	 * upper bound</em> over the total {@code (tx, position, index)} order that
+	 * {@link org.sliceworkz.eventstore.query.EventFilter#matches(StoredEvent)} implements, and it selects
+	 * the same events in both directions — direction decides only the order they come back in. An
+	 * implementation must not read it as "traverse until you reach it", which turns it into a lower bound
+	 * when going backward and returns the events on the far side of it. Nor may it compare positions
+	 * alone where positions and transactions can be assigned in different orders: the boundary has to be
+	 * compared the same way the cursor is.
+	 * <p>
+	 * A backend may implement the boundary as a superset — dropping only what it can cheaply prove is
+	 * past it — because the exact filter is re-applied above this SPI after upcasting. It must never
+	 * exclude an event the filter would keep. Note that a limit is applied <em>after</em> the boundary:
+	 * spending it on events beyond the boundary that are discarded later returns too few events, or none.
 	 *
 	 * @param query the event query defining type and tag filters
 	 * @param stream optional stream identifier to filter events by stream

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -233,9 +233,19 @@ public class InMemoryEventStorageImpl implements EventStorage {
 			}
 		}
 		
-		// if we only need to read until a certain event, we stop after we have reached it
+		// If we only need to read until a certain event, we can cut the traversal short. "until" is a
+		// matching criterion, not a traversal one: it is an inclusive upper bound over the total
+		// (tx, position, index) order and means the same thing in both directions. So the events beyond
+		// it are a suffix of a forward traversal and a prefix of a backward one -- hence takeWhile vs
+		// dropWhile. This is purely a short-circuit; the boundary itself is enforced by query::matches
+		// below, which is where the exact comparison lives.
 		if ( query.until() != null ) {
-			on = on.takeWhile(e->e.reference().position()<=query.until().position());
+			EventReference until = query.until();
+			if ( direction == QueryDirection.BACKWARD ) {
+				on = on.dropWhile(e->e.reference().happenedAfter(until));
+			} else {
+				on = on.takeWhile(e->!e.reference().happenedAfter(until));
+			}
 		}
 		
 		Stream<StoredEvent> result = on;

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -750,15 +750,8 @@ public class PostgresEventStorageImpl implements EventStorage {
 			parameters.add(after.position());
 		}
 		
-		if ( query.until() != null ) {
-			if ( direction == QueryDirection.FORWARD ) {
-				sqlBuilder.append(" AND event_position <= ?");
-			} else { 
-				sqlBuilder.append(" AND event_position >= ?");
-			}
-			parameters.add(query.until().position());
-		}
-		
+		addUntilBoundary(sqlBuilder, parameters, query.until());
+
 		// Add stream filtering
 		if (stream.isPresent()) {
 			if (!stream.get().isAnyContext()) {
@@ -816,6 +809,38 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 	}
 	
+	/**
+	 * Appends the {@code until} boundary of an {@link EventFilter} to a statement being built.
+	 * <p>
+	 * The boundary is a matching criterion, not a traversal one: it is the inclusive upper bound over
+	 * the same {@code (tx, position)} order the cursor uses, and it means the same thing whether the
+	 * query runs forward or backward. Reading it as "traverse until you reach it" -- a lower bound when
+	 * going backward -- returns the events on the wrong side of the boundary.
+	 * <p>
+	 * Comparing on {@code event_position} alone is not enough either. {@code event_tx} defaults to
+	 * {@code pg_current_xact_id()}, assigned at a transaction's first write, while {@code event_position}
+	 * comes from a sequence at insert time, so a transaction that wrote elsewhere first can carry a lower
+	 * tx and a higher position. Ordering is by the tuple, so the boundary has to be too, or an event
+	 * before the boundary is silently never fetched.
+	 * <p>
+	 * The {@code index} part of an {@link EventReference} has no column: it distinguishes sub-events an
+	 * upcaster produced from one stored event. This predicate therefore stays a deliberate superset, and
+	 * {@code EventStoreImpl} re-applies the exact filter after upcasting.
+	 *
+	 * @param sqlBuilder the statement being built
+	 * @param parameters the parameter list being built alongside it
+	 * @param until the boundary, or null for no boundary (in which case nothing is appended)
+	 */
+	private void addUntilBoundary(StringBuilder sqlBuilder, List<Object> parameters, EventReference until) {
+		if ( until == null ) {
+			return;
+		}
+		sqlBuilder.append(" AND ((event_tx<?::xid8) OR (event_tx = ?::xid8 AND event_position <= ?))");
+		parameters.add(Long.toUnsignedString(until.tx()));
+		parameters.add(Long.toUnsignedString(until.tx()));
+		parameters.add(until.position());
+	}
+
 	private void addEventFilterFiltering(StringBuilder sqlBuilder, List<Object> parameters, EventFilter filter) {
 		if (filter.items() == null || filter.items().isEmpty()) {
 			return; // matchAll case is already handled
@@ -1040,6 +1065,13 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 				// Add EventFilter filtering for the consistency boundary
 				EventFilter lockingFilter = appendCriteria.eventFilter();
+
+				// A consistency boundary is whatever its EventFilter matches, and a filter carrying an
+				// "until" does not match past it -- so an event beyond the boundary is not a new relevant
+				// fact and must not raise a conflict. Leaving this out made this backend lock where the
+				// in-memory one, which runs the criteria through query(), did not.
+				addUntilBoundary(sqlBuilder, parameters, lockingFilter.until());
+
 				if (!lockingFilter.isMatchAll()) {
 					addEventFilterFiltering(sqlBuilder, parameters, lockingFilter);
 				}

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/projection/ProjectorTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/projection/ProjectorTest.java
@@ -622,6 +622,35 @@ public class ProjectorTest extends AbstractEventStoreTest {
 		assertEquals(1, metrics2.eventsHandled());
 	}
 
+	/**
+	 * A bounded run bounds the savepoint too. Left unbounded, the init query returns the newest savepoint
+	 * in the store -- here one written past the requested point in time -- and the main query then starts
+	 * beyond the boundary, so a point-in-time projection silently reports present-day state.
+	 */
+	@ForEachBackend
+	void testProjectorWithInitQueryRunUntilIgnoresLaterSavepoints ( ) {
+		EventStreamId stream = EventStreamId.forContext("app").withPurpose("initquery-rununtil");
+		EventStream<MockDomainEvent> initEs = eventStore().getEventStream(stream, MockDomainEvent.class);
+
+		append(initEs, new FirstDomainEvent("10"), Tags.none());
+		append(initEs, new ThirdDomainEvent("savepoint:10"), Tags.none());
+		append(initEs, new FirstDomainEvent("5"), Tags.none());
+		append(initEs, new ThirdDomainEvent("savepoint:15"), Tags.none());
+		append(initEs, new FirstDomainEvent("3"), Tags.none());
+
+		EventReference until = initEs.query(EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none()))
+				.toList().get(1).reference(); // the "5", written before the second savepoint
+
+		InitQueryProjection projection = new InitQueryProjection();
+		var projector = Projector.from(initEs).towards(projection).build();
+
+		ProjectorMetrics metrics = projector.runUntil(until);
+
+		assertEquals("savepoint:10", projection.lastSavepoint());
+		assertEquals(2, projection.counter()); // the savepoint, then the "5"
+		assertEquals(2, metrics.eventsHandled());
+	}
+
 	@ForEachBackend
 	void testProjectorBackwardsWithLimitEnforcesTotalLimit ( ) {
 		BackwardsLimitProjection projection = new BackwardsLimitProjection();

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventQueryUntilBoundaryTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventQueryUntilBoundaryTest.java
@@ -1,0 +1,246 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventFilter;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.stream.OptimisticLockingException;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.SecondDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.ThirdDomainEvent;
+
+/**
+ * The {@code until} boundary of an {@link EventFilter}, in both traversal directions.
+ * <p>
+ * {@code until} is a matching criterion and lives on the filter, not on the query: it is the inclusive
+ * upper bound over the total {@code (tx, position, index)} order that
+ * {@link EventFilter#matches(Event)} implements. Direction decides the order results come back in and
+ * nothing else, so the same boundary selects the same set of events forward and backward.
+ * <p>
+ * That is easy to get wrong in a way no forward-only test can see -- reading the boundary as "traverse
+ * until you reach it" turns it into a lower bound when going backward, which selects the events on the
+ * far side of it. The savepoint pattern ({@code .backwards().limit(1)} for the most recent summary
+ * event) walks straight into it, and so does {@code Projector.runUntil}. Hence
+ * {@link #untilSelectsTheSameEventsInBothDirections}, which asserts the property itself rather than a
+ * handful of counts.
+ */
+public class EventQueryUntilBoundaryTest extends AbstractEventStoreTest {
+
+	private EventStreamId streamId;
+	private EventStream<MockDomainEvent> stream;
+
+	/** Every event on the stream, oldest first, by position: 1..7. */
+	private List<Event<MockDomainEvent>> all;
+
+	@BeforeEach
+	void seedStream ( ) {
+		this.streamId = EventStreamId.forContext("app").withPurpose("until-boundary");
+		this.stream = eventStore().getEventStream(streamId, MockDomainEvent.class);
+
+		append(new FirstDomainEvent("1"));          // 1
+		append(new ThirdDomainEvent("savepoint:a")); // 2
+		append(new FirstDomainEvent("2"));          // 3
+		append(new FirstDomainEvent("3"));          // 4
+		append(new ThirdDomainEvent("savepoint:b")); // 5
+		append(new FirstDomainEvent("4"));          // 6
+		append(new SecondDomainEvent("head"));      // 7
+
+		this.all = stream.query(EventQuery.matchAll()).toList();
+		assertEquals(7, all.size(), "fixture");
+	}
+
+	/**
+	 * The property the two backends disagreed on: forward and backward are the same selection in
+	 * opposite orders, for every boundary and with or without one. A single wrong comparison in a
+	 * storage breaks this for at least one boundary, whatever the counts happen to be.
+	 */
+	@ForEachBackend
+	void untilSelectsTheSameEventsInBothDirections ( ) {
+		List<EventQuery> shapes = List.of(
+				EventQuery.matchAll(),
+				EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none()),
+				EventQuery.forEvents(EventTypesFilter.of(ThirdDomainEvent.class), Tags.none()));
+
+		for ( EventQuery shape : shapes ) {
+			for ( Event<MockDomainEvent> boundary : all ) {
+				EventQuery bounded = shape.until(boundary.reference());
+
+				List<EventReference> forward = references(stream.query(bounded));
+				List<EventReference> backward = references(stream.query(bounded.backwards()));
+
+				List<EventReference> backwardReversed = new ArrayList<>(backward);
+				java.util.Collections.reverse(backwardReversed);
+
+				assertEquals(forward, backwardReversed,
+						"boundary at position %d selects a different set backwards".formatted(boundary.reference().position()));
+				assertTrue(forward.stream().noneMatch(r -> r.happenedAfter(boundary.reference())),
+						"an event past the boundary was returned");
+			}
+		}
+	}
+
+	/**
+	 * The savepoint pattern from the documentation, bounded: the most recent summary event at or before
+	 * a point in time. Returning the newest savepoint in the store regardless of the boundary is as
+	 * wrong as returning nothing.
+	 */
+	@ForEachBackend
+	void backwardsWithLimitFindsTheNewestMatchAtOrBeforeTheBoundary ( ) {
+		EventQuery savepoint = EventQuery.forEvents(EventTypesFilter.of(ThirdDomainEvent.class), Tags.none())
+				.backwards().limit(1);
+
+		assertEquals(List.of("savepoint:b"), values(stream.query(savepoint)));
+
+		// boundary on the head event, which is not itself a savepoint
+		assertEquals(List.of("savepoint:b"), values(stream.query(savepoint.until(at(7)))));
+
+		// boundary on the savepoint itself: inclusive
+		assertEquals(List.of("savepoint:b"), values(stream.query(savepoint.until(at(5)))));
+
+		// boundary just before it: the previous savepoint, not the newest one
+		assertEquals(List.of("savepoint:a"), values(stream.query(savepoint.until(at(4)))));
+		assertEquals(List.of("savepoint:a"), values(stream.query(savepoint.until(at(2)))));
+
+		// boundary before any savepoint exists: nothing, and the projection replays from the beginning
+		assertEquals(List.of(), values(stream.query(savepoint.until(at(1)))));
+	}
+
+	@ForEachBackend
+	void backwardsWithoutLimitStopsAtTheBoundary ( ) {
+		EventQuery savepoints = EventQuery.forEvents(EventTypesFilter.of(ThirdDomainEvent.class), Tags.none()).backwards();
+
+		assertEquals(List.of("savepoint:b", "savepoint:a"), values(stream.query(savepoints)));
+		assertEquals(List.of("savepoint:b", "savepoint:a"), values(stream.query(savepoints.until(at(7)))));
+		assertEquals(List.of("savepoint:a"), values(stream.query(savepoints.until(at(4)))));
+		assertEquals(List.of(), values(stream.query(savepoints.until(at(1)))));
+	}
+
+	@ForEachBackend
+	void forwardIsUnaffected ( ) {
+		EventQuery firsts = EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none());
+
+		assertEquals(List.of("1", "2", "3", "4"), values(stream.query(firsts)));
+		assertEquals(List.of("1", "2", "3", "4"), values(stream.query(firsts.until(at(7)))));
+		assertEquals(List.of("1", "2", "3"), values(stream.query(firsts.until(at(4)))));
+		assertEquals(List.of("1"), values(stream.query(firsts.until(at(1)))));
+		assertEquals(List.of("1", "2"), values(stream.query(firsts.until(at(4)), null, Limit.to(2))));
+	}
+
+	/**
+	 * The boundary and the cursor are different things and have to compose: the cursor says where to
+	 * start, the boundary says how far the selection reaches.
+	 */
+	@ForEachBackend
+	void untilComposesWithACursor ( ) {
+		EventQuery firsts = EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none());
+
+		// forward: after position 1, up to position 4
+		assertEquals(List.of("2", "3"), values(stream.query(firsts.until(at(4)), at(1))));
+
+		// backward: before position 6, up to position 3
+		assertEquals(List.of("2", "1"), values(stream.query(firsts.until(at(3)).backwards(), at(6))));
+	}
+
+	/**
+	 * A boundary on an event of another stream still orders against this stream's events -- it is a
+	 * position in the store, not in the stream.
+	 */
+	@ForEachBackend
+	void untilOnAnEventOfAnotherStreamStillBounds ( ) {
+		EventStream<MockDomainEvent> other = eventStore()
+				.getEventStream(EventStreamId.forContext("otherApp").withPurpose("until-boundary"), MockDomainEvent.class);
+		EventReference elsewhere = other
+				.append(AppendCriteria.none(), Event.of(new FirstDomainEvent("elsewhere"), Tags.none()))
+				.get(0).reference();
+
+		append(new FirstDomainEvent("5"));
+
+		EventQuery firsts = EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none());
+
+		// "5" was appended after the other stream's event, so the boundary excludes it, in both directions
+		assertEquals(List.of("1", "2", "3", "4"), values(stream.query(firsts.until(elsewhere))));
+		assertEquals(List.of("4", "3", "2", "1"), values(stream.query(firsts.until(elsewhere).backwards())));
+	}
+
+	/**
+	 * The boundary is part of the filter, so it is part of the consistency boundary too: an event past
+	 * it is not a new relevant fact and must not raise a conflict. Backends disagreed here as well --
+	 * one ran the criteria through its query path and honoured the boundary, the other built SQL that
+	 * left it out.
+	 */
+	@ForEachBackend
+	void appendCriteriaHonoursItsUntilBoundary ( ) {
+		EventFilter firsts = EventFilter.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none());
+
+		// unbounded: positions 3, 4 and 6 are new relevant facts after position 1
+		assertThrows(OptimisticLockingException.class,
+				() -> stream.append(AppendCriteria.of(firsts, at(1)), Event.of(new FirstDomainEvent("x"), Tags.none())));
+
+		// bounded at position 4: positions 3 and 4 are still inside the boundary, so still a conflict
+		assertThrows(OptimisticLockingException.class,
+				() -> stream.append(AppendCriteria.of(firsts.until(at(4)), at(1)), Event.of(new FirstDomainEvent("x"), Tags.none())));
+
+		// bounded at position 1: nothing matching the filter lies after the reference and inside the
+		// boundary, so the append goes through
+		List<Event<MockDomainEvent>> appended = stream.append(
+				AppendCriteria.of(firsts.until(at(1)), at(1)),
+				Event.of(new FirstDomainEvent("x"), Tags.none()));
+		assertEquals(1, appended.size());
+	}
+
+	private void append ( MockDomainEvent event ) {
+		stream.append(AppendCriteria.none(), Event.of(event, Tags.none()));
+	}
+
+	/** The reference of the seeded event at the given position (1-based, as positions are). */
+	private EventReference at ( int position ) {
+		return all.get(position - 1).reference();
+	}
+
+	private static List<String> values ( java.util.stream.Stream<Event<MockDomainEvent>> events ) {
+		return events.map(e -> switch ( e.data() ) {
+			case FirstDomainEvent f -> f.value();
+			case SecondDomainEvent s -> s.value();
+			case ThirdDomainEvent t -> t.value();
+		}).toList();
+	}
+
+	private static List<EventReference> references ( java.util.stream.Stream<Event<MockDomainEvent>> events ) {
+		return events.map(Event::reference).toList();
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes critical bugs in the `until` boundary implementation across query and append operations. The `until` boundary is a matching criterion (inclusive upper bound over the `(tx, position, index)` order), not a traversal directive, and must select the same events in both forward and backward directions. Two backends disagreed on this behavior, and the boundary was not being applied to consistency checks in append operations.

## Key Changes

- **New comprehensive test suite** (`EventQueryUntilBoundaryTest`): Validates that `until` selects identical events in both directions, tests the savepoint pattern with boundaries, and verifies boundary composition with cursors and cross-stream references.

- **PostgreSQL backend fix**: Replaced position-only comparison with proper tuple comparison `(event_tx, event_position)` to handle cases where transactions and positions are assigned in different orders. Extracted boundary logic into `addUntilBoundary()` method for reuse in both query and append paths.

- **In-memory backend fix**: Corrected traversal short-circuit logic to use `takeWhile` for forward direction and `dropWhile` for backward direction, ensuring the boundary is treated as an inclusive upper bound in both cases (not as a lower bound when traversing backward).

- **Append criteria consistency fix**: Applied the `until` boundary to optimistic locking checks in `PostgresEventStorageImpl.append()`. Events past the boundary are not new relevant facts and must not trigger `OptimisticLockingException`.

- **Projector fix**: Bounded the `initQuery()` (savepoint lookup) when `runUntil()` is called, preventing initialization from a savepoint written after the requested point in time.

- **Documentation updates**: Enhanced SPI documentation in `EventStorage` to clarify that `until` is a matching criterion, direction-independent, and must be compared as a tuple. Updated CLAUDE.md with guidance on the boundary semantics.

## Implementation Details

The `until` boundary comparison requires comparing both transaction ID and position as a tuple because:
- `event_tx` is assigned at a transaction's first write (via `pg_current_xact_id()`)
- `event_position` comes from a sequence at insert time
- A transaction writing elsewhere first can carry a lower tx but higher position

The `index` component of `EventReference` (which distinguishes sub-events from upcasting) has no storage column, so implementations may use a superset comparison; the exact filter is re-applied above the SPI after upcasting.

Limits are applied *after* the boundary: spending a limit on events beyond the boundary that are discarded later returns too few results.

https://claude.ai/code/session_01EHa4X7Bq1XdW6Vmk8knqL5