### PR TITLE
Fix subscription lifecycle: hold listeners strongly, add unsubscribe SPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,48 @@ The contract every backend implements (documented on `EventStorage.close()`):
 it is on the interface, so no downcast, and it works for framework integration (Spring infers `close` as
 the destroy method for a `@Bean`; CDI `@Disposes`; try-with-resources).
 
+### Lifecycle: closing a stream
+
+`EventSource` — so `EventStream` — is `AutoCloseable` too, but at a much smaller scale: the only thing a
+stream owns is its subscriptions.
+
+- **A stream you only query and append through owns nothing.** `getEventStream()` registers nothing with
+  the storage; the registration happens on the *first* `subscribe(...)`, because a stream with no
+  subscribers has nothing to do with a notification anyway. Most streams are in this category, are handed
+  out per operation, and need no lifecycle handling at all.
+- **A stream you subscribe to is held by the storage, strongly, until closed.** This is what makes live
+  updates survive the caller dropping the variable:
+  ```java
+  // this keeps working -- the storage holds the stream, so the subscription cannot be collected
+  eventStore.getEventStream(streamId, CustomerEvent.class)
+            .subscribe(reference -> { ...; return reference; });
+  ```
+  The cost of that guarantee is that nothing releases it on your behalf. A subscribed stream that is
+  never closed is retained for the lifetime of the storage — deliberately a leak you can find, rather
+  than a subscription that dies at an unpredictable GC with no error and no log, which is what holding
+  listeners weakly used to give.
+- **Close what you subscribe to**, or close the store, which closes them all:
+  ```java
+  try ( EventStream<CustomerEvent> stream = eventStore.getEventStream(streamId, CustomerEvent.class) ) {
+      Projector.from(stream).towards(projection).subscribe().build();
+      ...
+  }   // subscriptions ended, registration released
+  ```
+- **Closing a stream is not terminal**, unlike closing a store or a storage. It ends the subscriptions and
+  clears the listeners; the handle stays usable for query, append and bookmark, and subscribing again
+  re-registers it. A stream is a cheap per-operation handle, not a connection — there is nothing to
+  protect by poisoning it. Idempotent, and closing a never-subscribed stream is a no-op.
+- **Consistent append listeners need no registration.** `EventStreamConsistentAppendListener` is called
+  inline by `append()` on the same object, never through a storage notification, so subscribing one
+  registers nothing. `close()` still discards it.
+
+For backends: `EventStorage.unsubscribe(EventStoreListener)` is the SPI counterpart, and `subscribe` must
+hold listeners **strongly** and be idempotent per listener. `unsubscribe` has a no-op `default` so a
+backend written before it still compiles — and `EventStreamSubscriptionLifecycleTest` in the TCK catches
+one that relies on that default, by asserting a closed stream becomes unreachable. No count of delivered
+notifications can catch it: a closed stream has already discarded its listeners, so it stays quiet whether
+or not the storage let go of it.
+
 ### Typical Usage Pattern
 
 ```java

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/EventStore.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/EventStore.java
@@ -84,6 +84,10 @@ public interface EventStore extends AutoCloseable {
 	 * that strands anything subscribed to it. Streams from <em>other</em> stores on the same storage are
 	 * unaffected.
 	 * <p>
+	 * Closing a store also closes its streams, ending their subscriptions and handing their registrations
+	 * back to the storage — see {@link org.sliceworkz.eventstore.stream.EventSource#close()}. That one
+	 * operation on a stream keeps working afterwards, as closing something twice must.
+	 * <p>
 	 * Declared without a checked exception, unlike {@link AutoCloseable#close()}, so that
 	 * try-with-resources needs no catch block. The default implementation does nothing.
 	 */

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -608,9 +608,18 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 		 * and may batch multiple events before triggering a projection run.
 		 * <p>
 		 * Without this setting, projections only update when explicitly triggered via {@link Projector#run()}.
+		 * <p>
+		 * <b>Lifetime.</b> Subscribing registers the event source with the storage, which then holds it —
+		 * and this projector through it — until the source is closed. That is deliberate: it is what lets
+		 * a live projection go on updating without the caller having to keep a variable alive for it. It
+		 * also means the pair is released only by
+		 * {@link org.sliceworkz.eventstore.stream.EventSource#close()}, or by closing the
+		 * {@link org.sliceworkz.eventstore.EventStore} the source came from. Long-lived projections need
+		 * nothing; one per request, per tenant or per test should close its source when done.
 		 *
 		 * @return this builder for method chaining
 		 * @see EventStreamEventuallyConsistentAppendListener
+		 * @see org.sliceworkz.eventstore.stream.EventSource#close()
 		 */
 		public Builder<EVENT_TYPE> subscribe ( ) {
 			this.subscribe = true;

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -108,7 +108,12 @@ import org.sliceworkz.eventstore.stream.EventStreamId;
  *
  *     @Override
  *     public void subscribe(EventStoreListener listener) {
- *         listeners.add(listener);
+ *         listeners.addIfAbsent(listener);
+ *     }
+ *
+ *     @Override
+ *     public void unsubscribe(EventStoreListener listener) {
+ *         listeners.remove(listener);
  *     }
  *
  *     // Implement remaining methods...
@@ -361,13 +366,47 @@ public interface EventStorage extends AutoCloseable {
 	 * <p>
 	 * Implementations should ensure listeners are called in a thread-safe manner.
 	 * Listeners should perform minimal work and delegate to async processing where possible.
+	 * <p>
+	 * <b>The registration is a strong reference, and it is permanent until
+	 * {@link #unsubscribe(EventStoreListener)} is called.</b> Implementations must not hold listeners
+	 * weakly: a listener that quietly disappears when the caller stops referencing it turns "my
+	 * projection stopped updating" into a garbage-collection-timing bug with no error and no log. Who
+	 * registered a listener is responsible for unregistering it — which for the streams this library
+	 * hands out means {@code EventStream.close()}, or closing the store they came from.
+	 * <p>
+	 * Registering the same listener twice must be harmless and must not double the notifications it
+	 * receives, so that a caller need not track whether it has already subscribed.
 	 *
 	 * @param listener the listener to register for storage notifications
+	 * @see #unsubscribe(EventStoreListener)
 	 * @see EventStoreListener
 	 * @see AppendsToEventStoreNotification
 	 * @see BookmarkPlacedNotification
 	 */
 	void subscribe ( EventStoreListener listener );
+
+	/**
+	 * Unregisters a listener previously passed to {@link #subscribe(EventStoreListener)}, so that it
+	 * receives no further notifications and this storage stops referencing it.
+	 * <p>
+	 * Idempotent and forgiving: unregistering a listener that was never registered, or unregistering
+	 * one twice, does nothing and does not throw. Listeners are matched by identity unless the listener
+	 * type defines equality.
+	 * <p>
+	 * A notification already in flight on another thread may still reach the listener after this
+	 * returns; the guarantee is that no <em>new</em> notification will be dispatched to it.
+	 * <p>
+	 * The default implementation does nothing, so that an {@link EventStorage} written before this
+	 * method existed still compiles and runs. Such a backend leaks every listener ever registered with
+	 * it, which the compliance scenarios in {@code org.sliceworkz.eventstore.testing.tck} detect — a
+	 * backend that keeps a listener list must override this.
+	 *
+	 * @param listener the listener to unregister; ignored if null or not registered
+	 * @see #subscribe(EventStoreListener)
+	 */
+	default void unsubscribe ( EventStoreListener listener ) {
+		// backends predating this method keep their listeners forever; the TCK reports it
+	}
 
 	/**
 	 * Defines the direction of event query traversal.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -113,7 +113,45 @@ import org.sliceworkz.eventstore.query.Limit;
  * @see EventQuery
  * @see Event
  */
-public interface EventSource<DOMAIN_EVENT_TYPE> {
+public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
+
+	/**
+	 * Ends every subscription made on this source, releasing the registration it holds with the
+	 * underlying storage.
+	 * <p>
+	 * A source that has been subscribed to is kept alive by the storage for as long as it is
+	 * registered — that is what stops notifications from dying silently when the caller no longer
+	 * holds the source. The flip side is that nothing else will ever release it, so a subscribed
+	 * source that is never closed is retained for the lifetime of the storage. Close the sources you
+	 * subscribe to, or close the {@link org.sliceworkz.eventstore.EventStore} they came from, which
+	 * closes them all:
+	 * <pre>{@code
+	 * try ( EventStream<CustomerEvent> stream = eventStore.getEventStream(streamId, CustomerEvent.class) ) {
+	 *     Projector.from(stream).towards(projection).subscribe().build();
+	 *     ...
+	 * }   // subscriptions ended, registration released
+	 * }</pre>
+	 * A source that was never subscribed to holds no registration, so closing it does nothing — and
+	 * not closing it costs nothing either. Streams used only to query and append, which is most of
+	 * them, need no lifecycle handling at all.
+	 * <p>
+	 * <b>Closing is not terminal.</b> The source stays usable for querying, appending and bookmarking
+	 * afterwards, and subscribing again re-registers it. The only resource a source owns is its
+	 * subscriptions, so closing means "stop listening", not "throw this handle away" — poisoning a
+	 * cheap handle that 150 call sites obtain freely would buy nothing. This is the one respect in
+	 * which it differs from {@link org.sliceworkz.eventstore.EventStore#close()} and
+	 * {@link org.sliceworkz.eventstore.spi.EventStorage#close()}, which are terminal because they do
+	 * own threads and connections.
+	 * <p>
+	 * Idempotent. Declared without a checked exception, unlike {@link AutoCloseable#close()}, so that
+	 * try-with-resources needs no catch block. The default implementation does nothing.
+	 *
+	 * @see #subscribe(EventStreamEventuallyConsistentAppendListener)
+	 */
+	@Override
+	default void close ( ) {
+		// no subscriptions to release
+	}
 
 	/**
 	 * Queries events from the stream with full control over pagination and raw cursor tracking.
@@ -208,8 +246,12 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	 * This subscription provides eventual consistency guarantees - the listener may be notified
 	 * slightly after the append has completed. Useful for async processing where immediate
 	 * consistency is not required.
+	 * <p>
+	 * Subscribing registers this source with the underlying storage, which then keeps it alive until
+	 * {@link #close()}. Close the source when the subscription is no longer wanted — see {@link #close()}.
 	 *
 	 * @param listener the listener to receive append notifications
+	 * @see #close()
 	 */
 	void subscribe ( EventStreamEventuallyConsistentAppendListener listener );
 
@@ -218,8 +260,13 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	 * <p>
 	 * This subscription provides strong consistency guarantees - the listener is notified
 	 * synchronously as part of the append operation. The listener receives the typed domain events.
+	 * <p>
+	 * Unlike the eventually consistent overloads, this needs no registration with the storage: the
+	 * listener is called inline by the append, so reaching it means holding this source anyway.
+	 * {@link #close()} still discards it.
 	 *
 	 * @param listener the listener to receive append notifications with typed events
+	 * @see #close()
 	 */
 	void subscribe ( EventStreamConsistentAppendListener<DOMAIN_EVENT_TYPE> listener );
 
@@ -228,8 +275,11 @@ public interface EventSource<DOMAIN_EVENT_TYPE> {
 	 * <p>
 	 * This subscription allows monitoring bookmark updates, useful for coordinating
 	 * multiple readers or tracking processing progress.
+	 * <p>
+	 * As with the append overloads, this registers the source with the storage until {@link #close()}.
 	 *
 	 * @param listener the listener to receive bookmark notifications
+	 * @see #close()
 	 */
 	void subscribe ( EventStreamEventuallyConsistentBookmarkListener listener );
 

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -149,6 +150,17 @@ public class EventStoreImpl implements EventStore {
 	private final AtomicBoolean closed = new AtomicBoolean();
 
 	/**
+	 * The streams of this store that currently hold a listener registration with the storage — that is,
+	 * the ones somebody has subscribed to. Streams nobody subscribed to never appear here.
+	 * <p>
+	 * The storage references those streams strongly, so they outlive the caller's variable on purpose;
+	 * this set is what lets {@link #close()} hand them all back rather than leaving the storage holding
+	 * streams belonging to a store that is gone. Identity-based, since {@code EventStreamImpl} defines
+	 * no equality: two streams for the same id are two distinct registrations.
+	 */
+	private final Set<EventStreamImpl<?>> subscribedStreams = ConcurrentHashMap.newKeySet();
+
+	/**
 	 * How long {@link #close()} waits for each notification executor to finish before logging and
 	 * moving on. The tasks are short-lived listener callbacks, so this only covers a listener that
 	 * ignores interruption.
@@ -191,13 +203,19 @@ public class EventStoreImpl implements EventStore {
 	}
 
 	/**
-	 * Shuts down this store's notification executors, leaving the storage open.
+	 * Unregisters this store's subscribed streams from the storage and shuts down its notification
+	 * executors, leaving the storage itself open.
 	 * <p>
 	 * Idempotent, and bounded: the executors are interrupted and awaited briefly. The storage was handed
 	 * to this store rather than created by it, and may well be backing other stores, so closing it is
 	 * not this store's call — see {@link EventStore#close()}. A store that must close its storage is
 	 * composed with {@link EventStore#owning(EventStore, EventStorage)}, which is what the storage
 	 * builders' {@code buildStore()} returns.
+	 * <p>
+	 * The streams are unregistered <em>first</em>: the storage holds subscribed streams strongly, so
+	 * leaving them registered would keep this store — an inner-class stream references the store that
+	 * made it — reachable from a storage that outlives it, and would keep the storage delivering
+	 * notifications no one can act on any more.
 	 * <p>
 	 * Once closed, this store's streams stop working and its listeners fall silent, but nothing it does
 	 * disturbs another store on the same storage.
@@ -207,6 +225,7 @@ public class EventStoreImpl implements EventStore {
 		if ( !closed.compareAndSet(false, true) ) {
 			return;
 		}
+		subscribedStreams.forEach(EventStreamImpl::close);
 		shutdown(executorServiceForEventAppends);
 		shutdown(executorServiceForBookmarkUpdates);
 	}
@@ -268,12 +287,17 @@ public class EventStoreImpl implements EventStore {
 		private final List<EventStreamConsistentAppendListener<EVENT_TYPE>> consistentSubscribers = new CopyOnWriteArrayList<>();
 		private final List<EventStreamEventuallyConsistentBookmarkListener> bookmarkSubscribers = new CopyOnWriteArrayList<>();
 
+		/**
+		 * Whether this stream currently holds a listener registration with the storage. Flipped by
+		 * {@link #subscribeToStorage()} and {@link #close()}, which are the only two places it changes.
+		 */
+		private final AtomicBoolean subscribedToStorage = new AtomicBoolean();
+
 		public EventStreamImpl ( EventStorage eventStorage, EventStreamId eventStreamId, EventPayloadSerializerDeserializer serde ) {
 			this.eventStorage = eventStorage;
 			this.eventStreamId = eventStreamId;
-			this.eventStorage.subscribe(this);
 			this.serde = serde;
-			
+
 			String tagContextValue = Optional.ofNullable(eventStreamId.context()).orElse(""); // null is not allowed
 			String tagPurposeValue = Optional.ofNullable(eventStreamId.purpose()).orElse(""); // null is not allowed
 			String tagTypedValue = String.valueOf(serde.isTyped());
@@ -316,12 +340,70 @@ public class EventStoreImpl implements EventStore {
 			return eventStreamId;
 		}
 
+		/**
+		 * Registers this stream with the storage, on the first subscription and not before.
+		 * <p>
+		 * A stream that nobody subscribes to has nothing to do with a notification — {@link #notify} does
+		 * no more than fan out to the three subscriber lists — so registering one would only lengthen the
+		 * list the storage walks on every append, on the single thread that serves every store attached to
+		 * it. Streams are handed out per operation and most of them only query and append, so that list
+		 * used to grow with traffic rather than with the number of things actually listening.
+		 * <p>
+		 * Deferring registration to here is also what makes the storage's strong reference safe: it holds
+		 * exactly the streams somebody asked to be notified through, which are the streams that were
+		 * supposed to stay alive anyway.
+		 */
+		private void subscribeToStorage ( ) {
+			if ( !subscribedToStorage.compareAndSet(false, true) ) {
+				return;
+			}
+			subscribedStreams.add(this);
+			eventStorage.subscribe(this);
+			if ( closed.get() ) {
+				// the store was closed between this stream's checkStoreNotClosed and the registration
+				// above, so close() has already walked its streams and will not come back for this one.
+				// Undoing it here is what keeps that race from leaving a registration behind on a
+				// storage that outlives the store
+				close();
+			}
+		}
+
+		/**
+		 * Ends this stream's subscriptions and hands its registration back to the storage.
+		 * <p>
+		 * Idempotent, and not terminal: the stream stays usable for querying, appending and bookmarking,
+		 * and subscribing again re-registers it. See {@link org.sliceworkz.eventstore.stream.EventSource#close()}
+		 * for why a stream is closable at all and why closing it is not the end of it.
+		 * <p>
+		 * The subscriber lists are cleared as well as the registration released, so that a listener cannot
+		 * survive into a later subscription of the same stream and be notified twice.
+		 */
+		@Override
+		public void close ( ) {
+			if ( subscribedToStorage.compareAndSet(true, false) ) {
+				eventStorage.unsubscribe(this);
+				subscribedStreams.remove(this);
+			}
+			eventuallyConsistentSubscribers.clear();
+			consistentSubscribers.clear();
+			bookmarkSubscribers.clear();
+		}
+
 		@Override
 		public void subscribe(EventStreamEventuallyConsistentAppendListener eventuallyConsistentSubscriber) {
 			checkStoreNotClosed();
 			this.eventuallyConsistentSubscribers.add(new OptimizingApendListenerDecorator(eventuallyConsistentSubscriber));
+			subscribeToStorage();
 		}
 
+		/**
+		 * {@inheritDoc}
+		 * <p>
+		 * Deliberately does <em>not</em> register with the storage. A consistent subscriber is notified
+		 * inline by {@link #append}, on this very object, and never through a storage notification — so it
+		 * needs no registration, and it cannot be orphaned by one being absent: reaching it at all means
+		 * holding this stream to append through.
+		 */
 		@Override
 		public void subscribe(EventStreamConsistentAppendListener<EVENT_TYPE> consistentSubscriber) {
 			checkStoreNotClosed();
@@ -332,6 +414,7 @@ public class EventStoreImpl implements EventStore {
 		public void subscribe(EventStreamEventuallyConsistentBookmarkListener listener) {
 			checkStoreNotClosed();
 			this.bookmarkSubscribers.add(listener);
+			subscribeToStorage();
 		}
 
 		@Override
@@ -460,9 +543,10 @@ public class EventStoreImpl implements EventStore {
 
 		@Override
 		public void notify(AppendsToEventStoreNotification newEventsInStore) {
-			// A storage outlives the stores built on it, and keeps notifying every stream ever registered
-			// with it -- including ours, after our store was closed and its executors shut down. Dropping
-			// the notification is what keeps a closed store from poisoning the storage it shares.
+			// close() unregisters this stream, but a notification already being dispatched can still land
+			// here afterwards -- unsubscribe only promises no *new* dispatches. Dropping it is what keeps
+			// a closed store from poisoning the storage it shares: the executors are gone by then, and on
+			// Postgres the caller is the LISTEN/NOTIFY monitor thread every store on the storage depends on.
 			if ( closed.get() ) {
 				return;
 			}

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -133,6 +133,11 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 	}
 
 	@Override
+	public void unsubscribe ( EventStoreListener listener ) {
+		delegate.unsubscribe(listener);
+	}
+
+	@Override
 	public Optional<EventReference> getBookmark ( String reader ) {
 		return delegate.getBookmark(reader);
 	}

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -17,7 +17,6 @@
  */
 package org.sliceworkz.eventstore.infra.inmem;
 
-import java.lang.ref.WeakReference;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -117,7 +116,11 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	// Postgres backend's per-stream partial unique index, so the same key on two different streams
 	// does not collide and behaviour does not depend on how storage instances are wired at runtime.
 	private Set<IdempotencyScope> idempotencyKeys = new HashSet<>();
-	private List<WeakReference<EventStoreListener>> listeners = new CopyOnWriteArrayList<>();
+	// Strong references, released only by unsubscribe(). Held weakly, a listener whose registrant stopped
+	// referencing it would vanish at the next GC and take its notifications with it, silently -- see
+	// EventStorage.subscribe(). CopyOnWriteArrayList because notification is far more frequent than
+	// (un)subscription, and notifying must not block appends.
+	private final CopyOnWriteArrayList<EventStoreListener> listeners = new CopyOnWriteArrayList<>();
 	private Map<String,Bookmark> bookmarks = new HashMap<>();
 	private JsonMapper jsonMapper;
 	private Limit absoluteLimit;
@@ -351,11 +354,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 			        (existing, replacement) -> replacement // in sequence, only useful to notify about the last one
 			    ))
 			    .values()
-			    .forEach(notification->listeners.forEach(listener->{
-			    	if (listener.get()!=null){
-			    		notifyQuietly(listener.get(), notification);
-			    	};
-			    }));
+			    .forEach(notification->listeners.forEach(listener->notifyQuietly(listener, notification)));
 	}
 	
 	private StoredEvent addEventToEventLog ( EventToStore event, long tx ) {
@@ -472,8 +471,15 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	@Override
 	public void subscribe(EventStoreListener listener) {
 		checkNotClosed();
-		listeners.add(new WeakReference<>(listener));
-		listeners.removeIf(ref -> ref.get() == null);
+		// addIfAbsent, so re-registering the same listener does not double its notifications
+		listeners.addIfAbsent(listener);
+	}
+
+	@Override
+	public void unsubscribe(EventStoreListener listener) {
+		// deliberately no checkNotClosed: unsubscribing from a closed storage is what an orderly
+		// teardown looks like when the storage happened to be closed first, and it must not throw
+		listeners.remove(listener);
 	}
 
 	@Override
@@ -500,11 +506,7 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		Tags effectiveTags = tags == null ? Tags.none() : tags;
 		bookmarks.put(reader, new Bookmark(reader, eventReference, effectiveTags, Instant.now()));
 		BookmarkPlacedNotification notification = new BookmarkPlacedNotification(reader, eventReference);
-		listeners.forEach(l->{
-			if ( l.get() != null ) {
-				notifyQuietly(l.get(), notification);
-			}
-		});
+		listeners.forEach(l->notifyQuietly(l, notification));
 	}
 
 	/**
@@ -589,10 +591,15 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 * Idempotent. The events are deliberately not discarded: a closed storage rejects operations rather
 	 * than quietly answering from a half-torn-down state, and dropping the log would only make
 	 * diagnosing a lifecycle bug harder.
+	 * <p>
+	 * The listeners <em>are</em> discarded. They are held strongly, so a closed storage that kept them
+	 * would pin every stream ever subscribed to it, and every event store behind those streams, for as
+	 * long as anything still referenced the storage itself.
 	 */
 	@Override
 	public void close ( ) {
 		closed.set(true);
+		listeners.clear();
 	}
 
 	private void checkNotClosed ( ) {

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -19,7 +19,6 @@ package org.sliceworkz.eventstore.infra.postgres;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -151,7 +150,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 	 */
 	private final boolean ownsDataSources;
 
-	private final List<WeakReference<EventStoreListener>> listeners = new CopyOnWriteArrayList<>();
+	// Strong references, released only by unsubscribe(). Held weakly, a listener whose registrant stopped
+	// referencing it would vanish at the next GC and take its notifications with it, silently -- see
+	// EventStorage.subscribe(). CopyOnWriteArrayList because the monitor threads walk this on every
+	// notification and must never block on a subscription.
+	private final CopyOnWriteArrayList<EventStoreListener> listeners = new CopyOnWriteArrayList<>();
 	private final ExecutorService executorService;
 	private final AtomicBoolean stopped = new AtomicBoolean();
 
@@ -632,10 +635,15 @@ public class PostgresEventStorageImpl implements EventStorage {
 	 * A caller who supplied the DataSource must close this storage <em>before</em> closing that pool.
 	 * The other order leaves the monitors alive against a dead pool, where they cannot tell a closed
 	 * pool from a database outage and will retry with backoff, logging as they go.
+	 * <p>
+	 * The listeners are dropped once the monitors have stopped — after, so that nothing is walking the
+	 * list while it is emptied, and at all because they are held strongly: a closed storage that kept
+	 * them would pin every stream ever subscribed to it, and every event store behind those streams.
 	 */
 	@Override
 	public void close ( ) {
 		boolean wasRunning = stopMonitors();
+		listeners.clear();
 		if ( wasRunning && ownsDataSources ) {
 			closeDataSource(dataSource);
 			if ( monitoringDataSource != dataSource ) {
@@ -1445,11 +1453,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 		private static final Logger LOGGER = LoggerFactory.getLogger(NewEventsAppendedMonitor.class);
 
 		private String name;
-		private List<WeakReference<EventStoreListener>> listeners;
+		private List<EventStoreListener> listeners;
 		private DataSource monitoringDataSource;
 		private CountDownLatch readyLatch;
 
-		public NewEventsAppendedMonitor ( String name, List<WeakReference<EventStoreListener>> listeners, DataSource monitoringDataSource, CountDownLatch readyLatch ) {
+		public NewEventsAppendedMonitor ( String name, List<EventStoreListener> listeners, DataSource monitoringDataSource, CountDownLatch readyLatch ) {
 			this.name = name;
 			this.listeners = listeners;
 			this.monitoringDataSource = monitoringDataSource;
@@ -1494,17 +1502,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 									EventAppendedPostgresNotification msg = JSONMAPPER.readValue(notification.getParameter(), EventAppendedPostgresNotification.class);
 									AppendsToEventStoreNotification aesn = msg.toNotification();
 
-									listeners.forEach(l -> {
-										EventStoreListener listener = l.get();
-										if (listener != null) {
-											// one listener misbehaving must not kill this monitor: it is the only one this
-											// storage has, so its death silently stops notifications for every store,
-											// listener and projection attached to the storage
-											try {
-												listener.notify(aesn);
-											} catch (Exception e) {
-												LOGGER.error("event store listener failed handling a notification: {}", e.getMessage(), e);
-											}
+									listeners.forEach(listener -> {
+										// one listener misbehaving must not kill this monitor: it is the only one this
+										// storage has, so its death silently stops notifications for every store,
+										// listener and projection attached to the storage
+										try {
+											listener.notify(aesn);
+										} catch (Exception e) {
+											LOGGER.error("event store listener failed handling a notification: {}", e.getMessage(), e);
 										}
 									});
 
@@ -1548,11 +1553,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 		private static final Logger LOGGER = LoggerFactory.getLogger(BookmarkPlacedMonitor.class);
 
 		private String name;
-		private List<WeakReference<EventStoreListener>> listeners;
+		private List<EventStoreListener> listeners;
 		private DataSource monitoringDataSource;
 		private CountDownLatch readyLatch;
 
-		public BookmarkPlacedMonitor ( String name, List<WeakReference<EventStoreListener>> listeners, DataSource monitoringDataSource, CountDownLatch readyLatch ) {
+		public BookmarkPlacedMonitor ( String name, List<EventStoreListener> listeners, DataSource monitoringDataSource, CountDownLatch readyLatch ) {
 			this.name = name;
 			this.listeners = listeners;
 			this.monitoringDataSource = monitoringDataSource;
@@ -1599,17 +1604,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 									BookmarkPlacedNotification bpn = msg.toNotification();
 									LOGGER.debug("notification: " + bpn);
 
-									listeners.forEach(l -> {
-										EventStoreListener listener = l.get();
-										if (listener != null) {
-											// one listener misbehaving must not kill this monitor: it is the only one this
-											// storage has, so its death silently stops notifications for every store,
-											// listener and projection attached to the storage
-											try {
-												listener.notify(bpn);
-											} catch (Exception e) {
-												LOGGER.error("event store listener failed handling a notification: {}", e.getMessage(), e);
-											}
+									listeners.forEach(listener -> {
+										// one listener misbehaving must not kill this monitor: it is the only one this
+										// storage has, so its death silently stops notifications for every store,
+										// listener and projection attached to the storage
+										try {
+											listener.notify(bpn);
+										} catch (Exception e) {
+											LOGGER.error("event store listener failed handling a notification: {}", e.getMessage(), e);
 										}
 									});
 
@@ -1666,8 +1668,15 @@ public class PostgresEventStorageImpl implements EventStorage {
 	@Override
 	public void subscribe(EventStoreListener listener) {
 		checkNotClosed();
-		listeners.add(new WeakReference<>(listener));
-		listeners.removeIf(ref -> ref.get() == null);
+		// addIfAbsent, so re-registering the same listener does not double its notifications
+		listeners.addIfAbsent(listener);
+	}
+
+	@Override
+	public void unsubscribe(EventStoreListener listener) {
+		// deliberately no checkNotClosed: unsubscribing from a closed storage is what an orderly
+		// teardown looks like when the storage happened to be closed first, and it must not throw
+		listeners.remove(listener);
 	}
 
 	@Override

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStorageLifecycleTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStorageLifecycleTest.java
@@ -289,8 +289,8 @@ public class EventStorageLifecycleTest extends AbstractEventStoreTest {
 		EventStream<MockDomainEvent> closedStream = stream(closedStore);
 		EventStream<MockDomainEvent> survivingStream = stream(survivingStore);
 
-		// listeners on both: the closed store's stream stays registered with the storage, so the
-		// storage keeps offering it notifications it must now quietly decline rather than reject
+		// listeners on both: closing a store unregisters its streams from the storage, and anything
+		// already in flight when that happens must be declined quietly rather than rejected
 		AtomicInteger notificationsAfterClose = new AtomicInteger();
 		closedStream.subscribe((EventStreamEventuallyConsistentAppendListener) reference -> {
 			notificationsAfterClose.incrementAndGet();

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStreamSubscriptionLifecycleTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStreamSubscriptionLifecycleTest.java
@@ -1,0 +1,207 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamEventuallyConsistentAppendListener;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
+
+/**
+ * The subscription lifetime contract: what a backend must do with a listener between
+ * {@link EventStorage#subscribe} and {@link EventStorage#unsubscribe}.
+ * <p>
+ * The scenario worth the whole class is {@link #aSubscriptionOutlivesTheCallerDroppingTheStream()}.
+ * Both in-tree backends used to keep listeners as {@code WeakReference}s, so a stream nobody kept a
+ * variable for was collected and its subscription went quiet — no exception, no log, and timing that
+ * depended on when a collection happened to run. That is the one failure mode a test suite cannot
+ * stumble over by accident: on a small heap a test JVM may never collect at all, and the suite passes
+ * while live updates are broken in production.
+ * <p>
+ * The rest pin down the other side of holding listeners strongly: since nothing will ever release
+ * them on the caller's behalf, {@code close()} has to, exactly and repeatably.
+ */
+public class EventStreamSubscriptionLifecycleTest extends AbstractEventStoreTest {
+
+	private EventStream<MockDomainEvent> stream ( ) {
+		return eventStore().getEventStream(EventStreamId.forContext("subscriptions"), MockDomainEvent.class);
+	}
+
+	private void append ( EventStream<MockDomainEvent> stream, String payload ) {
+		stream.append(AppendCriteria.none(), Collections.singletonList(Event.of(new FirstDomainEvent(payload), Tags.none())));
+	}
+
+	private EventStreamEventuallyConsistentAppendListener counting ( AtomicInteger counter ) {
+		return reference -> {
+			counter.incrementAndGet();
+			return reference;
+		};
+	}
+
+	/**
+	 * Subscribes through a stream and then lets every reference to it die with this frame, so that the
+	 * caller keeps nothing but the counter its listener increments.
+	 */
+	private void subscribeThroughAStreamWeThenForget ( AtomicInteger notifications ) {
+		stream().subscribe(counting(notifications));
+	}
+
+	/**
+	 * Runs collections until a known-unreachable object has been collected, then asserts it was — so a
+	 * scenario relying on collection either really got one or fails, rather than passing vacuously on a
+	 * JVM that ignored the request.
+	 */
+	private void provokeGarbageCollection ( ) {
+		WeakReference<Object> canary = new WeakReference<>(new Object());
+		for ( int attempt = 0; attempt < 10 && canary.get() != null; attempt++ ) {
+			System.gc();
+		}
+		assertNull(canary.get(),
+			"this JVM did not collect an unreachable object on request, so this scenario cannot prove anything");
+	}
+
+	@ForEachBackend
+	void aSubscriptionOutlivesTheCallerDroppingTheStream ( ) {
+		AtomicInteger notifications = new AtomicInteger();
+		subscribeThroughAStreamWeThenForget(notifications);
+
+		// nothing in this test can reach the subscribing stream any more. Were it held weakly, this is
+		// where it would be collected and its listener would fall silent
+		provokeGarbageCollection();
+
+		append(stream(), "appended after the subscribing stream went out of scope");
+
+		waitBecauseOfEventualConsistency(( ) -> notifications.get() >= 1);
+	}
+
+	@ForEachBackend
+	void closingAStreamEndsItsSubscription ( ) {
+		AtomicInteger closedStreamNotifications = new AtomicInteger();
+		EventStream<MockDomainEvent> toBeClosed = stream();
+		toBeClosed.subscribe(counting(closedStreamNotifications));
+
+		AtomicInteger witnessNotifications = new AtomicInteger();
+		EventStream<MockDomainEvent> witness = stream();
+		witness.subscribe(counting(witnessNotifications));
+
+		toBeClosed.close();
+
+		append(witness, "appended after one subscription was closed");
+
+		// the witness is what makes the silence meaningful: it proves the notification round trip ran to
+		// completion, so the closed stream was passed over rather than merely slower than the assertion
+		waitBecauseOfEventualConsistency(( ) -> witnessNotifications.get() >= 1);
+		assertEquals(0, closedStreamNotifications.get(),
+			"a closed stream must receive no further notifications");
+	}
+
+	/**
+	 * Subscribes a stream, closes it, and hands back only a weak reference — so that after this frame
+	 * returns, the storage's own registration is the only thing that could still be holding it.
+	 */
+	private WeakReference<EventStream<MockDomainEvent>> subscribeCloseAndKeepOnlyAWeakReference ( AtomicInteger notifications ) {
+		EventStream<MockDomainEvent> stream = stream();
+		stream.subscribe(counting(notifications));
+		stream.close();
+		return new WeakReference<>(stream);
+	}
+
+	@ForEachBackend
+	void closingAStreamLetsTheStorageReleaseIt ( ) {
+		WeakReference<EventStream<MockDomainEvent>> closed = subscribeCloseAndKeepOnlyAWeakReference(new AtomicInteger());
+
+		provokeGarbageCollection();
+
+		// this is the scenario that catches a backend which accepted the subscription but never
+		// implemented unsubscribe: its listeners are silently immortal, and since they are held
+		// strongly that is an outright leak of every stream and every store behind them. No count of
+		// delivered notifications reveals it -- a closed stream has already discarded its listeners, so
+		// it stays quiet either way -- but reachability does
+		assertNull(closed.get(),
+			"a closed stream must be released by the storage; this backend is still holding it, so it most likely does not implement EventStorage.unsubscribe");
+	}
+
+	@ForEachBackend
+	void closingAStreamDiscardsItsListenersRatherThanParkingThem ( ) {
+		EventStream<MockDomainEvent> stream = stream();
+		AtomicInteger fromBeforeClose = new AtomicInteger();
+		stream.subscribe(counting(fromBeforeClose));
+
+		stream.close();
+
+		AtomicInteger fromAfterClose = new AtomicInteger();
+		stream.subscribe(counting(fromAfterClose));
+		append(stream, "appended after re-subscribing");
+
+		waitBecauseOfEventualConsistency(( ) -> fromAfterClose.get() >= 1);
+		assertEquals(0, fromBeforeClose.get(),
+			"a listener dropped by close() must not be revived by a later subscription on the same stream");
+	}
+
+	@ForEachBackend
+	void closingAStreamIsIdempotentAndLeavesItUsable ( ) {
+		EventStream<MockDomainEvent> neverSubscribed = stream();
+
+		// a stream nobody subscribed to holds no registration, so closing it -- twice -- has nothing to
+		// release and must still be silent about it
+		neverSubscribed.close();
+		neverSubscribed.close();
+
+		append(neverSubscribed, "appended through a closed stream");
+		assertEquals(1, neverSubscribed.query(EventQuery.matchAll()).count(),
+			"closing a stream ends its subscriptions; it must not disable the handle");
+	}
+
+	@ForEachBackend
+	void aStreamClosesItsSubscriptionAtTheEndOfATryWithResources ( ) {
+		AtomicInteger notifications = new AtomicInteger();
+		AtomicInteger witnessNotifications = new AtomicInteger();
+
+		EventStream<MockDomainEvent> witness = stream();
+		witness.subscribe(counting(witnessNotifications));
+
+		try ( EventStream<MockDomainEvent> scoped = stream() ) {
+			scoped.subscribe(counting(notifications));
+			append(scoped, "appended inside the block");
+			waitBecauseOfEventualConsistency(( ) -> notifications.get() >= 1);
+		}
+
+		int afterTheBlock = notifications.get();
+		append(witness, "appended after the block");
+
+		waitBecauseOfEventualConsistency(( ) -> witnessNotifications.get() >= 2);
+		assertEquals(afterTheBlock, notifications.get(),
+			"a stream closed by try-with-resources must stop receiving notifications");
+	}
+
+}


### PR DESCRIPTION
## Summary

This change fixes a critical bug where event stream subscriptions could be silently lost due to weak reference handling, and establishes a proper lifecycle contract for subscriptions. Listeners are now held strongly by storage implementations and released only through explicit `unsubscribe()` calls, making subscription lifetime predictable and debuggable.

## Key Changes

- **EventSource now extends AutoCloseable** with a `close()` method that ends subscriptions and releases storage registrations. Closing is idempotent and non-terminal — streams remain usable for query/append after closing.

- **EventStorage.unsubscribe() SPI added** as a new method (with a no-op default for backward compatibility) to release listener registrations. Backends must override this to remove listeners from their internal lists.

- **Listeners held strongly, not weakly**: Both in-memory and PostgreSQL backends changed from `WeakReference<EventStoreListener>` to direct strong references in `CopyOnWriteArrayList`. This prevents subscriptions from vanishing at unpredictable GC times.

- **Deferred storage registration**: EventStreamImpl now registers with storage only on first subscription (not on stream creation), reducing overhead for streams used only for query/append. Registration is tracked via `subscribedToStorage` flag.

- **EventStoreImpl tracks subscribed streams** in a `ConcurrentHashMap.newKeySet()` to enable orderly cleanup. When the store closes, it unsubscribes all registered streams before shutting down executors, preventing leaked registrations on long-lived storage.

- **Listener deduplication**: `subscribe()` now uses `addIfAbsent()` to prevent double-registration of the same listener, making the operation safely idempotent.

- **Comprehensive TCK test suite** added (`EventStreamSubscriptionLifecycleTest`) with six scenarios:
  - Subscriptions survive caller dropping the stream variable (proving strong references work)
  - Closing a stream ends its subscriptions
  - Closed streams are released by storage (catches missing `unsubscribe()` implementations)
  - Closed streams discard listeners rather than parking them
  - Closing is idempotent and doesn't disable the stream
  - Try-with-resources properly closes subscriptions

## Implementation Details

- **Race condition handling**: EventStreamImpl checks if the store was closed between subscription and registration, and closes itself if needed, preventing orphaned registrations.

- **Backward compatibility**: The `unsubscribe()` default implementation does nothing, so pre-existing backends compile. The TCK detects non-compliance by asserting closed streams become unreachable.

- **Consistent append listeners exempt**: `EventStreamConsistentAppendListener` is called inline by `append()` and needs no storage registration, so subscribing one does not register the stream.

- **Documentation**: Updated `EventSource`, `EventStorage`, and `Projector` javadocs to explain the subscription lifecycle, the need to close subscribed sources, and why strong references are essential.

- **Postgres and in-memory backends updated**: Both removed weak reference handling and implemented `unsubscribe()` to remove listeners from their lists. Monitor threads simplified to work directly with listeners instead of unwrapping weak references.

https://claude.ai/code/session_01Fie8RpAVKae6bShTJLCYNV