### PR TITLE
Prevent database passwords from leaking into exception messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -819,3 +819,13 @@ can pass all of it and still violate the boundary in production.
 - **Importing needed no DDL change**: `event_id` is already a plain `UUID NOT NULL UNIQUE` and `event_timestamp` is nullable with a `CURRENT_TIMESTAMP` default, so both can be supplied explicitly. `importEvents` binds them per row, chunks statements at 5000 rows (9 params/row against the 65535-parameter wire ceiling) inside a single transaction, and matches `RETURNING` rows **by event_id** rather than by row order — with `ON CONFLICT` the returned rows are a subset of the input, so position in the result set means nothing. Conflicts are routed by constraint name from `PSQLException.getServerErrorMessage().getConstraint()`, not by matching message text
 - **Imported event ids must be UUIDs** (the `::uuid` cast); `importEvents` validates this up front to give a clear error rather than an opaque cast failure
 - **`timestamptz` keeps microseconds and rounds anything finer**, so a nanosecond-precision timestamp (as an in-memory store produces) lands up to half a microsecond away from where it started. This is the only lossy part of an inmem → Postgres → inmem round trip; `EventImportRoundTripTest` pins it down
+- **A `db.properties` *value* never reaches an error message or a log line — only the key does.** Every
+  non-`datasource.` key goes through `HikariConfigurationUtil.setHikariProperty`, and
+  `db.<name>.password` is one of them, so a value interpolated into a message is a database password in
+  every log, stack trace and error reporter downstream. The failure message names the property and the
+  type the setter expected (`Error setting property 'maximumPoolSize' (expected int)`) and stops there;
+  the detail is left to the cause, which for the realistic throwers — a numeric property fed a
+  non-numeric value, a Hikari setter rejecting one — concerns a property that is never a secret. An
+  empty property name (a stray `db.pooled.=x` line) is rejected with that explanation rather than
+  reaching `charAt(0)`. `HikariConfigurationUtilTest` asserts the value is absent from the whole
+  exception chain, not just its top frame

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/HikariConfigurationUtil.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/HikariConfigurationUtil.java
@@ -102,30 +102,45 @@ public class HikariConfigurationUtil {
     }
     
     /**
-     * Sets a property on HikariConfig using reflection to find the appropriate setter
+     * Sets a property on HikariConfig using reflection to find the appropriate setter.
+     * <p>
+     * <strong>The value never appears in the exception message.</strong> Every non-{@code datasource.}
+     * key of the db properties reaches this method, and {@code db.<name>.password} is one of them (see
+     * the example configuration above), so interpolating the value would put a database password into
+     * an exception message and from there into logs, stack traces and error reporters. The property
+     * name is what makes such a failure actionable and is kept; the type the setter expected is kept
+     * too, since the realistic failures are a numeric property fed a non-numeric value and a Hikari
+     * setter rejecting one. The detail is left to the cause.
      */
