### PR TITLE
Fix optimistic locking to compare (tx, position) tuple, not position alone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,14 @@ The key insight of DCB is that business decisions are based on querying relevant
 3. Append new events with `AppendCriteria` containing the query's `EventFilter` and last reference
 4. If new events matching the filter exist after the reference, the append fails
 
+**"After the reference" in step 4 means the total `(tx, position, index)` order** — the one
+`EventReference.happenedAfter` defines and reads are ordered by — not position alone. The two are not
+interchangeable: a backend assigning position and transaction independently can produce an event holding a
+lower position and a higher transaction than one that committed before it, and such an event is after the
+reference for every reader. A check comparing positions alone does not see it and admits an append against
+a history the store no longer agrees with, silently. `PostgresLockCheckOrderingTest` pins this down for the
+Postgres backend, where the two are a `bigserial` and a `xid8`; see the PostgreSQL notes below.
+
 **The guarantee holds under concurrency, and every backend has to earn it.** The check in step 4 and the
 insert must be one indivisible step. If they are not, two appends racing at the same boundary each find it
 empty, both are admitted, and the invariant is gone with nothing raised — the worst kind of failure, since
@@ -525,6 +533,16 @@ can pass all of it and still violate the boundary in production.
 - Separate DataSource for monitoring queries (optional, defaults to main DataSource)
 - Tests use Testcontainers for isolated PostgreSQL instances
 - Requires the `btree_gin` extension (a standard contrib extension, available on the major managed Postgres offerings). Schema initialization runs `CREATE EXTENSION IF NOT EXISTS btree_gin` and schema validation requires `idx_events_stream_tags`, a combined stream+tags GIN index that serves DCB reads scoping by stream *and* filtering by tags in one index. The B-tree indexes are retained for ordered stream replay (GIN cannot serve `ORDER BY`)
+- **Ordering is the `(event_tx, event_position)` tuple everywhere — reads, the `until` boundary, and the
+  optimistic-locking check.** `event_position` is a `bigserial` taken at insert time and `event_tx` is
+  `pg_current_xact_id()`, assigned independently, so the two orders genuinely disagree: a transaction can
+  carry a lower position and a higher tx than one that committed before it. The read path's
+  `pg_snapshot_xmin` barrier makes that ordinary rather than exotic — it withholds an event whose
+  transaction is still in flight, so a reader takes a reference and the event surfaces afterwards, sorting
+  later on a lower position. Any predicate over the log's order goes through `addCursorBoundary` or
+  `addUntilBoundary`; comparing `event_position` alone is a different order and silently drops events.
+  Writers that do not hold the append lock (unconditional appends, `importEvents`, raw SQL) are where the
+  inversion actually comes from, which is why the advisory lock below does not subsume this
 - **Conditional appends are serialized per stream by a `pg_advisory_xact_lock`.** The optimistic-locking
   check is an `INSERT … WHERE NOT EXISTS (…)`, and under PostgreSQL's default READ COMMITTED isolation each
   statement fixes its snapshot when it starts, so two concurrent appends at the same consistency boundary

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -746,18 +746,9 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 		List<Object> parameters = new ArrayList<>();
 
-		// Add position filtering if reference is provided (exclusive - events after the reference)
-		if (after != null ) {
-			if ( direction == QueryDirection.FORWARD ) {
-				sqlBuilder.append(" AND ((event_tx>?::xid8) OR (event_tx = ?::xid8 AND event_position > ?))");
-			} else {
-				sqlBuilder.append(" AND ((event_tx<?::xid8) OR (event_tx = ?::xid8 AND event_position < ?))");
-			}
-			parameters.add(Long.toUnsignedString(after.tx()));
-			parameters.add(Long.toUnsignedString(after.tx()));
-			parameters.add(after.position());
-		}
-		
+		// Seek past the reference if one is provided (exclusive)
+		addCursorBoundary(sqlBuilder, parameters, after, direction);
+
 		addUntilBoundary(sqlBuilder, parameters, query.until());
 
 		// Add stream filtering
@@ -817,6 +808,53 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 	}
 	
