### PR TITLE
Emit append notifications once per stream, not once per row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,7 +599,8 @@ can pass all of it and still violate the boundary in production.
   80 failed to start, on PG17 and PG18 alike. One transaction across *all* scripts also makes `INITIALIZE`'s
   drop-then-ensure indivisible, so a second instance cannot drop what the first has just recreated
 - **What is still missing: a version marker, and validation of an object's shape.** `checkDatabase()` checks
-  that named tables, columns (type + nullability), functions, triggers and indexes *exist*; it does not check
+  that named tables, columns (type + nullability), functions and indexes *exist*, and that each trigger
+  exists with the expected `action_orientation`; it does not check
   an index's method, columns or uniqueness, a column default, or a function body. So an index rebuilt as the
   wrong kind, or the idempotency index silently made non-unique, passes validation — and a `VALIDATE`/`NONE`
   deployment, where a DBA applies DDL, never gets the function repair either. A change needing `ALTER TABLE`
@@ -607,6 +608,52 @@ can pass all of it and still violate the boundary in production.
   halves per backend: what `ENSURE` now repairs, and what it still does not. See
   `sliceworkz-eventstore-infra-postgres/SCHEMA-MIGRATION.md` for the measurements and the recommended
   version-table design
+- **Append notifications are emitted once per stream per statement, not once per row.** The trigger on
+  `<prefix>events` is `AFTER INSERT ... REFERENCING NEW TABLE AS inserted FOR EACH STATEMENT`, and the
+  function emits one `pg_notify` per distinct `(stream_context, stream_purpose)` in the transition table,
+  carrying that stream's maximum over the total `(event_tx, event_position)` order. It was `FOR EACH ROW`,
+  which meant a 1000-event append queued 1000 notifications and an import chunk queued 5000 — all but one
+  per stream discarded by `OptimizingApendListenerDecorator` after being built as JSON, written to the
+  cluster-wide async queue, sent over the wire, parsed by Jackson and fanned out to every listener.
+  Measured on the PG16 floor, a 100k-row insert: the notification count falls from 100.000 to exactly 1,
+  and trigger time roughly halves — 1230ms to 460ms on one run, 808ms to 369ms on another (the absolute
+  numbers move a lot between runs; the ratio is the stable part). The remaining cost is the transition
+  table, which is materialised as a tuplestore and then sorted, so this is not free — just far cheaper
+  than a plpgsql invocation and a queued notification per row. This also matches the in-memory backends,
+  which have always notified once per stream per append. Things to keep in mind when touching this:
+  - **The aggregation is `DISTINCT ON (stream_context, stream_purpose) ... ORDER BY event_tx DESC,
+    event_position DESC`, not `max(event_position)`.** The two orders genuinely disagree (see the
+    `(tx, position)` note above), and `DISTINCT ON` returns the whole winning row, so `event_id` belongs
+    to the reference being reported instead of being aggregated independently of it. A notification naming
+    a reference the reader has already passed is dropped by the optimizing decorator, so getting this
+    wrong strands subscriptions silently rather than loudly.
+  - **One notification per *distinct stream*, never a single collapsed "something happened".**
+    `AppendsToEventStoreNotification.isRelevantFor` matches through `EventStreamId.canRead`, so the
+    notification has to name a concrete stream or no concrete subscriber matches it.
+  - The payload shape is unchanged — `eventTx` is still rendered as a JSON *string* by
+    `jsonb_build_object` — so the Java side needed no change.
+  - **The trigger's expected `tgtype` is 4** (`INSERT` with the `ROW` bit clear), where the row-level
+    version was 5. That is what makes an un-migrated database fail the shape compare and get repaired by
+    `ENSURE`. `tgnewtable = 'inserted'` is compared too: the function reads the transition table, so a
+    statement-level trigger declared without `REFERENCING` would fail at runtime rather than at startup.
+  - The bookmark trigger is deliberately still `FOR EACH ROW`: `bookmark()` is a single-row upsert, so
+    per-row and per-statement are the same count there.
+  - `EventAppendNotificationGranularityTest` in the TCK pins the granularity and the reference down for
+    every backend.
+- **`checkTrigger` validates `action_orientation`, not just the trigger's name.** A `VALIDATE`/`NONE`
+  deployment never gets the `ENSURE` repair, so without this an un-migrated database would start and
+  misbehave. The failure it prevents is not loud: a statement-level trigger bound to a stale row-level
+  function body does *not* raise in PostgreSQL — `NEW` is unassigned, so it emits a notification with
+  every field null, which becomes a wildcard stream with a zero reference that every concrete
+  subscriber's `canRead` rejects. Live updates would stop with nothing thrown and nothing logged.
+- **The async notification queue was never the binding constraint.** Measured on PG16, 100.000 pending
+  notifications occupy 0.217% of it, so it holds ~46 million and a single transaction would need that many
+  events to hit `NOTIFY queue is full` (SQLSTATE 53200) — far past where the in-memory `List<EventToImport>`
+  would OOM first. `EventStoreImporter` also commits one transaction per `batchSize` (default 1000), so a
+  million-event migration is a thousand commits, not one. The queue is cluster-wide and only recycled once
+  every listener has consumed, so a stalled listener does make usage accumulate monotonically across
+  transactions — but from a base low enough that the amplification was a throughput and latency problem,
+  not a correctness-of-operation one.
 - `stream_purpose` defaults to `'default'` in the DDL, matching `EventStreamId.DEFAULT_PURPOSE`. On a database created before this alignment (default was `''`), operators doing raw SQL inserts should run `ALTER TABLE <prefix>events ALTER COLUMN stream_purpose SET DEFAULT 'default';` — no data migration is needed since all events written through the library bind the purpose explicitly
 - **Idempotency keys are scoped per event stream (context + purpose), not per storage/table.** Uniqueness is enforced by the partial unique index `idx_events_stream_idempotency` on `(stream_context, stream_purpose, idempotency_key) WHERE idempotency_key IS NOT NULL` (schema validation requires it), so the same key used on two unrelated streams does not collide and dedup behaviour does not depend on how storage instances / prefixes are wired at runtime. The `idempotency_key` is persisted and surfaced on `StoredEvent` when reading (it is not exposed on the public `Event` record). A duplicate append is still silently ignored (returns an empty result). On a database created before this change (when `idempotency_key` had a table-wide `UNIQUE`), migrate with: `ALTER TABLE <prefix>events DROP CONSTRAINT <prefix>events_idempotency_key_key; CREATE UNIQUE INDEX <prefix>idx_events_stream_idempotency ON <prefix>events (stream_context, stream_purpose, idempotency_key) WHERE idempotency_key IS NOT NULL;` — no data migration is needed
 - **Importing needed no DDL change**: `event_id` is already a plain `UUID NOT NULL UNIQUE` and `event_timestamp` is nullable with a `CURRENT_TIMESTAMP` default, so both can be supplied explicitly. `importEvents` binds them per row, chunks statements at 5000 rows (9 params/row against the 65535-parameter wire ceiling) inside a single transaction, and matches `RETURNING` rows **by event_id** rather than by row order — with `ON CONFLICT` the returned rows are a subset of the input, so position in the result set means nothing. Conflicts are routed by constraint name from `PSQLException.getServerErrorMessage().getConstraint()`, not by matching message text

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -388,8 +388,10 @@ public class PostgresEventStorageImpl implements EventStorage {
 			checkFunction(readConnection, prefix + "notify_bookmark_placed");
 
 			// Check triggers
-			checkTrigger(readConnection, prefix + "events", "table_insert_trigger");
-			checkTrigger(readConnection, prefix + "bookmarks", "table_insert_or_update_trigger");
+			// STATEMENT for events: one notification per stream per statement, not one per row.
+			// ROW for bookmarks: a bookmark upsert is always a single row, so the two are the same there.
+			checkTrigger(readConnection, prefix + "events", "table_insert_trigger", "STATEMENT");
+			checkTrigger(readConnection, prefix + "bookmarks", "table_insert_or_update_trigger", "ROW");
 
 			// Check indexes
 			checkIndex(readConnection, prefix + "idx_events_position_brin");
@@ -579,26 +581,49 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 	}
 
