### PR TITLE
Document that query() returns in-memory streams, not lazy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,19 @@ mvn clean install -DskipTests
 - Supports both reading (via `query()`) and writing (via `append()`)
 - Type-safe through generic parameter `<DOMAIN_EVENT_TYPE>`
 - Combines `EventSource` (reading) and `EventSink` (writing) interfaces
+- **`query()` returns a `Stream`, but it is already in memory.** Storage has finished reading by the
+  time the stream comes back — the whole result set is fetched and the stream iterates a list. So
+  `findFirst()`, `.limit(10)` and `takeWhile` on the returned stream discard work already done, and a
+  query with no limit against a storage with no `resultLimit` reads everything matching into heap: an
+  OOM rather than a slow stream, with no back-pressure to arrive at. Bound the read with
+  `EventQuery.limit(n)`, which is the limit storage is given. Nothing needs closing — no database
+  resource is held open behind the stream, so it is safe to abandon half-consumed (`EventSource.close()`
+  is about subscriptions, not queries)
+- **A full replay is a loop, not one unbounded query.** `Projector` already reads in batches of 500,
+  carrying a cursor between them, and is the right tool for a stream of unknown size. By hand, page with
+  `query(q.limit(n), cursor)`, advancing `cursor` to the last reference of each page. The unlimited path
+  exists for callers who know their result set is small, or who genuinely want it all at once — it is
+  not a way to process a large stream incrementally
 
 **Event:**
 - Record type containing: `stream`, `type`, `reference`, `data`, `tags`, `timestamp`

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -228,13 +228,32 @@ public interface EventStorage extends AutoCloseable {
 	 * past it — because the exact filter is re-applied above this SPI after upcasting. It must never
 	 * exclude an event the filter would keep. Note that a limit is applied <em>after</em> the boundary:
 	 * spending it on events beyond the boundary that are discarded later returns too few events, or none.
+	 * <p>
+	 * The Returned Stream:
+	 * <p>
+	 * The return type is a {@link Stream}, but laziness is not part of this contract, and callers do not
+	 * get to assume it. Every in-tree backend reads its whole result set before returning and hands back
+	 * a stream over a list; {@link org.sliceworkz.eventstore.stream.EventSource} documents that to
+	 * callers as the behaviour to expect. So {@code limit} is what bounds the work and the memory of a
+	 * query — a caller that passes {@link Limit#none()} is asking to have everything matching read into
+	 * heap, and gets it.
+	 * <p>
+	 * An implementation <em>may</em> stream its result set lazily, but then it owns two obligations this
+	 * SPI does not otherwise impose. First, nothing above it closes the returned stream — neither
+	 * {@code EventSource} nor {@link org.sliceworkz.eventstore.projection.Projector} does, and user code
+	 * receives a bare {@code Stream} it has never been told to close — so any resource held open behind
+	 * it (a connection, a cursor) leaks on every query, including one abandoned half-consumed. Second, a
+	 * cursor held open for the caller's whole traversal is a long-running transaction, which on
+	 * PostgreSQL holds down {@code pg_snapshot_xmin} and thereby stalls what every reader of that
+	 * database can see. Neither is a reason not to do it; both have to be solved deliberately rather
+	 * than discovered.
 	 *
 	 * @param query the event query defining type and tag filters
 	 * @param stream optional stream identifier to filter events by stream
 	 * @param after the reference point to start querying after (exclusive - events after this reference)
-	 * @param limit maximum number of events to return
+	 * @param limit maximum number of events to read; {@link Limit#none()} reads everything matching
 	 * @param queryDirection the direction of query traversal (FORWARD or BACKWARD)
-	 * @return a stream of stored events matching the query criteria
+	 * @return a stream of stored events matching the query criteria, which callers must not assume is lazy
 	 * @throws EventStorageException if an error occurs during query execution
 	 * @see EventQuery
 	 * @see QueryDirection

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -56,6 +56,34 @@ import org.sliceworkz.eventstore.query.Limit;
  *   <li><strong>Pagination</strong>: Use cursor references and limits for efficient navigation</li>
  * </ul>
  *
+ * <h2>A Returned Stream Is Already In Memory:</h2>
+ * Every {@code query} method here returns a {@link Stream}, but none of them is lazy in the sense the
+ * type suggests. The storage below has finished reading by the time the stream is handed back: its
+ * whole result set has been fetched and is being iterated from a list. Every storage backend shipped
+ * with this library works that way, and no caller may assume otherwise.
+ * <p>
+ * What follows from that:
+ * <ul>
+ *   <li><b>Short-circuiting terminal operations do not save any work.</b>
+ *       {@code query(q).findFirst()}, {@code .limit(10)} and {@code .takeWhile(…)} discard events that
+ *       have already been read, deserialized and upcasted. Bound the read with
+ *       {@link EventQuery#limit(long)} instead — that is the limit storage is given.</li>
+ *   <li><b>An unbounded query holds its whole result in heap.</b> A query with no limit, run against a
+ *       storage with no absolute result limit configured, reads every matching event before returning.
+ *       On a large stream that is an {@link OutOfMemoryError}, not a slow stream — there is no
+ *       back-pressure to arrive at.</li>
+ *   <li><b>Nothing needs closing.</b> No database resource is held open behind the returned stream, so
+ *       it can be abandoned half-consumed without leaking anything. (Closing an {@code EventSource} is
+ *       a separate matter, and concerns subscriptions only — see {@link #close()}.)</li>
+ * </ul>
+ * <p>
+ * So a full replay is a loop, not a single unbounded query. {@link org.sliceworkz.eventstore.projection.Projector}
+ * already does this — it reads in batches of
+ * {@value org.sliceworkz.eventstore.projection.Projector.Builder#DEFAULT_MAX_EVENTS_PER_QUERY} and
+ * carries a cursor between them — and is the right tool for replaying a stream of unknown size. To do
+ * it by hand, page with {@link #query(EventQuery, EventReference)} and a limited query, advancing the
+ * cursor to the last reference of each page.
+ *
  * <h2>Example Usage:</h2>
  * <pre>{@code
  * EventStream<CustomerEvent> stream = eventStore.getEventStream(
@@ -237,9 +265,16 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 * event that upcasts into two returns both — truncating them would hand back half of one stored
 	 * event and leave a cursor pointing into its middle. Read it as "read n stored events", not as
 	 * "return at most n events".
+	 * <p>
+	 * <b>A query with no limit reads everything before it returns.</b> The stream handed back is already
+	 * in memory (see the class javadoc), so {@code query(EventQuery.matchAll())} on a large stream is an
+	 * {@link OutOfMemoryError} rather than something that can be consumed a piece at a time, and
+	 * {@code query(q).findFirst()} pays for the whole result set. Give the query a limit and page with
+	 * {@link #query(EventQuery, EventReference)}, or use
+	 * {@link org.sliceworkz.eventstore.projection.Projector}, which does that for you.
 	 *
 	 * @param query the query criteria specifying which events to retrieve
-	 * @return a Stream of events matching the query criteria
+	 * @return a Stream of events matching the query criteria, fully realised before it is returned
 	 */
 	default Stream<Event<DOMAIN_EVENT_TYPE>> query ( EventQuery query ) {
 		return query(query, null, query.limit());

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorage.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorage.java
@@ -166,6 +166,14 @@ public interface InMemoryEventStorage {
 		 * <p>
 		 * The absolute limit acts as a hard ceiling - even if a query specifies a higher limit via
 		 * {@link Limit}, the absolute limit will take precedence.
+		 * <p>
+		 * <b>Leaving it unset means queries are unbounded, not streamed.</b> A query is read in full
+		 * before its {@link java.util.stream.Stream} is returned (see
+		 * {@link org.sliceworkz.eventstore.stream.EventSource}), so a query that carries no limit of its
+		 * own against a storage with no absolute limit reads every matching event into heap. Not setting
+		 * this is the right choice when callers bound their own queries — as
+		 * {@link org.sliceworkz.eventstore.projection.Projector} does — and a way to run out of memory
+		 * when they do not.
 		 *
 		 * @param absoluteLimit the maximum number of events any query can return (must be positive)
 		 * @return this Builder instance for method chaining

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
@@ -322,6 +322,17 @@ public interface PostgresEventStorage {
 		 * The limit applies to all queries executed through this storage instance, including
 		 * event stream queries and projections. Individual queries can specify lower limits,
 		 * but cannot exceed this absolute limit.
+		 * <p>
+		 * When it is set, a query that carries no limit of its own is given {@code absoluteLimit + 1} as
+		 * its {@code LIMIT}, so the read stays bounded and the extra row is what reveals the violation.
+		 * <p>
+		 * <b>Leaving it unset means queries are unbounded, not streamed.</b> A query is read in full
+		 * before its {@link java.util.stream.Stream} is returned (see
+		 * {@link org.sliceworkz.eventstore.stream.EventSource}), so a query with no limit of its own,
+		 * against a storage with no absolute limit, issues a {@code SELECT} with no {@code LIMIT} and
+		 * materialises every matching row in heap. Not setting this is the right choice when callers
+		 * bound their own queries — as {@link org.sliceworkz.eventstore.projection.Projector} does, and
+		 * as a paging loop does — and a way to run out of memory when they do not.
 		 *
 		 * @param absoluteLimit the maximum number of events that can be returned from any query
 		 * @return this Builder for method chaining


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation clarifying that `EventSource.query()` and `EventStorage.query()` return streams that are **already fully materialized in memory**, not lazy streams. This is a critical contract detail that affects how callers should use the API to avoid performance problems and out-of-memory errors.

## Key Changes

- **EventSource javadoc**: Added detailed section "A Returned Stream Is Already In Memory" explaining:
  - Streams are fully fetched before being returned
  - Short-circuiting operations like `findFirst()` and `limit()` on the returned stream don't save work
  - Unbounded queries read everything into heap (OOM risk, not a slow stream)
  - No resources need closing (unlike lazy streams)
  - Proper pattern: use `EventQuery.limit()` to bound storage reads, or page with `Projector`

- **EventSource.query() method javadoc**: Enhanced with warnings about:
  - Unbounded queries reading entire result sets into memory
  - Proper usage patterns: use `EventQuery.limit()` or `Projector` for large streams
  - Clarified return type documentation

- **EventStorage.query() SPI javadoc**: Added detailed section "The Returned Stream" explaining:
  - Laziness is not part of the contract
  - All in-tree backends materialize results before returning
  - `limit` parameter is what bounds work and memory
  - Notes for implementations considering lazy evaluation (resource management and transaction implications)

- **PostgresEventStorage.Builder.absoluteLimit() javadoc**: Clarified that:
  - Leaving `absoluteLimit` unset means queries are unbounded, not streamed
  - Unbounded queries materialize entire result sets in heap
  - Proper usage when callers bound their own queries (like `Projector`)

- **InMemoryEventStorage.Builder.absoluteLimit() javadoc**: Similar clarifications about unbounded query behavior

- **CLAUDE.md**: Added section documenting the in-memory stream behavior and proper usage patterns for callers

## Implementation Details

All changes are documentation-only (javadoc and markdown). No functional code changes. The documentation emphasizes:

1. **The core contract**: Streams are materialized before return, not lazy
2. **The implications**: Unbounded queries are OOM risks, not slow streams
3. **The proper patterns**: Use `EventQuery.limit()` for bounded reads, `Projector` for pagination, or explicit paging loops
4. **Resource safety**: No resources held open, safe to abandon half-consumed streams

https://claude.ai/code/session_01D9c8bt5AiFfkMipFr58MGp