+	/**
+	 * Appends the exclusive cursor of a statement being built: "strictly after the given reference"
+	 * going forward, "strictly before it" going backward.
+	 * <p>
+	 * The comparison is over the {@code (tx, position)} tuple, because that is the order events are
+	 * read in — {@code ORDER BY event_tx, event_position}, matching
+	 * {@link EventReference#happenedAfter(EventReference)}. Comparing on {@code event_position} alone
+	 * would be a different order, and the two genuinely disagree: {@code event_position} comes from a
+	 * sequence at insert time while {@code event_tx} defaults to {@code pg_current_xact_id()}, and the
+	 * two are assigned independently, so a transaction can carry a lower position and a higher tx than
+	 * one that committed before it.
+	 * <p>
+	 * That matters most for the optimistic-locking check, where the cursor is the caller's expected
+	 * last event and anything after it that matches the filter is a new relevant fact. On a
+	 * position-only comparison such an event is invisible to the check while every reader sorts it
+	 * after the reference, so the append succeeds against a history the store does not agree with —
+	 * silently, which is the worst way for a consistency boundary to fail. The read path's
+	 * {@code pg_snapshot_xmin} barrier makes that reachable rather than theoretical: it deliberately
+	 * withholds an event whose transaction is still in flight, so a reader legitimately takes a
+	 * reference with a higher position than an event that becomes visible, and sorts later, moments
+	 * afterwards.
+	 * <p>
+	 * The {@code index} part of an {@link EventReference} has no column, exactly as in
+	 * {@link #addUntilBoundary}: it distinguishes sub-events an upcaster produced from one stored
+	 * event. Two sub-events of the <em>same</em> stored event are therefore indistinguishable here —
+	 * narrow, since they come from one atomic append, and on the read path {@code EventStoreImpl}
+	 * re-applies the exact filter after upcasting.
+	 *
+	 * @param sqlBuilder the statement being built
+	 * @param parameters the parameter list being built alongside it
+	 * @param after the reference to seek past, or null for no cursor (in which case nothing is appended)
+	 * @param direction which side of the reference to keep
+	 */
+	private void addCursorBoundary(StringBuilder sqlBuilder, List<Object> parameters, EventReference after, QueryDirection direction) {
+		if ( after == null ) {
+			return;
+		}
+		if ( direction == QueryDirection.FORWARD ) {
+			sqlBuilder.append(" AND ((event_tx>?::xid8) OR (event_tx = ?::xid8 AND event_position > ?))");
+		} else {
+			sqlBuilder.append(" AND ((event_tx<?::xid8) OR (event_tx = ?::xid8 AND event_position < ?))");
+		}
+		parameters.add(Long.toUnsignedString(after.tx()));
+		parameters.add(Long.toUnsignedString(after.tx()));
+		parameters.add(after.position());
+	}
+
 	/**
 	 * Appends the {@code until} boundary of an {@link EventFilter} to a statement being built.
 	 * <p>
@@ -1065,9 +1103,11 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 				if ( appendCriteria.expectedLastEventReference() != null && appendCriteria.expectedLastEventReference().isPresent()  ) {
 
-					// Add position filtering - check for events after the expected last event
-					sqlBuilder.append(" AND event_position > ?");
-					parameters.add(appendCriteria.expectedLastEventReference().get().position());
+					// Look for events after the expected last one, over the same (tx, position) order
+					// readers see and EventReference.happenedAfter defines. See addCursorBoundary: on a
+					// position-only comparison a committed event that every reader sorts after the
+					// reference can carry a lower position, and the check would not see it.
+					addCursorBoundary(sqlBuilder, parameters, appendCriteria.expectedLastEventReference().get(), QueryDirection.FORWARD);
 				}
 
 

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresLockCheckOrderingTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresLockCheckOrderingTest.java
@@ -1,0 +1,230 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.query.Limit;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorage.EventToStore;
+import org.sliceworkz.eventstore.spi.EventStorage.QueryDirection;
+import org.sliceworkz.eventstore.spi.EventStorage.StoredEvent;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.stream.OptimisticLockingException;
+
+/**
+ * Pins down that the optimistic-locking check compares over {@code (tx, position)} — the order events
+ * are actually read in — and not over {@code event_position} alone.
+ * <p>
+ * The two orders genuinely disagree. {@code event_position} comes from a sequence at insert time,
+ * {@code event_tx} from {@code pg_current_xact_id()}, and the two are assigned independently, so a
+ * transaction can end up with a lower position and a higher tx than one that committed before it. Such
+ * an event sorts <em>after</em> the reference for every reader while carrying a lower position, so a
+ * position-only check does not see it and the append succeeds against a history the store no longer
+ * agrees with — silently, with no exception raised.
+ * <p>
+ * <b>Why this test lives here and not in the TCK.</b> Reproducing the inversion deterministically needs
+ * a position to be reserved out of band, ahead of the transaction that eventually uses it — raw SQL
+ * against the sequence, which is not something the storage SPI can express. The TCK's
+ * {@code ConcurrentOptimisticLockingTest} cannot stand in for it either: it races <em>conditional</em>
+ * appends on one stream, and those are serialized by the advisory lock, so no inversion can arise
+ * between them. The inversion needs a writer that does not take that lock — an unconditional append, an
+ * import, or a raw writer, all of which are lock-free by design.
+ * <p>
+ * Rather than race threads and hope for the interleaving, the setup reserves the low position up front
+ * and commits the inverted event at a controlled moment, so the scenario is exact and cannot flake.
+ */
+public class PostgresLockCheckOrderingTest {
+
+	abstract static class Tests {
+
+		final String image;
+
+		Tests ( String image ) {
+			this.image = image;
+		}
+
+		@Test
+		public void testLockCheckSeesEventWithLowerPositionButHigherTx ( ) throws Exception {
+			String prefix = "lockorder_";
+			DataSource dataSource = PostgresContainer.dataSource(image);
+
+			EventStorage storage = PostgresEventStorage.newBuilder()
+				.name("unit-test")
+				.prefix(prefix)
+				.dataSource(dataSource)
+				.initializeDatabase()
+				.build();
+
+			try {
+				EventStreamId stream = EventStreamId.forContext("account").withPurpose("42");
+				Tags boundaryTags = Tags.of("account", "42");
+				EventQuery boundary = EventQuery.forEvents(EventTypesFilter.any(), boundaryTags);
+
+				// 1. Reserve a position out of band. Nothing has consumed it yet, so every event the
+				//    library appends from here on carries a HIGHER position than this one.
+				long reservedPosition = reserveNextPosition(dataSource, prefix);
+
+				// 2. Append through the library: higher position, and a transaction that commits now.
+				storage.append(AppendCriteria.none(), Optional.of(stream),
+					List.of(event(stream, "MoneyDeposited", boundaryTags)));
+
+				// 3. Read the boundary the way a decider would, and take the reference it would use.
+				List<StoredEvent> seen = storage
+					.query(boundary, Optional.of(stream), null, Limit.none(), QueryDirection.FORWARD)
+					.toList();
+				assertEquals(1, seen.size(), "expected the appended event to be readable");
+				EventReference reference = seen.get(0).reference();
+				assertTrue(reference.position() > reservedPosition,
+					"the reserved position must be lower than the appended event's, or the inversion is not set up");
+
+				// 4. Now commit an event at the reserved (lower) position. Its transaction starts after
+				//    the one above committed, so it takes a HIGHER tx: position and tx now disagree.
+				insertAtPosition(dataSource, prefix, reservedPosition, stream, "MoneyWithdrawn", boundaryTags);
+
+				// 5. Every reader sorts that event AFTER the reference, despite the lower position —
+				//    the read path orders by (event_tx, event_position).
+				List<StoredEvent> replay = storage
+					.query(boundary, Optional.of(stream), null, Limit.none(), QueryDirection.FORWARD)
+					.toList();
+				assertEquals(2, replay.size(), "expected both events to be readable");
+				EventReference inverted = replay.get(1).reference();
+				assertEquals(reservedPosition, inverted.position(),
+					"the event with the LOWER position must be read last, or the inversion did not happen");
+				assertTrue(inverted.happenedAfter(reference),
+					"the inverted event must count as happening after the reference");
+
+				// 6. ...so it is a new relevant fact, and the lock check has to see it. Comparing on
+				//    event_position alone would not: reservedPosition < reference.position().
+				assertThrows(OptimisticLockingException.class,
+					() -> storage.append(AppendCriteria.of(boundary, reference), Optional.of(stream),
+						List.of(event(stream, "MoneyWithdrawn", boundaryTags))),
+					"appending against a stale reference must conflict on an event that sorts after it");
+
+				// 7. Control: the check is not simply rejecting everything. Against the reference a
+				//    reader would hold now, the very same append succeeds.
+				List<StoredEvent> appended = storage.append(AppendCriteria.of(boundary, inverted),
+					Optional.of(stream), List.of(event(stream, "MoneyWithdrawn", boundaryTags)));
+				assertEquals(1, appended.size(), "appending against the current reference must succeed");
+			} finally {
+				storage.close();
+			}
+		}
+
+		private EventToStore event ( EventStreamId stream, String type, Tags tags ) {
+			return new EventToStore(stream, new EventType(type), "{}", null, tags, null);
+		}
+
+		/**
+		 * Consumes one value from the events table's position sequence without inserting anything, so a
+		 * row can be given that position later, from a transaction that by then holds a higher tx.
+		 */
+		private long reserveNextPosition ( DataSource dataSource, String prefix ) throws SQLException {
+			try ( Connection connection = dataSource.getConnection();
+				  PreparedStatement stmt = connection.prepareStatement(
+					  "SELECT nextval(pg_get_serial_sequence(?, 'event_position'))") ) {
+				stmt.setString(1, prefix + "events");
+				try ( ResultSet rs = stmt.executeQuery() ) {
+					assertTrue(rs.next(), "expected the position sequence to yield a value");
+					return rs.getLong(1);
+				}
+			}
+		}
+
+		/**
+		 * Inserts an event at an explicitly chosen position, letting {@code event_tx} take its default,
+		 * so the row lands with that position and whatever transaction id this insert is assigned.
+		 */
+		private void insertAtPosition ( DataSource dataSource, String prefix, long position,
+				EventStreamId stream, String type, Tags tags ) throws SQLException {
+			try ( Connection connection = dataSource.getConnection();
+				  PreparedStatement insert = connection.prepareStatement(
+					  "INSERT INTO " + prefix + "events "
+					  + "(event_position, event_id, stream_context, stream_purpose, event_type, event_data, event_tags) "
+					  + "VALUES (?, ?::uuid, ?, ?, ?, ?::jsonb, ?)") ) {
+				insert.setLong(1, position);
+				insert.setString(2, UUID.randomUUID().toString());
+				insert.setString(3, stream.context());
+				insert.setString(4, stream.purpose());
+				insert.setString(5, type);
+				insert.setString(6, "{}");
+				// Encode the tags the way the library does, so the query filter matches them.
+				insert.setArray(7, connection.createArrayOf("text", tags.toStrings().toArray(new String[0])));
+				insert.executeUpdate();
+			}
+		}
+	}
+
+	@Nested
+	class OnPostgres17 extends Tests {
+
+		OnPostgres17 ( ) { super(PostgresContainer.IMAGE_PG17); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG17);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG17);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG17);
+		}
+	}
+
+	@Nested
+	class OnPostgres18 extends Tests {
+
+		OnPostgres18 ( ) { super(PostgresContainer.IMAGE_PG18); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG18);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG18);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18);
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes a critical bug in the optimistic-locking check where events with inverted `(position, tx)` ordering were invisible to the lock, allowing appends against stale references to silently succeed. The check now compares the full `(event_tx, event_position)` tuple — the order events are actually read in — rather than position alone.