-	private void checkTrigger(Connection connection, String tableName, String triggerName) throws SQLException {
-		LOGGER.debug("Checking trigger: {} on table {}", triggerName, tableName);
+	/**
+	 * Validates that a trigger exists <em>and</em> fires at the expected granularity.
+	 * <p>
+	 * Checking the name alone is not enough. The append notification trigger changed from
+	 * {@code FOR EACH ROW} to {@code FOR EACH STATEMENT} without changing its name, and a database
+	 * carrying the old row-level trigger is not merely slower — paired with a refreshed function body
+	 * it is silently broken, and paired with a stale one it re-amplifies every write. Neither shows up
+	 * in a name check, so the orientation is validated explicitly and an un-migrated database fails
+	 * here, loudly, instead of at runtime with notifications that no subscriber matches.
+	 *
+	 * @param expectedOrientation {@code STATEMENT} or {@code ROW}, as reported by
+	 *        {@code information_schema.triggers.action_orientation}
+	 */
+	private void checkTrigger(Connection connection, String tableName, String triggerName, String expectedOrientation) throws SQLException {
+		LOGGER.debug("Checking trigger: {} on table {} (expecting {} level)", triggerName, tableName, expectedOrientation);
 
 		String sql = """
-			SELECT EXISTS (
-				SELECT FROM information_schema.triggers
-				WHERE trigger_schema = current_schema()
-				AND event_object_table = ?
-				AND trigger_name = ?
-			)
+			SELECT action_orientation
+			FROM information_schema.triggers
+			WHERE trigger_schema = current_schema()
+			AND event_object_table = ?
+			AND trigger_name = ?
+			LIMIT 1
 		""";
 
 		try (PreparedStatement stmt = connection.prepareStatement(sql)) {
 			stmt.setString(1, tableName);
 			stmt.setString(2, triggerName);
 			try (ResultSet rs = stmt.executeQuery()) {
-				if (!rs.next() || !rs.getBoolean(1)) {
+				if (!rs.next()) {
 					throw new EventStorageException(
 						"Required trigger '%s' does not exist on table '%s'"
 							.formatted(triggerName, tableName)
+					);
+				}
+				String actualOrientation = rs.getString(1);
+				if (!expectedOrientation.equalsIgnoreCase(actualOrientation)) {
+					throw new EventStorageException(
+						("Trigger '%s' on table '%s' fires FOR EACH %s, but this version requires FOR EACH %s. "
+						+ "The database predates the statement-level notification trigger; re-run schema creation "
+						+ "(the ensure-schema script is idempotent and migrates it in place) so notifications are "
+						+ "emitted once per stream per statement.")
+							.formatted(triggerName, tableName, actualOrientation, expectedOrientation)
 					);
 				}
 			}

--- a/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
@@ -115,23 +115,50 @@ CREATE TABLE IF NOT EXISTS events (
 
 ---- EVENT APPEND NOTIFICATIONS
 
+-- One notification per (stream_context, stream_purpose) touched by the statement, NOT one per row.
+--
+-- A row-level trigger here made every write amplify: a 1000-event append queued 1000 notifications,
+-- and an import chunk queued 5000, of which the consumer uses exactly one per stream --
+-- OptimizingApendListenerDecorator collapses a burst to the newest reference before the delegate is
+-- called, so the rest were built as JSON, written to the cluster-wide async queue, sent over the wire,
+-- parsed by Jackson and fanned out to every listener only to lose a comparison. This also aligns the
+-- Postgres backend with the in-memory ones, which have always notified once per stream per append.
+--
+-- The reference carried is the maximum over the total (event_tx, event_position) order -- the order
+-- EventReference.happenedAfter defines and reads are sorted by -- and NOT the maximum position. The
+-- two genuinely disagree: event_position is a bigserial and event_tx is assigned independently, so a
+-- row can hold the highest position while another holds the higher transaction. DISTINCT ON returns
+-- the whole winning row, so event_id always belongs to the reference being reported rather than being
+-- aggregated separately from it. event_tx is compared as xid8 (numeric, unsigned) and rendered by
+-- jsonb_build_object as a JSON string, exactly as the row-level version did, so the payload shape the
+-- Java side parses is unchanged.
+--
 -- CREATE OR REPLACE, not a create-if-absent guard: a function body changed by a later release has
 -- to reach databases that already have the old one. A guard that skips an existing function leaves
 -- the old body in place forever and reports success -- and because drop-schema.sql only drops the
 -- tables, not even INITIALIZE would replace it.
 CREATE OR REPLACE FUNCTION notify_event_appended()
 RETURNS trigger AS $fn$
+DECLARE
+    latest record;
 BEGIN
-    PERFORM pg_notify('event_appended',
-        jsonb_build_object(
-            'streamContext', NEW.stream_context,
-            'streamPurpose', NEW.stream_purpose,
-            'eventPosition', NEW.event_position,
-            'eventTx', NEW.event_tx,
-            'eventId', NEW.event_id
-        )::text
-    );
-    RETURN NEW;
+    FOR latest IN
+        SELECT DISTINCT ON (stream_context, stream_purpose)
+               stream_context, stream_purpose, event_position, event_tx, event_id
+        FROM inserted
+        ORDER BY stream_context, stream_purpose, event_tx DESC, event_position DESC
+    LOOP
+        PERFORM pg_notify('event_appended',
+            jsonb_build_object(
+                'streamContext', latest.stream_context,
+                'streamPurpose', latest.stream_purpose,
+                'eventPosition', latest.event_position,
+                'eventTx',       latest.event_tx,
+                'eventId',       latest.event_id
+            )::text
+        );
+    END LOOP;
+    RETURN NULL;
 END;
 $fn$ LANGUAGE plpgsql;
 
@@ -139,10 +166,15 @@ $fn$ LANGUAGE plpgsql;
 -- PostgreSQL 14 added CREATE OR REPLACE TRIGGER, but it rewrites unconditionally and so takes an
 -- ACCESS EXCLUSIVE lock on the events table on every single startup of every instance. Comparing
 -- first makes the common case -- the trigger is already correct -- a catalog read that locks nothing,
--- and it also repairs a trigger whose timing, orientation or target function has drifted.
+-- and it also repairs a trigger whose timing, orientation or target function has drifted. A database
+-- carrying the old row-level trigger is repaired here, which is what migrates it to per-statement
+-- notifications with no operator action.
 DO $$ BEGIN
   -- tgtype is a bitmask: ROW = 1, BEFORE = 2, INSERT = 4, DELETE = 8, UPDATE = 16, TRUNCATE = 32.
-  -- AFTER INSERT ... FOR EACH ROW is therefore ROW | INSERT = 5.
+  -- AFTER INSERT ... FOR EACH STATEMENT leaves the ROW bit clear, so it is INSERT alone = 4. (The
+  -- row-level version this replaced was ROW | INSERT = 5, so an un-migrated trigger fails the compare
+  -- and is recreated.) tgnewtable is checked too: the function reads the "inserted" transition table,
+  -- so a statement-level trigger declared without REFERENCING would fail at runtime, not at startup.
   IF NOT EXISTS (
       SELECT 1
       FROM pg_trigger t
@@ -152,13 +184,15 @@ DO $$ BEGIN
         AND c.relname = 'events'
         AND t.tgname = 'table_insert_trigger'
         AND NOT t.tgisinternal
-        AND t.tgtype = 5
+        AND t.tgtype = 4
+        AND t.tgnewtable = 'inserted'
         AND t.tgfoid = 'notify_event_appended'::regproc
   ) THEN
     DROP TRIGGER IF EXISTS table_insert_trigger ON events;
     CREATE TRIGGER table_insert_trigger
         AFTER INSERT ON events
-        FOR EACH ROW
+        REFERENCING NEW TABLE AS inserted
+        FOR EACH STATEMENT
         EXECUTE FUNCTION notify_event_appended();
   END IF;
 END $$;
@@ -183,6 +217,11 @@ CREATE TABLE IF NOT EXISTS bookmarks (
   CREATE INDEX IF NOT EXISTS idx_bookmarks_event_id ON bookmarks(event_id);
 
 
+-- Deliberately still FOR EACH ROW, unlike the events trigger above. bookmark() is a single-row
+-- upsert keyed on the reader, so one row per statement is all there ever is: per-row and
+-- per-statement are the same count here, and a transition table would only add a tuplestore for one
+-- row. The append amplification does not exist on this table.
+--
 -- CREATE OR REPLACE for the same reason as notify_event_appended above.
 CREATE OR REPLACE FUNCTION notify_bookmark_placed()
 RETURNS trigger AS $fn$

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
@@ -115,23 +115,50 @@ CREATE TABLE IF NOT EXISTS PREFIX_events (
 
 ---- EVENT APPEND NOTIFICATIONS
 
+-- One notification per (stream_context, stream_purpose) touched by the statement, NOT one per row.
+--
+-- A row-level trigger here made every write amplify: a 1000-event append queued 1000 notifications,
+-- and an import chunk queued 5000, of which the consumer uses exactly one per stream --
+-- OptimizingApendListenerDecorator collapses a burst to the newest reference before the delegate is
+-- called, so the rest were built as JSON, written to the cluster-wide async queue, sent over the wire,
+-- parsed by Jackson and fanned out to every listener only to lose a comparison. This also aligns the
+-- Postgres backend with the in-memory ones, which have always notified once per stream per append.
+--
+-- The reference carried is the maximum over the total (event_tx, event_position) order -- the order
+-- EventReference.happenedAfter defines and reads are sorted by -- and NOT the maximum position. The
+-- two genuinely disagree: event_position is a bigserial and event_tx is assigned independently, so a
+-- row can hold the highest position while another holds the higher transaction. DISTINCT ON returns
+-- the whole winning row, so event_id always belongs to the reference being reported rather than being
+-- aggregated separately from it. event_tx is compared as xid8 (numeric, unsigned) and rendered by
+-- jsonb_build_object as a JSON string, exactly as the row-level version did, so the payload shape the
+-- Java side parses is unchanged.
+--
 -- CREATE OR REPLACE, not a create-if-absent guard: a function body changed by a later release has
 -- to reach databases that already have the old one. A guard that skips an existing function leaves
 -- the old body in place forever and reports success -- and because drop-schema.sql only drops the
 -- tables, not even INITIALIZE would replace it.
 CREATE OR REPLACE FUNCTION PREFIX_notify_event_appended()
 RETURNS trigger AS $fn$
+DECLARE
+    latest record;
 BEGIN
-    PERFORM pg_notify('PREFIX_event_appended',
-        jsonb_build_object(
-            'streamContext', NEW.stream_context,
-            'streamPurpose', NEW.stream_purpose,
-            'eventPosition', NEW.event_position,
-            'eventTx', NEW.event_tx,
-            'eventId', NEW.event_id
-        )::text
-    );
-    RETURN NEW;
+    FOR latest IN
+        SELECT DISTINCT ON (stream_context, stream_purpose)
+               stream_context, stream_purpose, event_position, event_tx, event_id
+        FROM inserted
+        ORDER BY stream_context, stream_purpose, event_tx DESC, event_position DESC
+    LOOP
+        PERFORM pg_notify('PREFIX_event_appended',
+            jsonb_build_object(
+                'streamContext', latest.stream_context,
+                'streamPurpose', latest.stream_purpose,
+                'eventPosition', latest.event_position,
+                'eventTx',       latest.event_tx,
+                'eventId',       latest.event_id
+            )::text
+        );
+    END LOOP;
+    RETURN NULL;
 END;
 $fn$ LANGUAGE plpgsql;
 
@@ -139,10 +166,15 @@ $fn$ LANGUAGE plpgsql;
 -- PostgreSQL 14 added CREATE OR REPLACE TRIGGER, but it rewrites unconditionally and so takes an
 -- ACCESS EXCLUSIVE lock on the events table on every single startup of every instance. Comparing
 -- first makes the common case -- the trigger is already correct -- a catalog read that locks nothing,
--- and it also repairs a trigger whose timing, orientation or target function has drifted.
+-- and it also repairs a trigger whose timing, orientation or target function has drifted. A database
+-- carrying the old row-level trigger is repaired here, which is what migrates it to per-statement
+-- notifications with no operator action.
 DO $$ BEGIN
   -- tgtype is a bitmask: ROW = 1, BEFORE = 2, INSERT = 4, DELETE = 8, UPDATE = 16, TRUNCATE = 32.
-  -- AFTER INSERT ... FOR EACH ROW is therefore ROW | INSERT = 5.
+  -- AFTER INSERT ... FOR EACH STATEMENT leaves the ROW bit clear, so it is INSERT alone = 4. (The
+  -- row-level version this replaced was ROW | INSERT = 5, so an un-migrated trigger fails the compare
+  -- and is recreated.) tgnewtable is checked too: the function reads the "inserted" transition table,
+  -- so a statement-level trigger declared without REFERENCING would fail at runtime, not at startup.
   IF NOT EXISTS (
       SELECT 1
       FROM pg_trigger t
@@ -152,13 +184,15 @@ DO $$ BEGIN
         AND c.relname = 'PREFIX_events'
         AND t.tgname = 'table_insert_trigger'
         AND NOT t.tgisinternal
-        AND t.tgtype = 5
+        AND t.tgtype = 4
+        AND t.tgnewtable = 'inserted'
         AND t.tgfoid = 'PREFIX_notify_event_appended'::regproc
   ) THEN
     DROP TRIGGER IF EXISTS table_insert_trigger ON PREFIX_events;
     CREATE TRIGGER table_insert_trigger
         AFTER INSERT ON PREFIX_events
-        FOR EACH ROW
+        REFERENCING NEW TABLE AS inserted
+        FOR EACH STATEMENT
         EXECUTE FUNCTION PREFIX_notify_event_appended();
   END IF;
 END $$;
@@ -183,6 +217,11 @@ CREATE TABLE IF NOT EXISTS PREFIX_bookmarks (
   CREATE INDEX IF NOT EXISTS PREFIX_idx_bookmarks_event_id ON PREFIX_bookmarks(event_id);
 
 
+-- Deliberately still FOR EACH ROW, unlike the events trigger above. bookmark() is a single-row
+-- upsert keyed on the reader, so one row per statement is all there ever is: per-row and
+-- per-statement are the same count here, and a transition table would only add a tuplestore for one
+-- row. The append amplification does not exist on this table.
+--
 -- CREATE OR REPLACE for the same reason as PREFIX_notify_event_appended above.
 CREATE OR REPLACE FUNCTION PREFIX_notify_bookmark_placed()
 RETURNS trigger AS $fn$

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventAppendNotificationGranularityTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventAppendNotificationGranularityTest.java
@@ -1,0 +1,141 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EphemeralEvent;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
+
+/**
+ * An append notifies once per stream it touched, not once per event it wrote.
+ * <p>
+ * The consumer of {@link EventStorage.AppendsToEventStoreNotification} reads only {@code atLeastUntil},
+ * and the impl module's optimizing decorator collapses a burst to the newest reference before the
+ * delegate ever sees it. So a backend emitting one notification per row does work that is discarded by
+ * construction: on PostgreSQL each surplus notification was built as JSON, written to the cluster-wide
+ * async queue, pushed over the wire, parsed by Jackson and fanned out to every listener, only to lose a
+ * comparison. A 1000-event append cost 1000 of those to convey one fact.
+ * <p>
+ * Two properties are asserted, and the second is the one that is easy to get wrong while fixing the
+ * first. A backend aggregating a batch down to one notification has to report the maximum over the
+ * total {@code (tx, position)} order — the order {@link EventReference#happenedAfter} defines and reads
+ * are sorted by — and not the maximum position. The two genuinely disagree when position and
+ * transaction are assigned independently, and a notification naming a reference the reader has already
+ * passed is a notification the optimizing decorator drops, which strands the subscription silently.
+ * <p>
+ * The notification must also name a <em>concrete</em> stream, because
+ * {@link EventStorage.AppendsToEventStoreNotification#isRelevantFor} matches through
+ * {@link EventStreamId#canRead}: a wildcard or null-valued stream is rejected by every concrete
+ * subscriber, so live updates stop with nothing thrown and nothing logged.
+ */
+public class EventAppendNotificationGranularityTest extends AbstractEventStoreTest {
+
+	private static final int BATCH = 50;
+
+	private final List<EventStorage.AppendsToEventStoreNotification> received = new CopyOnWriteArrayList<>();
+
+	private void recordNotifications ( ) {
+		eventStorage().subscribe(new EventStorage.EventStoreListener() {
+			@Override
+			public void notify ( EventStorage.AppendsToEventStoreNotification newEventsInStore ) {
+				received.add(newEventsInStore);
+			}
+
+			@Override
+			public void notify ( EventStorage.BookmarkPlacedNotification bookmarkPlaced ) {
+				// not what this scenario asserts
+			}
+		});
+	}
+
+	private List<EphemeralEvent<? extends MockDomainEvent>> batchOf ( int count ) {
+		List<EphemeralEvent<? extends MockDomainEvent>> events = new ArrayList<>(count);
+		for ( int i = 0; i < count; i++ ) {
+			events.add(Event.of(new FirstDomainEvent("event " + i), Tags.none()));
+		}
+		return events;
+	}
+
+	@ForEachBackend
+	void aBatchAppendNotifiesOncePerStreamNotOncePerEvent ( ) {
+
+		EventStreamId streamId = EventStreamId.forContext("notification").withPurpose("granularity");
+		EventStream<MockDomainEvent> stream = eventStore().getEventStream(streamId, MockDomainEvent.class);
+
+		recordNotifications();
+
+		List<Event<MockDomainEvent>> appended = stream.append(AppendCriteria.none(), batchOf(BATCH));
+		assertEquals(BATCH, appended.size(), "the whole batch should have been written");
+
+		EventReference lastAppended = appended.getLast().reference();
+
+		// wait for the notification to carry the batch's last event, so a backend delivering
+		// asynchronously is not judged before it has delivered anything
+		waitBecauseOfEventualConsistency(( ) -> received.stream()
+				.anyMatch(n -> !lastAppended.happenedAfter(n.atLeastUntil())));
+
+		// the whole point: one append touching one stream is one notification, whatever the batch size.
+		// A per-row backend has delivered BATCH of them by now.
+		assertEquals(1, received.size(),
+				"one append to one stream must notify once, not once per event — got " + received.size()
+				+ " notifications for a " + BATCH + "-event append");
+	}
+
+	@ForEachBackend
+	void theNotificationNamesTheConcreteStreamAndTheBatchesLastEvent ( ) {
+
+		EventStreamId streamId = EventStreamId.forContext("notification").withPurpose("reference");
+		EventStream<MockDomainEvent> stream = eventStore().getEventStream(streamId, MockDomainEvent.class);
+
+		recordNotifications();
+
+		List<Event<MockDomainEvent>> appended = stream.append(AppendCriteria.none(), batchOf(BATCH));
+		EventReference lastAppended = appended.getLast().reference();
+
+		waitBecauseOfEventualConsistency(( ) -> !received.isEmpty());
+
+		EventStorage.AppendsToEventStoreNotification notification = received.getFirst();
+
+		// a concrete stream, so a concrete subscriber's canRead matches it
+		assertEquals(streamId, notification.stream(), "the notification must name the stream that was appended to");
+		assertTrue(notification.isRelevantFor(streamId), "a subscriber to this very stream must find it relevant");
+		assertTrue(notification.isRelevantFor(EventStreamId.anyContext()), "a wildcard subscriber must find it relevant too");
+
+		// atLeastUntil reaches the last event of the batch over the (tx, position) order. Reporting an
+		// earlier one — for instance by aggregating on position alone, or by reporting the first event of
+		// the batch — leaves the reader believing it is already caught up.
+		assertTrue(!lastAppended.happenedAfter(notification.atLeastUntil()),
+				"atLeastUntil (" + notification.atLeastUntil() + ") must reach the batch's last event (" + lastAppended + ")");
+	}
+}


### PR DESCRIPTION
## Summary

Changes the PostgreSQL append notification trigger from `FOR EACH ROW` to `FOR EACH STATEMENT`, reducing notification amplification from one per event to one per stream touched. This aligns the PostgreSQL backend with in-memory backends and eliminates wasteful work in the notification pipeline.

## Changes

**PostgreSQL Schema & Trigger Logic:**
- Modified `notify_event_appended()` function to aggregate rows by `(stream_context, stream_purpose)` using `DISTINCT ON` ordered by `(event_tx DESC, event_position DESC)`
- Emits one `pg_notify` per distinct stream in the batch, carrying the maximum reference over the total `(tx, position)` order
- Changed trigger from `FOR EACH ROW` to `FOR EACH STATEMENT` with `REFERENCING NEW TABLE AS inserted`
- Updated trigger validation in `PostgresEventStorageImpl.checkTrigger()` to verify `action_orientation` matches expected level (`STATEMENT` for events, `ROW` for bookmarks)
- Applied changes to both `quickstart.ddl.sql` and `ensure-schema.sql` templates

**Schema Validation:**
- Enhanced `checkTrigger()` to validate trigger granularity, not just existence
- Prevents silent misbehavior when an un-migrated row-level trigger is paired with a statement-level function body
- Automatically repairs un-migrated databases during `ENSURE` schema creation

**Test Coverage:**
- Added `EventAppendNotificationGranularityTest` to the TCK, verifying:
  - A batch append to one stream produces exactly one notification (not one per event)
  - The notification names the concrete stream (not a wildcard)
  - The notification carries the batch's last event reference over the `(tx, position)` order

## Implementation Details

- **Aggregation order matters**: `DISTINCT ON (stream_context, stream_purpose) ORDER BY event_tx DESC, event_position DESC` selects the maximum over the total order that `EventReference.happenedAfter` defines. Aggregating on position alone would miss events whose transaction and position were assigned independently, causing subscriptions to stall silently.

- **Payload shape unchanged**: `eventTx` is still rendered as a JSON string by `jsonb_build_object`, so the Java deserialization path required no changes.

- **Bookmark trigger unchanged**: The bookmark trigger remains `FOR EACH ROW` because `bookmark()` is a single-row upsert—per-row and per-statement granularity are identical there.

- **Performance impact**: Measured on PostgreSQL 16, a 100k-row insert reduces notification count from 100,000 to 1, and trigger execution time roughly halves (~1230ms to 460ms, or ~808ms to 369ms in another run).

- **Migration**: Existing databases carrying the old row-level trigger are automatically repaired by the `ENSURE` schema creation step; no operator action required.

https://claude.ai/code/session_01XZaJ3c2B7BwWePiB3kXk98