### PR TITLE
Clarify that query limits count stored events, not returned ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,20 @@ mvn clean install -DskipTests
 - Can match all (`EventQuery.matchAll()`), none (`EventQuery.matchNone()`), or specific criteria
 - Supports backward direction (`.backwards()`) and result limits (`.limit(n)`)
 - Created via `EventQuery.forEvents(eventTypesFilter, tags)`
+- **`.limit(n)` means "read n stored events", and it is pushed into the storage query** — a SQL
+  `LIMIT` on Postgres, a short-circuiting `Stream.limit` in memory — not applied to the result. That
+  is what makes it bound memory as well as output: a storage query materialises its whole result set
+  before returning it, so an unbounded query over a large stream is a heap problem rather than a slow
+  one. A cursor does not change this: `query(q.limit(500), cursor)` reads 500, same as `query(q)`
+  would with the limit on `q`. Pass `Limit.none()` to the three-argument overload to read to the end
+  of a stream deliberately
+- **Without upcasting, n stored events are n events back. With it, they are not.** An `@Upcast`
+  method may turn one stored event into several or into none, and the limit is spent before it runs,
+  so `.limit(1)` over an event upcasting into two returns two, and over one upcasting into none
+  returns zero — having read exactly one stored event either way. Trimming the surplus would return a
+  fragment of a stored event and leave a cursor pointing into its middle; `Projector` counts stored
+  events for exactly this reason. Where a caller needs exactly n, `.limit(n)` the returned `Stream` —
+  cheap, since those events are already read. `UpcastMultiTest` pins this per backend
 
 **AppendCriteria:**
 - Controls optimistic locking when appending events

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventQuery.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/EventQuery.java
@@ -211,8 +211,11 @@ public record EventQuery ( EventFilter filter, Direction direction, Limit limit 
 
 	/**
 	 * Returns a new EventQuery with the specified limit.
+	 * <p>
+	 * The limit is how many <em>stored</em> events to read; see {@link Limit} for what that means when
+	 * upcasting is in play.
 	 *
-	 * @param limit the maximum number of events to return
+	 * @param limit how many stored events to read
 	 * @return a new EventQuery with the specified limit
 	 */
 	public EventQuery limit ( Limit limit ) {
@@ -221,8 +224,11 @@ public record EventQuery ( EventFilter filter, Direction direction, Limit limit 
 
 	/**
 	 * Returns a new EventQuery with the specified limit.
+	 * <p>
+	 * The limit is how many <em>stored</em> events to read; see {@link Limit} for what that means when
+	 * upcasting is in play.
 	 *
-	 * @param n the maximum number of events to return (must be positive)
+	 * @param n how many stored events to read (must be positive)
 	 * @return a new EventQuery with the specified limit
 	 */
 	public EventQuery limit ( long n ) {

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/Limit.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/query/Limit.java
@@ -20,22 +20,39 @@ package org.sliceworkz.eventstore.query;
 import org.sliceworkz.eventstore.events.Event;
 
 /**
- * Represents the maximum number of {@link Event}s to query from the store.
+ * Represents how many {@link Event}s to read from the store in one query.
  *
- * <p>Limit allows you to restrict the number of events returned from a query.
- * A limit of null means no limit is applied (all matching events are returned).
- * A positive limit value restricts the result set to that many events.
+ * <p>Limit allows you to restrict the number of events read by a query.
+ * A limit of null means no limit is applied (all matching events are read).
+ * A positive limit value restricts the query to that many events.
+ *
+ * <p>The limit is pushed into the storage query itself — a SQL {@code LIMIT} on the PostgreSQL
+ * backend — rather than applied to its result, so it bounds the work done and the memory used, not
+ * just what you end up looking at. That is the point of setting one: a storage query materialises
+ * its whole result set before returning it, so an unlimited query over a large stream is a heap
+ * problem, not a slow one.
+ *
+ * <p><strong>A limit counts stored events.</strong> Normally that is also the number of events you
+ * get back, because a stored event yields exactly one. Upcasting is where the two part company: an
+ * {@link org.sliceworkz.eventstore.events.Upcast @Upcast} method may turn one stored event into
+ * several, or into none, and the limit is spent before any of that happens. So
+ * {@code EventQuery.matchAll().limit(1)} over a stored event that upcasts into two returns two
+ * events, and over one that upcasts into none returns zero — while having read exactly one stored
+ * event either way, which is what was asked for. Trimming the surplus would hand back a fragment of
+ * a stored event and leave a cursor pointing into its middle, so the count read is what the limit
+ * governs. Where the distinction matters, apply your own {@code .limit(n)} to the returned
+ * {@link java.util.stream.Stream}: cheap, since it operates on events already read.
  *
  * <p><strong>Usage Examples:</strong>
  * <pre>{@code
- * // No limit - return all matching events
+ * // No limit - read all matching events
  * Limit noLimit = Limit.none();
  *
- * // Return at most 100 events
- * Limit maxHundred = Limit.to(100);
+ * // Read 100 stored events
+ * Limit hundred = Limit.to(100);
  *
- * // Return at most 10 events (using int)
- * Limit maxTen = Limit.to(10);
+ * // Read 10 stored events (using int)
+ * Limit ten = Limit.to(10);
  *
  * // Check if a limit is set
  * if (limit.isSet()) {
@@ -43,7 +60,7 @@ import org.sliceworkz.eventstore.events.Event;
  * }
  * }</pre>
  *
- * @param value the maximum number of events to return (null for no limit, must be positive if set)
+ * @param value how many stored events to read (null for no limit, must be positive if set)
  *
  * @see EventQuery
  */
@@ -129,7 +146,7 @@ public record Limit ( Long value ) {
 	}
 
 	/**
-	 * Creates a Limit with no restriction (returns all matching events).
+	 * Creates a Limit with no restriction (reads all matching events).
 	 *
 	 * @return a Limit representing no limit
 	 */
@@ -138,9 +155,9 @@ public record Limit ( Long value ) {
 	}
 
 	/**
-	 * Creates a Limit with the specified maximum number of events.
+	 * Creates a Limit reading the specified number of stored events.
 	 *
-	 * @param value the maximum number of events to return (must be positive)
+	 * @param value how many stored events to read (must be positive)
 	 * @return a Limit with the specified value
 	 * @throws IllegalArgumentException if value is less than or equal to 0
 	 */
@@ -149,10 +166,10 @@ public record Limit ( Long value ) {
 	}
 
 	/**
-	 * Creates a Limit with the specified maximum number of events.
+	 * Creates a Limit reading the specified number of stored events.
 	 * Convenience method that accepts an int parameter.
 	 *
-	 * @param value the maximum number of events to return (must be positive)
+	 * @param value how many stored events to read (must be positive)
 	 * @return a Limit with the specified value
 	 * @throws IllegalArgumentException if value is less than or equal to 0
 	 */

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -172,7 +172,7 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 *
 	 * @param query the query criteria specifying which events to retrieve and in which direction
 	 * @param cursor optional reference for pagination (after for forward, before for backward), null to start from the beginning/end
-	 * @param limit maximum number of events to return (overrides the query's own limit)
+	 * @param limit how many stored events to read (overrides the query's own limit); see {@link #query(EventQuery)} for why that is not always the number of events returned
 	 * @param storedEventCursorTracker callback invoked with each raw stored event's reference before upcasting, useful for advancing cursors past events that upcast to zero enriched events
 	 * @return a Stream of events matching the query criteria
 	 * @see EventQuery
@@ -188,7 +188,7 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 *
 	 * @param query the query criteria specifying which events to retrieve and in which direction
 	 * @param cursor optional reference for pagination (after for forward, before for backward), null to start from the beginning/end
-	 * @param limit maximum number of events to return (overrides the query's own limit)
+	 * @param limit how many stored events to read (overrides the query's own limit); see {@link #query(EventQuery)} for why that is not always the number of events returned
 	 * @return a Stream of events matching the query criteria
 	 * @see EventQuery
 	 * @see Limit
@@ -227,7 +227,16 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 * <p>
 	 * If the query has a backward direction (via {@link EventQuery#backwards()}), events are returned
 	 * in reverse chronological order. If the query has a limit (via {@link EventQuery#limit(long)}),
-	 * at most that many events are returned. Otherwise, returns all events in forward order.
+	 * that many events are read from storage. Otherwise, returns all events in forward order.
+	 * <p>
+	 * <b>A limit counts stored events, which is what upcasting makes visible.</b> It is what the
+	 * storage query is given, so it bounds the work and the memory — that is its job. Ordinarily it is
+	 * also the number of events you get back, because a stored event yields exactly one. Where an
+	 * {@link org.sliceworkz.eventstore.events.Upcast @Upcast} method turns one stored event into
+	 * several, or into none, the count returned is not the count read: {@code limit(1)} over a stored
+	 * event that upcasts into two returns both — truncating them would hand back half of one stored
+	 * event and leave a cursor pointing into its middle. Read it as "read n stored events", not as
+	 * "return at most n events".
 	 *
 	 * @param query the query criteria specifying which events to retrieve
 	 * @return a Stream of events matching the query criteria

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -198,17 +198,28 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	}
 
 	/**
-	 * Queries events from the stream starting from a specific cursor reference.
+	 * Queries events from the stream starting from a specific cursor reference, respecting the query's
+	 * own direction and limit.
 	 * <p>
-	 * Convenience method for paginated queries without an explicit limit.
-	 * The direction is determined by the query ({@link EventQuery#backwards()}).
+	 * Convenience method for paginated queries. The direction comes from the query
+	 * ({@link EventQuery#backwards()}) and so does the limit ({@link EventQuery#limit(long)}), exactly
+	 * as for {@link #query(EventQuery)} — a cursor says where to start reading, not how much to read.
+	 * To override the query's own limit, pass one explicitly through
+	 * {@link #query(EventQuery, EventReference, Limit)}, or {@link Limit#none()} there to read to the
+	 * end of the stream.
+	 * <p>
+	 * This overload used to substitute {@link Limit#none()} for the query's limit, which made the
+	 * natural way to page — {@code query(q.limit(500), cursor)} — an unbounded read of everything past
+	 * the cursor: fetched from storage and held in heap, since a storage query materialises its whole
+	 * result set before returning it. It degraded silently, the caller still receiving its first 500
+	 * events, having paid for all of them.
 	 *
-	 * @param query the query criteria specifying which events to retrieve and in which direction
+	 * @param query the query criteria specifying which events to retrieve, in which direction, and how many
 	 * @param cursor optional reference for pagination, null to start from the beginning/end
 	 * @return a Stream of events matching the query criteria
 	 */
 	default Stream<Event<DOMAIN_EVENT_TYPE>> query ( EventQuery query, EventReference cursor ) {
-		return query(query, cursor, Limit.none());
+		return query(query, cursor, query.limit());
 	}
 
 	/**

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -423,10 +423,25 @@ public class EventStoreImpl implements EventStore {
 			meterQuery.increment(); // one query done
 			QueryDirection direction = query.isBackwards() ? QueryDirection.BACKWARD : QueryDirection.FORWARD;
 			EventFilter originalFilter = query.filter();
-			return timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query),Optional.of(eventStreamId), cursor, limit, direction)
+
+			// Time the storage fetch itself, and nothing else. The pipeline built on top of it -- peek,
+			// upcasting, filtering -- is lazy, so wrapping the whole expression in timerQuery.record(...)
+			// would time the construction of that pipeline rather than any work: microseconds, whatever
+			// the query costs. It happens to report the fetch today only because every backend
+			// materialises its whole result set before returning (EventStorage.query is eager by
+			// contract), which puts the fetch inside the supplier by accident rather than by design.
+			// Measuring the storage call explicitly says what the metric means and keeps it saying it if
+			// a backend ever streams its result set instead.
+			// Deserialisation and upcasting are deliberately outside this timer: they happen per element
+			// as the caller consumes, are counted separately by sliceworkz.eventstore.query.event, and
+			// are the caller's pace, not the store's.
+			Stream<StoredEvent> storedEvents =
+				timerQuery.record(()->eventStorage.query(includeLegacyEventTypes(query), Optional.of(eventStreamId), cursor, limit, direction));
+
+			return storedEvents
 				.peek(se -> storedEventCursorTracker.accept(se.reference()))
 				.flatMap(se->enrichAfterQuery(se, direction))
-				.filter(e->originalFilter.matches(e)));
+				.filter(e->originalFilter.matches(e));
 		}
 
 		private Stream<Event<EVENT_TYPE>> enrichAfterQuery ( StoredEvent storedEvent, QueryDirection direction ) {

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStoreLimitTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/EventStoreLimitTest.java
@@ -24,9 +24,11 @@ import java.util.Collections;
 import org.sliceworkz.eventstore.events.EphemeralEvent;
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.Tag;
+import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.query.Limit;
 import org.sliceworkz.eventstore.spi.EventStorageException;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStream;
@@ -76,6 +78,46 @@ public class EventStoreLimitTest extends AbstractEventStoreTest {
 		// these should all be ok
 		eventStore().getEventStream(stream).query(EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.of("mod2", "1")));
 		eventStore().getEventStream(stream).query(EventQuery.forEvents(EventTypesFilter.any(), Tags.of("mod2", "2")));
+	}
+
+	/**
+	 * A limit the caller asked for has to reach the storage query, not be applied to its result.
+	 * <p>
+	 * The configured hard limit is what makes this observable without reaching past the SPI. The store
+	 * below holds eight events and refuses to return more than two, so a query carrying
+	 * {@code limit(2)} can only succeed if those two are the only two ever fetched. A backend
+	 * satisfying the limit by reading everything and trimming afterwards trips its own guard, and one
+	 * that quietly drops the limit somewhere between the caller and the storage does too — which is
+	 * the failure this pins, since it is otherwise invisible: the caller still receives the two events
+	 * it asked for, having paid to fetch and materialise every event in the store.
+	 * <p>
+	 * Every overload is exercised, because they do not all carry the limit the same way: one takes it
+	 * from the query, one takes it as an argument, and the cursor overload used to substitute
+	 * {@link Limit#none()} for it — turning the natural way to page through a stream into a full read
+	 * of everything past the cursor.
+	 */
+	@ForEachBackend(requires = Capability.RESULT_LIMIT)
+	void testAnAskedForLimitReachesTheStorageQueryOnEveryOverload ( ) {
+		for ( int i = 0 ; i < 8 ; i++ ) {
+			storeEvent(stream, new MockDomainEvent.FirstDomainEvent("event-" + i), Tags.none());
+		}
+
+		EventStream<MockDomainEvent> eventStream = eventStore().getEventStream(stream, MockDomainEvent.class);
+
+		EventReference cursor = eventStream.query(EventQuery.matchAll().limit(1))
+				.findFirst().orElseThrow().reference();
+
+		assertEquals(2, eventStream.query(EventQuery.matchAll().limit(2)).count(),
+				"limit carried by the query itself");
+
+		assertEquals(2, eventStream.query(EventQuery.matchAll().limit(2), cursor).count(),
+				"limit carried by the query, with a cursor -- the paging idiom");
+
+		assertEquals(2, eventStream.query(EventQuery.matchAll(), cursor, Limit.to(2)).count(),
+				"limit passed explicitly, overriding the query's own");
+
+		assertEquals(2, eventStream.query(EventQuery.matchAll().limit(5), cursor, Limit.to(2)).count(),
+				"explicit limit wins over the query's own");
 	}
 
 }

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/UpcastMultiTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/UpcastMultiTest.java
@@ -106,6 +106,44 @@ public class UpcastMultiTest extends AbstractEventStoreTest {
 		assertEquals(CurrentEvent.CustomerChurned.class, events.get(3).data().getClass());
 	}
 
+	/**
+	 * A limit counts stored events, and upcasting is what makes that observable.
+	 * <p>
+	 * The limit is what the storage query is given — a SQL {@code LIMIT} on a SQL backend — so it is
+	 * spent before an upcaster has run. Position 1 upcasts into two events and position 2 into none,
+	 * so reading one stored event returns two events, and reading two returns two as well. Neither
+	 * equals the limit, and both are correct: trimming the first case would return a fragment of a
+	 * stored event and leave a cursor pointing into its middle, and padding the second would mean
+	 * reading past what the caller asked for.
+	 * <p>
+	 * Pinned rather than merely documented because it is the kind of behaviour a future "fix" looks
+	 * reasonable: re-applying the limit to the enriched events would satisfy the phrase "at most n
+	 * events" and break {@code Projector}'s cursor, which counts stored events to decide when a batch
+	 * has exhausted the stream.
+	 */
+	@ForEachBackend
+	void testLimitCountsStoredEventsNotUpcastedOnes() {
+		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();
+
+		// one stored event read (position 1), which upcasts into CustomerRegistered + AddressRecorded
+		List<Event<CurrentEvent>> fromOne = stream.query(EventQuery.matchAll().limit(1)).toList();
+		assertEquals(2, fromOne.size(), "a stored event upcasting into two returns both");
+		assertEquals(CurrentEvent.CustomerRegistered.class, fromOne.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, fromOne.get(1).data().getClass());
+
+		// two stored events read (positions 1 and 2); position 2 upcasts into nothing
+		List<Event<CurrentEvent>> fromTwo = stream.query(EventQuery.matchAll().limit(2)).toList();
+		assertEquals(2, fromTwo.size(), "a stored event upcasting into nothing contributes nothing");
+		assertEquals(CurrentEvent.CustomerRegistered.class, fromTwo.get(0).data().getClass());
+		assertEquals(CurrentEvent.AddressRecorded.class, fromTwo.get(1).data().getClass());
+
+		// three stored events read: position 3 upcasts one-to-one and takes the count to three
+		assertEquals(3, stream.query(EventQuery.matchAll().limit(3)).count());
+
+		// a caller who needs exactly n events limits the returned stream, on events already read
+		assertEquals(1, stream.query(EventQuery.matchAll().limit(1)).limit(1).count());
+	}
+
 	@ForEachBackend
 	void testForwardQueryFilteredEventTypesIncludeUpcasted() {
 		EventStream<CurrentEvent> stream = storeOriginalAndGetUpcastedStream();

--- a/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/QueryTimerTest.java
+++ b/sliceworkz-eventstore-tests/src/test/java/org/sliceworkz/eventstore/QueryTimerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Pins what {@code sliceworkz.eventstore.query.duration} measures: the storage fetch, recorded when
+ * the query is issued.
+ * <p>
+ * The timer used to wrap the whole expression that builds the event stream — the storage call plus
+ * the lazy {@code peek}/{@code flatMap}/{@code filter} chain hung off it. Everything after the
+ * storage call is lazy, so that timed the construction of a pipeline rather than any work, and it
+ * reported the fetch only because {@link EventStorage#query} materialises its whole result set
+ * before returning. Should a backend ever stream its result set instead, the metric would silently
+ * fall to zero for every user of the library, with nothing failing to say so.
+ * <p>
+ * This test fails on that arrangement: it asks a storage whose {@code query} is slow, and never
+ * consumes the returned stream, so a timer covering anything other than the storage call records
+ * nothing.
+ */
+class QueryTimerTest {
+
+	private static final long STORAGE_QUERY_DELAY_MS = 250;
+
+	sealed interface TestEvent {
+		record Ping ( String id ) implements TestEvent { }
+	}
+
+	@Test
+	void queryTimerMeasuresTheStorageFetchAndNotThePipelineConstruction ( ) {
+
+		SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+		try ( EventStorage storage = slowQuerying(InMemoryEventStorage.newBuilder().build()) ) {
+
+			EventStore eventStore = EventStoreFactory.get().eventStore(storage, meterRegistry);
+			EventStream<TestEvent> stream =
+					eventStore.getEventStream(EventStreamId.forContext("timer"), TestEvent.class);
+
+			stream.append(AppendCriteria.none(), Event.of(new TestEvent.Ping("1"), Tags.none()));
+
+			// deliberately NOT consumed: the timer must have recorded the fetch already
+			Stream<Event<TestEvent>> unconsumed = stream.query(EventQuery.matchAll());
+
+			Timer timer = meterRegistry.find("sliceworkz.eventstore.query.duration").timer();
+			assertTrue(timer != null, "no sliceworkz.eventstore.query.duration timer was registered");
+			assertTrue(timer.count() == 1, "expected exactly one recorded query, got " + timer.count());
+			assertTrue(timer.totalTime(TimeUnit.MILLISECONDS) >= STORAGE_QUERY_DELAY_MS,
+					"query.duration recorded %.1f ms for a storage query that took at least %d ms — the timer is measuring the construction of the lazy pipeline, not the fetch"
+						.formatted(timer.totalTime(TimeUnit.MILLISECONDS), STORAGE_QUERY_DELAY_MS));
+
+			unconsumed.close();
+		}
+	}
+
+	/**
+	 * Wraps a storage so that {@code query} takes a measurable amount of time, leaving every other
+	 * operation untouched. A proxy rather than a hand-written delegate, so that adding a method to the
+	 * SPI does not break this test.
+	 */
+	private static EventStorage slowQuerying ( EventStorage delegate ) {
+		InvocationHandler handler = (proxy, method, args) -> {
+			if ( "query".equals(method.getName()) ) {
+				Thread.sleep(STORAGE_QUERY_DELAY_MS);
+			}
+			try {
+				return method.invoke(delegate, args);
+			} catch ( InvocationTargetException e ) {
+				throw e.getCause();
+			}
+		};
+		return (EventStorage) Proxy.newProxyInstance(
+				EventStorage.class.getClassLoader(), new Class<?>[] { EventStorage.class }, handler);
+	}
+}


### PR DESCRIPTION
## Summary

This PR clarifies the semantics of query limits throughout the codebase and fixes a critical bug where limits were not being passed through to storage queries when using the cursor-based pagination overload.

## Key Changes

- **Fixed cursor pagination bug**: The `query(EventQuery, EventReference)` overload was substituting `Limit.none()` for the query's limit, causing unbounded reads of everything past the cursor. Now it correctly passes the query's own limit through to storage.

- **Clarified limit semantics in documentation**: Updated all javadocs for `Limit`, `EventQuery`, and `EventSource` to explicitly state that limits count *stored events*, not returned events. This distinction matters when upcasting is involved: a stored event may upcast into multiple events or none, so the limit is spent before upcasting runs.

- **Added comprehensive tests**:
  - `QueryTimerTest`: Pins that the query duration timer measures the storage fetch itself, not the lazy pipeline construction, by verifying the timer records time even when the returned stream is never consumed.
  - `EventStoreLimitTest.testAnAskedForLimitReachesTheStorageQueryOnEveryOverload()`: Verifies that limits reach the storage query on all three overloads, using a hard limit guard to detect if limits are applied post-fetch instead of pre-fetch.
  - `UpcastMultiTest.testLimitCountsStoredEventsNotUpcastedOnes()`: Demonstrates and pins the behavior that limits count stored events: reading 1 stored event that upcasts into 2 returns 2 events, and reading 2 where the second upcasts into nothing returns 2 events total.

- **Updated implementation**: Modified `EventStoreImpl.query()` to explicitly time only the storage fetch, not the lazy pipeline, making the metric's meaning clear and resilient to future backends that stream results instead of materializing them.

- **Updated documentation**: Enhanced CLAUDE.md with detailed explanation of limit semantics and the interaction with upcasting.

## Notable Implementation Details

- The timer wrapping the storage query was moved outside the lazy pipeline to measure only the actual fetch, not the construction of peek/flatMap/filter chains that run lazily as the caller consumes.
- The cursor overload now correctly passes `query.limit()` instead of `Limit.none()`, fixing the silent degradation where `query(q.limit(500), cursor)` would read everything past the cursor instead of just 500 events.
- All documentation now consistently uses "read n stored events" language to distinguish from "return n events", making the upcasting interaction explicit.

https://claude.ai/code/session_01FWyhoBE924H2NMFVgNzcNV