## Problem

The PostgreSQL backend assigns `event_position` (a `bigserial`) and `event_tx` (from `pg_current_xact_id()`) independently at insert time. This means a transaction can carry a lower position and a higher tx than one that committed before it. The read path orders by `(event_tx, event_position)` and the `pg_snapshot_xmin` barrier withholds in-flight transactions, so a reader can take a reference and have an event surface afterwards that sorts later on a lower position.

The optimistic-locking check was comparing `event_position` alone, which is a different order. An event that every reader sorts after the reference could carry a lower position and be invisible to the check, allowing the append to succeed against a history the store no longer agrees with — silently, the worst kind of consistency failure.

## Changes

- **Extract cursor boundary logic**: Refactored the `(tx, position)` comparison into a new `addCursorBoundary()` method that handles both forward and backward queries consistently
- **Fix optimistic-locking check**: Updated the append criteria validation to use `addCursorBoundary()` instead of comparing `event_position` alone
- **Add comprehensive test**: `PostgresLockCheckOrderingTest` reproduces the inversion deterministically by reserving a position out of band, then committing an event at that position from a later transaction. It verifies the lock check sees the inverted event and rejects the stale append
- **Document the invariant**: Updated CLAUDE.md to explain why `(tx, position, index)` ordering matters everywhere — reads, `until` boundaries, and the optimistic-locking check

## Implementation Details

The `addCursorBoundary()` method encodes the comparison as:
- Forward: `(event_tx > ? OR (event_tx = ? AND event_position > ?))`
- Backward: `(event_tx < ? OR (event_tx = ? AND event_position < ?))`

This matches `EventReference.happenedAfter()` and the read path's `ORDER BY event_tx, event_position`, ensuring the lock check and readers agree on what "after the reference" means.

The test is Postgres-specific because reproducing the inversion deterministically requires raw SQL against the position sequence, which the storage SPI cannot express. It runs on both PostgreSQL 17 and 18.

https://claude.ai/code/session_015PjGcYAG1cAnYiQHg3GSut