-    private static void setHikariProperty(HikariConfig config, String propertyName, String value) {
+    static void setHikariProperty(HikariConfig config, String propertyName, String value) {
+        if (propertyName == null || propertyName.isEmpty()) {
+            // a db properties line that is nothing but its prefix, e.g. "db.pooled.=x"
+            throw new IllegalArgumentException("Cannot set a HikariCP property with an empty name: the db properties hold a key consisting of nothing but its 'db.<name>.' prefix");
+        }
+
         // Convert property name to setter method name (e.g., "url" -> "setJdbcUrl", "username" -> "setUsername")
         String methodName = "set" + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
-        
+
         // Special case: "url" maps to "setJdbcUrl"
         if ("url".equals(propertyName)) {
             methodName = "setJdbcUrl";
         }
-        
+
+        Class<?> expectedType = null;
         try {
             // Try to find the setter method with String parameter
             Method method = findSetterMethod(config.getClass(), methodName);
-            
+
             if (method != null) {
-                Class<?> paramType = method.getParameterTypes()[0];
-                Object convertedValue = convertValue(value, paramType);
+                expectedType = method.getParameterTypes()[0];
+                Object convertedValue = convertValue(value, expectedType);
                 method.invoke(config, convertedValue);
             } else {
-                LOGGER.warn("Warning: No setter found for property: " + propertyName);
+                LOGGER.warn("No setter found for property: {}", propertyName);
             }
         } catch (Exception e) {
-            throw new RuntimeException("Error setting property " + propertyName + " to value " + value, e);
+            throw new RuntimeException("Error setting property '%s'%s -- the value is omitted because db properties can hold secrets"
+                    .formatted(propertyName, expectedType == null ? "" : " (expected %s)".formatted(expectedType.getSimpleName())), e);
         }
     }
     

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/HikariConfigurationUtilTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/HikariConfigurationUtilTest.java
@@ -1,0 +1,140 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import com.zaxxer.hikari.HikariConfig;
+
+/**
+ * Pins down that a db properties <em>value</em> never reaches an error message.
+ * <p>
+ * Every non-{@code datasource.} key flows through
+ * {@link HikariConfigurationUtil#setHikariProperty(HikariConfig, String, String)}, and
+ * {@code db.<name>.password} is one of them, so a value interpolated into the exception message is a
+ * database password in every log, stack trace and error reporter downstream of it.
+ */
+class HikariConfigurationUtilTest {
+
+	private static final String SECRET = "hunter2-Th3-Actual-Passw0rd";
+
+	/** A config whose password setter fails, standing in for any Hikari setter that rejects its argument. */
+	private static class FailingPasswordConfig extends HikariConfig {
+
+		@Override
+		public void setPassword ( String password ) {
+			throw new IllegalStateException("setter refused the argument");
+		}
+	}
+
+	private static String stackTraceOf ( Throwable throwable ) {
+		StringWriter writer = new StringWriter();
+		throwable.printStackTrace(new PrintWriter(writer));
+		return writer.toString();
+	}
+
+	@Test
+	void testSetterFailureOnASecretDoesNotLeakTheValue ( ) {
+
+		RuntimeException thrown = assertThrows(RuntimeException.class,
+			() -> HikariConfigurationUtil.setHikariProperty(new FailingPasswordConfig(), "password", SECRET));
+
+		assertFalse(thrown.getMessage().contains(SECRET), "the password must not appear in the exception message: " + thrown.getMessage());
+		// the whole chain, not only the top frame -- an error reporter renders all of it
+		assertFalse(stackTraceOf(thrown).contains(SECRET), "the password must not appear anywhere in the stack trace");
+
+		// what is left has to stay actionable
+		assertTrue(thrown.getMessage().contains("password"), "the property name is what makes the error actionable: " + thrown.getMessage());
+		// the cause carries the detail: the reflective wrapper, and under it what the setter actually threw
+		InvocationTargetException cause = assertInstanceOf(InvocationTargetException.class, thrown.getCause());
+		assertInstanceOf(IllegalStateException.class, cause.getCause());
+	}
+
+	@Test
+	void testSecretIsNotLeakedThroughCreateConfigEither ( ) {
+
+		Properties properties = new Properties();
+		properties.setProperty("db.pooled.url", "jdbc:postgresql://localhost:5432/eventstore");
+		properties.setProperty("db.pooled.password", SECRET);
+		// a numeric property with a non-numeric value: the realistic thrower, since convertValue parses unguarded
+		properties.setProperty("db.pooled.maximumPoolSize", "twenty-five");
+
+		RuntimeException thrown = assertThrows(RuntimeException.class, () -> HikariConfigurationUtil.createConfig("pooled", properties));
+
+		assertFalse(stackTraceOf(thrown).contains(SECRET), "no property value from the file may reach the failure of another property");
+	}
+
+	@Test
+	void testNonNumericValueForANumericPropertyNamesThePropertyAndTheExpectedType ( ) {
+
+		RuntimeException thrown = assertThrows(RuntimeException.class,
+			() -> HikariConfigurationUtil.setHikariProperty(new HikariConfig(), "maximumPoolSize", "twenty-five"));
+
+		assertTrue(thrown.getMessage().contains("maximumPoolSize"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("int"), "the expected type is signal the value is not: " + thrown.getMessage());
+		assertInstanceOf(NumberFormatException.class, thrown.getCause());
+	}
+
+	@Test
+	void testEmptyPropertyNameIsRejectedWithContext ( ) {
+
+		// "db.pooled.=x" -- a stray line used to reach charAt(0) and throw StringIndexOutOfBoundsException with no context
+		Properties properties = new Properties();
+		properties.setProperty("db.pooled.", "x");
+
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> HikariConfigurationUtil.createConfig("pooled", properties));
+
+		assertTrue(thrown.getMessage().contains("empty name"), thrown.getMessage());
+
+		assertThrows(IllegalArgumentException.class, () -> HikariConfigurationUtil.setHikariProperty(new HikariConfig(), "", "x"));
+		assertThrows(IllegalArgumentException.class, () -> HikariConfigurationUtil.setHikariProperty(new HikariConfig(), null, "x"));
+	}
+
+	@Test
+	void testValidConfigurationStillLoads ( ) {
+
+		Properties properties = new Properties();
+		properties.setProperty("db.pooled.url", "jdbc:postgresql://localhost:5432/eventstore");
+		properties.setProperty("db.pooled.username", "eventstore");
+		properties.setProperty("db.pooled.password", SECRET);
+		properties.setProperty("db.pooled.maximumPoolSize", "25");
+		properties.setProperty("db.pooled.datasource.sslmode", "require");
+		properties.setProperty("db.nonpooled.maximumPoolSize", "2");
+
+		HikariConfig config = HikariConfigurationUtil.createConfig("pooled", properties);
+
+		assertNotNull(config);
+		assertEquals("jdbc:postgresql://localhost:5432/eventstore", config.getJdbcUrl());
+		assertEquals("eventstore", config.getUsername());
+		assertEquals(SECRET, config.getPassword());
+		assertEquals(25, config.getMaximumPoolSize());
+		assertEquals("require", config.getDataSourceProperties().getProperty("sslmode"));
+	}
+}


### PR DESCRIPTION
## Summary

Hardens error handling in `HikariConfigurationUtil` to ensure that database property values—particularly passwords—never appear in exception messages, logs, or stack traces. This prevents sensitive credentials from being exposed in error reports and logging systems.

## Key Changes

- **Made `setHikariProperty()` public and testable**: Changed from private to package-private to enable comprehensive testing of error scenarios
- **Added input validation**: Rejects empty or null property names with a clear error message instead of allowing them to reach `charAt(0)` and throw `StringIndexOutOfBoundsException`
- **Sanitized exception messages**: Modified error handling to exclude property values from exception messages while retaining:
  - The property name (makes the error actionable)
  - The expected type for numeric properties (helps diagnose type mismatches)
  - The underlying cause chain (preserves diagnostic detail)
- **Added comprehensive test suite** (`HikariConfigurationUtilTest`): 
  - Verifies secrets don't leak through exception messages or stack traces
  - Tests that property names and type information remain in error messages
  - Validates that empty property names are rejected with context
  - Confirms valid configurations still load correctly
- **Updated documentation**: Added detailed JavaDoc explaining the security rationale and implementation approach

## Implementation Details

The error message format changed from:
```
Error setting property <name> to value <value>
```

To:
```
Error setting property '<name>'[optional: (expected <type>)] -- the value is omitted because db properties can hold secrets
```

This ensures that even if a property setter fails, the database password (or other sensitive values) never reaches any error reporting system, while still providing enough context to diagnose configuration issues.

https://claude.ai/code/session_01V1ckqkuoZhyKDnqj9B91N1