### PR TITLE
Enforce Tag round-trip invariant: reject ambiguous tags at construction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,45 @@ mvn clean install -DskipTests
 - Enable querying events across different event types
 - Core to the Dynamic Consistency Boundary pattern
 - Created via `Tags.of("key", "value")` or `Tags.of(Tag.of("key", "value"))`
+- **`Tag.toString()` is the wire format, not a debugging rendering.** A tag is flattened to
+  `"key:value"` to be persisted and to be matched: the Postgres backend stores `Tags.toStrings()` in a
+  `text[]` column and answers a tag query with `event_tags @> ARRAY[...]` built from the *same*
+  rendering, then hands tags back through `Tags.parse(String[])`. The string is unescaped, and
+  `Tag.parse` splits on the **first** `':'`, strips both halves and maps an empty half to `null` —
+  so `toString`/`parse` is only a round trip for tags whose key has no colon and whose halves are
+  neither empty nor padded. The in-memory backends flatten nothing and match on the `Tag` record,
+  so they cannot fail this way, which is exactly why it stayed invisible: a store that behaves in
+  tests and diverges in production
+- **Construction therefore rejects the shapes that do not survive it**, rather than escaping the
+  stored form — existing rows cannot be rewritten, so the encoding has to stay as it is.
+  `IllegalArgumentException` for: a `':'` in the **key** (`Tag.of("a:b","c")` rendered as `"a:b:c"`,
+  which is also what `Tag.of("a","b:c")` renders to — two logical tags, one stored string); leading
+  or trailing whitespace on either half (`parse` strips it); an empty key or value (`parse` nulls
+  it); and a tag with neither key nor value (renders as `""`, reads back as nothing). Values may
+  contain `':'` freely, and whitespace *inside* a key or value is fine. Whitespace is rejected
+  rather than silently stripped so the mistake surfaces where it is made — a caller handling
+  untrusted input should `strip()` first. `Tag.of(null, "v")` stays legal, because `Tag.parse(":v")`
+  still produces it from history
+- **What that buys: `toString` is injective, so `parse(tag.toString())` is the identity** for every
+  constructible tag. Two distinct tags on one event can no longer be stored as one array element,
+  and a tag read off an `Event` is the tag that was appended — which matters because re-tagging a
+  new event with a tag read back from an old one is an ordinary pattern
+- **`Tag.parse` and `Tags.parse` stay lenient, deliberately.** They are the read path for tags
+  written before any of this was enforced, and they normalise instead of rejecting: a stored
+  `"k: v "` comes back as `Tag.of("k","v")`, a stored `"k:"` as `Tag.of("k")`. Everything they
+  return is constructible, so reading legacy data never throws. Two consequences for legacy rows
+  only: the tag read off such an event is not the tag that was appended, and because `Tags.parse`
+  builds a `Set`, two stored strings normalising to the same tag **collapse into one**
+- **Matching is exact containment, never key-prefix.** `Tag.of("customer")` and
+  `Tag.of("customer","123")` are two different tags on every backend, and a query for the first does
+  **not** return events carrying the second. Users reasonably expect the bare key to act as "any
+  customer"; it does not, and there is no wildcard form. Tag every event with
+  `Tag.of("customer", id)` and query for that; a bare key is a flag, for when the presence of the
+  tag is itself the fact
+- `TagTest`/`TagsTest` pin the round trip and the rejections; `TagRoundTripTest` in the TCK proves
+  per backend that a written tag is found by a query for itself and comes back unchanged, over the
+  full legal character set (colons in values, unicode, newlines, `{`/`,`/quotes that are `text[]`
+  syntax, 1000-character values)
 
 **EventFilter:**
 - Pure matching criteria: event types, tags, and an optional "until" temporal boundary

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Tag.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Tag.java
@@ -42,6 +42,35 @@ import org.sliceworkz.eventstore.stream.AppendCriteria;
  *   <li>{@code "key:value"} - a tag with both key and value</li>
  * </ul>
  *
+ * <h2>The string form is the wire format</h2>
+ * {@link #toString()} is not a debugging convenience: it is how a tag is persisted and how it is
+ * matched. The PostgreSQL backend stores {@link Tags#toStrings()} into a {@code text[]} column and
+ * answers a tag query with {@code event_tags @> ARRAY[...]} built from the same {@code toString()},
+ * so a query is an <em>exact string comparison</em> against the stored form, and
+ * {@link #parse(String)} is what a caller gets back when reading tags off an {@link Event}.
+ * <p>
+ * That only works if {@code parse(tag.toString())} returns the same tag it started with, and for a
+ * tag whose key contains {@code ':'}, or whose key or value is empty or carries surrounding
+ * whitespace, it does not — {@code parse} splits on the <em>first</em> {@code ':'}, strips both
+ * halves and maps an empty half to {@code null}. {@code Tag.of("a:b", "c")} renders as
+ * {@code "a:b:c"}, which reads back as key {@code "a"} and value {@code "b:c"}: a different tag,
+ * and the same string a genuine {@code Tag.of("a", "b:c")} renders to. The failure such a tag
+ * produces is a query returning nothing, or matching something it should not, with no exception
+ * raised anywhere.
+ * <p>
+ * The constructor therefore <b>rejects</b> exactly the tags that cannot survive the round trip
+ * (see {@link #Tag(String, String)}), which makes {@code toString}/{@code parse} a bijection over
+ * every tag that can be constructed. {@link #parse(String)} deliberately stays lenient, because it
+ * has to keep reading tags written before this was enforced.
+ *
+ * <h2>Matching is exact, not by key prefix</h2>
+ * A tag matches a query tag when <em>both</em> the key and the value are equal. {@code Tag.of("customer")}
+ * and {@code Tag.of("customer", "123")} are two different tags, and a query for the first does
+ * <b>not</b> return events carrying the second — there is no key-prefix, key-only or wildcard
+ * matching anywhere in the store. To find every event for a customer, tag them all with
+ * {@code Tag.of("customer", id)} and query for that; a bare {@code Tag.of("customer")} is a flag,
+ * useful when the presence of the tag is itself the fact.
+ *
  * <h2>Example Usage:</h2>
  * <pre>{@code
  * // Creating tags with key and value
@@ -91,13 +120,87 @@ import org.sliceworkz.eventstore.stream.AppendCriteria;
 public record Tag ( String key, String value ) {
 
 	/**
+	 * The character separating key from value in the string form, and therefore the one character a
+	 * key may not contain.
+	 */
+	public static final char SEPARATOR = ':';
+
+	/**
+	 * Constructs a tag, rejecting the shapes that do not survive the string round trip.
+	 * <p>
+	 * The string form produced by {@link #toString()} is what gets persisted and what a tag query is
+	 * matched against, so a tag that {@link #parse(String)} reads back as something else is a query
+	 * that silently returns the wrong events. Rather than escape the string form — which would change
+	 * what is already in the databases — construction refuses the four shapes that are ambiguous:
+	 * <ul>
+	 *   <li><b>a key containing {@value #SEPARATOR}</b>, because {@code parse} splits on the first
+	 *       one: {@code Tag.of("a:b", "c")} would render as {@code "a:b:c"} and read back as
+	 *       {@code Tag.of("a", "b:c")}, which is also what a genuine {@code Tag.of("a", "b:c")}
+	 *       renders to. Values may contain {@value #SEPARATOR} freely — everything after the first
+	 *       one is the value.</li>
+	 *   <li><b>a key or value with leading or trailing whitespace</b>, because {@code parse} strips
+	 *       both halves: {@code Tag.of("k", " v ")} would read back as {@code Tag.of("k", "v")}.
+	 *       Whitespace <em>inside</em> a key or value is fine. Whitespace is rejected rather than
+	 *       silently stripped so the mistake surfaces where it is made; a caller handling untrusted
+	 *       input should {@code strip()} it themselves.</li>
+	 *   <li><b>an empty key or an empty value</b>, because {@code parse} maps an empty half to
+	 *       {@code null}: {@code Tag.of("k", "")} would render as {@code "k:"} and read back as
+	 *       {@code Tag.of("k")}, so an event visibly carrying tag {@code k} would not be found by a
+	 *       query for {@code Tag.of("k")}. Use {@link #of(String)} when there is no value.</li>
+	 *   <li><b>a tag that is entirely null</b>, which renders as the empty string and is read back as
+	 *       no tag at all.</li>
+	 * </ul>
+	 * A {@code null} key with a value is legal and renders as {@code ":value"}; {@link #parse(String)}
+	 * still produces such tags from history, so they have to remain constructible.
+	 *
+	 * @param key the tag key, may be null
+	 * @param value the tag value, may be null
+	 * @throws IllegalArgumentException if the tag cannot be rendered and parsed back unchanged
+	 */
+	public Tag {
+		if ( key == null && value == null ) {
+			throw new IllegalArgumentException(
+					"a tag needs a key or a value: a tag with neither renders as the empty string and cannot be read back");
+		}
+		if ( key != null && key.indexOf(SEPARATOR) >= 0 ) {
+			throw new IllegalArgumentException(
+					"tag key must not contain '" + SEPARATOR + "': it separates key from value in the stored form, so \""
+							+ key + "\" would be read back as a different tag");
+		}
+		checkRoundTrippable("key", key);
+		checkRoundTrippable("value", value);
+	}
+
+	private static void checkRoundTrippable ( String what, String s ) {
+		if ( s == null ) {
+			return;
+		}
+		if ( s.isEmpty() ) {
+			throw new IllegalArgumentException(
+					"tag " + what + " must not be empty (it is stored as, and read back as, no " + what + " at all)"
+							+ ("value".equals(what) ? " — use Tag.of(key) for a tag without a value" : ""));
+		}
+		if ( !s.equals(s.strip()) ) {
+			throw new IllegalArgumentException(
+					"tag " + what + " must not have leading or trailing whitespace (it is stripped when read back, so \""
+							+ s + "\" would become \"" + s.strip() + "\"");
+		}
+	}
+
+	/**
 	 * Creates a tag with only a key and no value.
 	 * <p>
 	 * This is useful for boolean-style tags or flags where the presence of the tag
 	 * itself is meaningful, without requiring a specific value.
+	 * <p>
+	 * Note that this is a <em>different tag</em> from {@code Tag.of(key, someValue)}, not a prefix of
+	 * it: a query for {@code Tag.of("customer")} does not match events tagged
+	 * {@code Tag.of("customer", "123")}. See the class javadoc.
 	 *
 	 * @param key the tag key
 	 * @return a new Tag with the specified key and null value
+	 * @throws IllegalArgumentException if the key is null, empty, or has leading or trailing
+	 *         whitespace, or contains {@value #SEPARATOR}
 	 */
 	public static Tag of ( String key ) {
 		return new Tag(key, null);
@@ -112,6 +215,8 @@ public record Tag ( String key, String value ) {
 	 * @param key the tag key
 	 * @param value the tag value
 	 * @return a new Tag with the specified key and value
+	 * @throws IllegalArgumentException if the tag cannot be rendered and parsed back unchanged —
+	 *         see {@link #Tag(String, String)}
 	 */
 	public static Tag of ( String key, String value ) {
 		return new Tag(key, value);
@@ -154,6 +259,19 @@ public record Tag ( String key, String value ) {
 	 *   <li>{@code "key:value"} - creates a tag with both key and value</li>
 	 * </ul>
 	 * Whitespace is trimmed from both key and value. Empty strings are converted to null.
+	 * <p>
+	 * <b>This is deliberately lenient, and deliberately not symmetric with construction.</b> Tags
+	 * written before the constructor started rejecting ambiguous shapes are in databases that cannot
+	 * be rewritten, so the read path has to keep accepting them; it normalises them instead. A stored
+	 * {@code "k: v "} comes back as {@code Tag.of("k", "v")}, a stored {@code "k:"} as
+	 * {@code Tag.of("k")}, and a stored {@code "a:b:c"} as {@code Tag.of("a", "b:c")} whichever tag
+	 * wrote it. Note what that means for legacy data: the tag you read off an event may not be the
+	 * tag that was appended, and re-tagging a new event with it stores a different string.
+	 * <p>
+	 * Everything {@code parse} returns is a tag the constructor accepts — the key it produces never
+	 * contains {@value #SEPARATOR}, both halves are stripped, and an empty half becomes {@code null} —
+	 * so reading legacy data never throws, and for any constructible tag
+	 * {@code parse(tag.toString()).equals(tag)}.
 	 * <p>
 	 * <b>Examples:</b>
 	 * <pre>{@code
@@ -201,13 +319,19 @@ public record Tag ( String key, String value ) {
 	/**
 	 * Converts this tag to its string representation.
 	 * <p>
+	 * <b>This is the persisted and matched form</b>, not just a debugging rendering — see the class
+	 * javadoc. It is unescaped, and it is kept that way because escaping would change the form
+	 * already sitting in every existing database; the constructor rejects the tags that would need
+	 * escaping instead.
+	 * <p>
 	 * The format is:
 	 * <ul>
 	 *   <li>{@code "key"} if value is null</li>
 	 *   <li>{@code "key:value"} if both key and value are present</li>
 	 *   <li>{@code ":value"} if key is null but value is present</li>
-	 *   <li>{@code ""} (empty string) if both key and value are null</li>
 	 * </ul>
+	 * The fourth case the constructor used to allow — both key and value null, rendering as the empty
+	 * string — is now rejected, since nothing can read it back.
 	 *
 	 * @return the string representation of this tag
 	 */

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Tags.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Tags.java
@@ -44,6 +44,16 @@ import org.sliceworkz.eventstore.stream.AppendCriteria;
  *   <li>Check for tag presence and containment relationships</li>
  * </ul>
  *
+ * <h2>Matching is exact, not by key prefix</h2>
+ * A query tag matches an event's tag only when key <em>and</em> value are equal, whatever the
+ * backend: {@link #containsAll(Tags)} is a {@link java.util.Set} containment over {@link Tag}
+ * records in memory, and a {@code text[]} containment over {@link #toStrings()} on PostgreSQL. So
+ * {@code Tags.of("customer", "123")} matches only events carrying exactly that tag, and
+ * {@code Tags.of(Tag.of("customer"))} matches only events carrying the bare {@code customer} flag —
+ * <b>not</b> events tagged {@code customer:123}. There is no key-prefix, key-only or wildcard
+ * matching. See {@link Tag} for why, and for the constraints construction enforces so that a tag
+ * survives being written and read back unchanged.
+ *
  * <h2>Basic Usage:</h2>
  * <pre>{@code
  * // Creating tags for an event
@@ -312,6 +322,13 @@ public record Tags ( Set<Tag> tags ) {
 	 * combined into a single Tags instance. Null or unparseable strings are ignored.
 	 * Strings should be in the format "key" or "key:value".
 	 * <p>
+	 * This is the read path — the PostgreSQL backend calls it on the {@code text[]} column — so it
+	 * inherits {@link Tag#parse(String)}'s leniency towards tags written before construction was
+	 * validated, and adds one effect of its own: because the result is a {@link java.util.Set}, two
+	 * stored strings that normalise to the same tag <b>collapse into one</b>. A row storing
+	 * {@code {"k: v ", "k:v"}} comes back carrying a single {@code Tag.of("k", "v")}. No tag the
+	 * current constructor accepts can collide this way, so this only affects legacy rows.
+	 * <p>
 	 * <b>Example:</b>
 	 * <pre>{@code
 	 * Tags tags = Tags.parse("customer:123", "region:EU", "important");
@@ -325,11 +342,14 @@ public record Tags ( Set<Tag> tags ) {
 	 * // Results in two tags: customer:123 and region:EU
 	 * }</pre>
 	 *
-	 * @param values the string representations to parse
+	 * @param values the string representations to parse (if null, returns {@link #none()})
 	 * @return a new Tags instance containing all successfully parsed tags
 	 * @see Tag#parse(String)
 	 */
 	public static Tags parse ( String... values ) {
+		if ( values == null ) {
+			return Tags.none();
+		}
 		Set<Tag> tags = new HashSet<>();
 		for ( String v: values ) {
 			Tag t = Tag.parse(v);
@@ -345,6 +365,10 @@ public record Tags ( Set<Tag> tags ) {
 	 * <p>
 	 * Each tag is converted using {@link Tag#toString()}, resulting in strings in the
 	 * format "key" or "key:value". The result is returned as a Set to maintain uniqueness.
+	 * <p>
+	 * This is the form a backend persists and matches against, so the returned set is the same size
+	 * as {@link #tags()}: {@link Tag}'s constructor rejects the shapes whose string forms could
+	 * collide, which is what stops two distinct tags on one event from being stored as one.
 	 * <p>
 	 * <b>Example:</b>
 	 * <pre>{@code

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/TagTest.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/TagTest.java
@@ -18,8 +18,13 @@
 package org.sliceworkz.eventstore.events;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -104,6 +109,127 @@ public class TagTest {
 	@Test
 	void testToStringNullValue ( ) {
 		assertEquals("key", Tag.of("key").toString());
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// The string form is the wire format: it is what a backend stores and what a tag query is matched
+	// against, so every constructible tag has to survive parse(toString()) unchanged. These pin that
+	// down, and pin down that the shapes which do not survive it are refused at construction rather
+	// than at query time, where the failure is a silently empty result.
+	// ---------------------------------------------------------------------------------------------
+
+	private static void assertRoundTrips ( Tag tag ) {
+		assertEquals(tag, Tag.parse(tag.toString()),
+				"tag " + tag + " does not survive being rendered and parsed back");
+	}
+
+	@Test
+	void testRoundTripsPlainTag ( ) {
+		assertRoundTrips(Tag.of("customer", "123"));
+		assertRoundTrips(Tag.of("region", "EU"));
+	}
+
+	@Test
+	void testRoundTripsKeyOnlyTag ( ) {
+		assertRoundTrips(Tag.of("important"));
+	}
+
+	@Test
+	void testRoundTripsNullKeyTag ( ) {
+		// legal, and Tag.parse(":value") keeps producing it, so it has to stay constructible
+		assertRoundTrips(Tag.of(null, "value"));
+	}
+
+	@Test
+	void testRoundTripsColonInValue ( ) {
+		// only the FIRST colon separates, so a value may contain as many as it likes
+		assertRoundTrips(Tag.of("url", "https://example.org:8443/x"));
+		assertEquals(Tag.of("a", "b:c"), Tag.parse("a:b:c"));
+	}
+
+	@Test
+	void testRoundTripsAwkwardButLegalCharacters ( ) {
+		// whitespace and separators inside a key or value are fine -- only the ends matter
+		assertRoundTrips(Tag.of("first name", "Jan Van Roey"));
+		assertRoundTrips(Tag.of("path", "a/b\\c,d;e\"f'g"));
+		assertRoundTrips(Tag.of("json", "{\"a\":1}"));
+		assertRoundTrips(Tag.of("unicode", "élève-中文-🎉"));
+		assertRoundTrips(Tag.of("multi", "line\nbreak"));
+	}
+
+	@Test
+	void testColonInKeyIsRejected ( ) {
+		// the defect: Tag.of("a:b","c") renders as "a:b:c" and parses back as Tag.of("a","b:c"),
+		// which is a different tag -- and the very string a genuine Tag.of("a","b:c") renders to
+		assertEquals("a:b:c", Tag.of("a", "b:c").toString());
+		assertEquals(Tag.of("a", "b:c"), Tag.parse("a:b:c"));
+
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("a:b", "c"));
+		assertNotNull(e.getMessage());
+
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("a:b"));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("trailing:", "v"));
+		assertThrows(IllegalArgumentException.class, ( ) -> new Tag(":", "v"));
+	}
+
+	@Test
+	void testSurroundingWhitespaceIsRejected ( ) {
+		// the defect: parse() strips, so " v " would come back as "v" -- a different tag, and one
+		// whose query would silently match nothing
+		assertEquals(Tag.of("k", "v"), Tag.parse("k: v "));
+
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("k", " v "));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("k", "v "));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of(" k ", "v"));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("k\t", "v"));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("k", "\nv"));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("   "));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("k", "   "));
+	}
+
+	@Test
+	void testEmptyKeyOrValueIsRejected ( ) {
+		// the invisible one: Tag.of("k","") is stored as "k:" and read back as Tag.of("k"), so the
+		// event visibly carries tag "k" while a query for Tag.of("k") -- stored form "k" -- finds nothing
+		assertEquals("k", Tag.of("k").toString());
+		assertEquals(Tag.of("k"), Tag.parse("k:"));
+
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("k", ""));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of("", "v"));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of(""));
+	}
+
+	@Test
+	void testEntirelyNullTagIsRejected ( ) {
+		// renders as "", which parse() reads back as no tag at all: the tag would simply vanish
+		assertNull(Tag.parse(""));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of(null, (String) null));
+		assertThrows(IllegalArgumentException.class, ( ) -> Tag.of(null));
+		assertThrows(IllegalArgumentException.class, ( ) -> new Tag(null, null));
+	}
+
+	@Test
+	void testEveryTagParseProducesIsConstructible ( ) {
+		// what keeps the read path lenient: parse() normalises legacy strings into tags the
+		// constructor accepts, so reading tags written before this validation existed never throws
+		List<String> legacy = List.of(
+				"", "   ", ":", " : ", "k", "k:", "k: v ", " k :v", ":v", ": v ", "a:b:c", "k:v:",
+				"\t k \t : \t v \t", "k:  ", "  :  ", "k:v");
+		for ( String stored : legacy ) {
+			Tag parsed = Tag.parse(stored);   // must not throw
+			if ( parsed != null ) {
+				assertRoundTrips(parsed);     // and must itself be stable from here on
+			}
+		}
+	}
+
+	@Test
+	void testKeyOnlyTagIsNotAPrefixOfAKeyValueTag ( ) {
+		// matching is exact containment, in memory and in SQL alike: a query for Tag.of("customer")
+		// does not find events tagged Tag.of("customer","123")
+		assertNotEquals(Tag.of("customer"), Tag.of("customer", "123"));
+		assertNotEquals(Tag.of("customer").toString(), Tag.of("customer", "123").toString());
+		assertFalse(Tags.of(Tag.of("customer", "123")).containsAll(Tags.of(Tag.of("customer"))));
 	}
 
 }

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/TagsTest.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/events/TagsTest.java
@@ -118,4 +118,62 @@ public class TagsTest {
 		assertTrue(tags.tags().contains(Tag.parse("customer:456")));
 		assertTrue(tags.tags().contains(Tag.parse("order:ABC")));
 	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Tags.parse(String[]) is the read path -- the PostgreSQL backend calls it on the text[] column.
+	// It inherits Tag.parse's leniency towards tags written before construction was validated, and
+	// adds a collapse of its own, because the result is a Set.
+	// ---------------------------------------------------------------------------------------------
+
+	@Test
+	void testParseIsLenientForLegacyStoredForms ( ) {
+		// none of these round-trip to what wrote them, and none of them may throw: they are what is
+		// already sitting in databases written before Tag validated on construction
+		assertEquals(Tag.of("k", "v"), Tag.parse("k: v "));
+		assertEquals(Tag.of("k"), Tag.parse("k:"));
+		assertEquals(Tag.of("a", "b:c"), Tag.parse("a:b:c"));
+		assertEquals(Tag.of(null, "v"), Tag.parse(" : v "));
+
+		Tags tags = Tags.parse("k: v ", "k2:", "a:b:c", "", "   ");
+		assertEquals(3, tags.tags().size());
+		assertTrue(tags.tags().contains(Tag.of("k", "v")));
+		assertTrue(tags.tags().contains(Tag.of("k2")));
+		assertTrue(tags.tags().contains(Tag.of("a", "b:c")));
+	}
+
+	@Test
+	void testParseCollapsesLegacyFormsThatNormaliseToTheSameTag ( ) {
+		// a row storing both of these comes back carrying ONE tag: the event loses a tag on read.
+		// Only reachable for legacy rows -- no two tags the constructor accepts render alike.
+		Tags tags = Tags.parse("k: v ", "k:v", " k :v");
+		assertEquals(1, tags.tags().size());
+		assertEquals(Tag.of("k", "v"), tags.tags().iterator().next());
+	}
+
+	@Test
+	void testParseNullArray ( ) {
+		String[] values = null;
+		assertEquals(Tags.none(), Tags.parse(values));
+	}
+
+	@Test
+	void testToStringsNeverCollapses ( ) {
+		// what makes the stored text[] faithful: toString is injective over constructible tags, so a
+		// three-tag event is stored as three array elements and read back as three tags
+		Tags tags = Tags.of(Tag.of("a", "b:c"), Tag.of("customer", "123"), Tag.of("important"));
+		assertEquals(3, tags.toStrings().size());
+		assertEquals(tags, Tags.parse(tags.toStrings().toArray(new String[0])));
+	}
+
+	@Test
+	void testKeyOnlyTagDoesNotMatchAKeyValueTag ( ) {
+		// matching is exact containment, never key-prefix: a query for Tag.of("customer") does not
+		// find events tagged Tag.of("customer","123"), and vice versa
+		Tags onEvent = Tags.of(Tag.of("customer", "123"));
+		Tags keyOnlyQuery = Tags.of(Tag.of("customer"));
+
+		assertFalse(onEvent.containsAll(keyOnlyQuery));
+		assertFalse(Tags.of(Tag.of("customer")).containsAll(onEvent));
+		assertFalse(onEvent.toStrings().contains("customer"));
+	}
 }

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -1368,7 +1368,9 @@ public class PostgresEventStorageImpl implements EventStorage {
 				parameters.add(event.erasableData());
 
 				// Convert tags to array
-				String[] tagsArray = event.tags().toStrings().toArray(new String[event.tags().tags().size()]);
+				// sized from the string set, not from tags(): a set sized larger than its contents leaves a
+				// trailing null element, which would be written into the text[] column as a NULL tag
+				String[] tagsArray = event.tags().toStrings().toArray(new String[0]);
 				parameters.add(tagsArray);
 			}
 
@@ -1618,7 +1620,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 			parameters.add(OffsetDateTime.of(event.timestamp(), ZoneOffset.UTC));
 			parameters.add(event.immutableData());
 			parameters.add(event.erasableData());
-			parameters.add(event.tags().toStrings().toArray(new String[event.tags().tags().size()]));
+			parameters.add(event.tags().toStrings().toArray(new String[0]));
 		}
 
 		List<StoredEvent> imported = new ArrayList<>(chunk.size());
@@ -2151,7 +2153,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 						stmt.setString(4, eventReference==null?null:eventReference.id().value());
 						
 						// Convert tags to array
-						String[] tagsArray = tags.toStrings().toArray(new String[tags.tags().size()]);
+						String[] tagsArray = tags.toStrings().toArray(new String[0]);
 						stmt.setArray(5, writeConnection.createArrayOf("text", (String[]) tagsArray));
 						
 						int rowsAffected = stmt.executeUpdate();

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodec.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonBookmarkCodec.java
@@ -108,7 +108,10 @@ public final class JsonBookmarkCodec {
 			JsonNode tagsNode = node.get("tags");
 			if ( tagsNode != null && tagsNode.isArray() ) {
 				for ( JsonNode tagNode : tagsNode ) {
-					String key = tagNode.get("key").asText();
+					// see JsonEventCodec: asText() renders a JSON null as "", which is a key Tag rejects
+					String key = tagNode.has("key") && !tagNode.get("key").isNull()
+							? tagNode.get("key").asText()
+							: null;
 					String value = tagNode.has("value") && !tagNode.get("value").isNull()
 							? tagNode.get("value").asText()
 							: null;

--- a/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonEventCodec.java
+++ b/sliceworkz-eventstore-serialization-json/src/main/java/org/sliceworkz/eventstore/serialization/json/JsonEventCodec.java
@@ -166,7 +166,12 @@ public final class JsonEventCodec {
 			JsonNode tagsNode = node.get("tags");
 			if ( tagsNode != null && tagsNode.isArray() ) {
 				for ( JsonNode tagNode : tagsNode ) {
-					String key = tagNode.get("key").asText();
+					// a null key has to come back as null, not as "": asText() on a JSON null renders
+					// the empty string, which is a key Tag rejects, and which used to turn the legal
+					// Tag.of(null, "v") into a different tag on every reload
+					String key = tagNode.has("key") && !tagNode.get("key").isNull()
+							? tagNode.get("key").asText()
+							: null;
 					String value = tagNode.has("value") && !tagNode.get("value").isNull()
 							? tagNode.get("value").asText()
 							: null;

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/TagRoundTripTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/TagRoundTripTest.java
@@ -1,0 +1,166 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.Tag;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
+
+/**
+ * A tag written to a stream is found by a query for that same tag, and comes back off the event
+ * unchanged — for every tag {@link Tag} lets you construct.
+ * <p>
+ * This is not as obvious as it looks, because a tag does not travel as a pair. The PostgreSQL backend
+ * flattens it to {@link Tag#toString()} — {@code "key:value"} — stores that in a {@code text[]}
+ * column, matches a query with {@code event_tags @> ARRAY[...]} built from the same rendering, and
+ * hands it back through {@link Tags#parse(String[])}. The string form is the wire format, and it is
+ * unescaped. So the property under test is a triangle: what is stored, what is matched, and what is
+ * read back all have to agree, and the in-memory backends — which never flatten anything, and so
+ * cannot fail the way a text backend can — have to agree with them.
+ * <p>
+ * {@link Tag}'s constructor is what makes this hold: it rejects the shapes whose rendering is
+ * ambiguous (a {@code ':'} in the key, surrounding whitespace, an empty half), which leaves
+ * {@code toString}/{@code parse} a bijection. Before that, {@code Tag.of("k", "")} was stored as
+ * {@code "k:"}, read back as {@code Tag.of("k")}, and <em>not</em> found by a query for
+ * {@code Tag.of("k")} — an event visibly carrying a tag that a query for that tag could not find,
+ * with nothing raised anywhere. The cases below are therefore all legal tags; the illegal ones are
+ * pinned down in {@code TagTest}, where they now throw at construction.
+ *
+ * @see Tag
+ */
+public class TagRoundTripTest extends AbstractEventStoreTest {
+
+	/** Every shape a caller may construct, including the ones that are awkward to render. */
+	private static final List<Tag> TAGS = List.of(
+			Tag.of("customer", "123"),
+			Tag.of("important"),                                  // key only, no value
+			Tag.of(null, "keyless"),                              // renders as ":keyless"
+			Tag.of("url", "https://example.org:8443/a:b"),        // colons in the value are fine
+			Tag.of("first name", "Jan Van Roey"),                 // whitespace inside, not around
+			Tag.of("json", "{\"a\":1,\"b\":[2]}"),
+			Tag.of("punctuation", "a/b\\c,d;e'f\"g|h"),
+			Tag.of("unicode", "élève-中文-🎉"),
+			Tag.of("multiline", "line\nbreak"),
+			Tag.of("percent", "100%_x"),
+			Tag.of("sql", "'); DROP TABLE events; --"),
+			Tag.of("brace", "{a,b}"),                             // reads as an array literal in text[]
+			Tag.of("long", "x".repeat(1000)));
+
+	private EventStream<MockDomainEvent> streamFor ( String purpose ) {
+		return eventStore().getEventStream(
+				EventStreamId.forContext("tag-roundtrip").withPurpose(purpose), MockDomainEvent.class);
+	}
+
+	private static List<Event<MockDomainEvent>> queryFor ( EventStream<MockDomainEvent> stream, Tag tag ) {
+		return stream.query(EventQuery.forEvents(EventTypesFilter.any(), Tags.of(tag))).toList();
+	}
+
+	@ForEachBackend
+	void everyConstructibleTagIsFoundByAQueryForItselfAndComesBackUnchanged ( ) {
+
+		EventStream<MockDomainEvent> stream = streamFor("each");
+
+		for ( int i = 0; i < TAGS.size(); i++ ) {
+			Tag tag = TAGS.get(i);
+			// a discriminator so each event is identifiable, and so a query has to select on the tag
+			// under test rather than simply returning the only event in the stream
+			Tags tags = Tags.of(tag, Tag.of("seq", i));
+			stream.append(AppendCriteria.none(), Event.of(new FirstDomainEvent("event " + i), tags));
+		}
+
+		for ( int i = 0; i < TAGS.size(); i++ ) {
+			Tag tag = TAGS.get(i);
+
+			List<Event<MockDomainEvent>> found = queryFor(stream, tag);
+
+			assertEquals(1, found.size(),
+					"a query for the tag just written found " + found.size() + " events instead of 1: " + tag);
+			assertEquals("event " + i, ((FirstDomainEvent) found.getFirst().data()).value(),
+					"the query for " + tag + " matched the wrong event");
+
+			// and the tag survives the trip back: same key, same value, no stripping, no re-splitting
+			Tags readBack = found.getFirst().tags();
+			assertEquals(2, readBack.tags().size(),
+					"the event should carry both its tag and its discriminator, got " + readBack.tags());
+			assertTrue(readBack.tags().contains(tag),
+					"the tag read off the event is not the tag that was written: wrote " + tag
+							+ ", read " + readBack.tags());
+		}
+	}
+
+	@ForEachBackend
+	void distinctTagsOnOneEventStayDistinct ( ) {
+
+		// tags whose renderings are close enough to collide if the encoding were ambiguous:
+		// "a:b:c" is what Tag.of("a:b","c") would have rendered to, and Tag.of("a:b","c") is now
+		// rejected precisely so that this one is unambiguous
+		Tags tags = Tags.of(
+				Tag.of("a", "b:c"),
+				Tag.of("a", "b"),
+				Tag.of("a"),
+				Tag.of("ab", "c"));
+
+		EventStream<MockDomainEvent> stream = streamFor("distinct");
+		stream.append(AppendCriteria.none(), Event.of(new FirstDomainEvent("multi"), tags));
+
+		for ( Tag tag : tags.tags() ) {
+			assertEquals(1, queryFor(stream, tag).size(), "the event should be found by its tag " + tag);
+		}
+
+		Tags readBack = stream.query(EventQuery.matchAll()).toList().getFirst().tags();
+		assertEquals(tags, readBack, "four distinct tags must not collapse on the way through storage");
+	}
+
+	@ForEachBackend
+	void aKeyOnlyTagIsNotAPrefixOfAKeyValueTag ( ) {
+
+		// documented and deliberate: matching is exact containment, never key-prefix. Users reasonably
+		// expect Tag.of("customer") to act as "any customer"; it does not, on any backend.
+		EventStream<MockDomainEvent> stream = streamFor("prefix");
+
+		stream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("with value"), Tags.of(Tag.of("customer", "123"))));
+		stream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("flag only"), Tags.of(Tag.of("customer"))));
+
+		List<Event<MockDomainEvent>> byKeyOnly = queryFor(stream, Tag.of("customer"));
+		assertEquals(1, byKeyOnly.size(), "a key-only tag matches only events carrying the key-only tag");
+		assertEquals("flag only", ((FirstDomainEvent) byKeyOnly.getFirst().data()).value());
+
+		List<Event<MockDomainEvent>> byKeyValue = queryFor(stream, Tag.of("customer", "123"));
+		assertEquals(1, byKeyValue.size(), "a key-value tag matches only events carrying that exact tag");
+		assertEquals("with value", ((FirstDomainEvent) byKeyValue.getFirst().data()).value());
+
+		assertEquals(0, queryFor(stream, Tag.of("customer", "456")).size(),
+				"a tag nobody wrote must match nothing");
+	}
+}


### PR DESCRIPTION
## Summary

Tags are persisted as unescaped strings (`"key:value"`) and matched by exact string comparison in PostgreSQL (`text[]` containment). The string form is the wire format, not a debugging rendering. This means `Tag.toString()` and `Tag.parse()` must be inverses for every constructible tag, or queries silently return wrong results.

This change enforces that invariant by rejecting at construction time the four shapes that cannot survive the round trip, rather than allowing them to be written and discovered as broken only at query time.

## Key Changes

- **Tag constructor validation**: Rejects tags with:
  - A colon (`:`) in the key (ambiguous split point)
  - Leading or trailing whitespace on key or value (stripped on parse)
  - Empty key or value (nulled on parse)
  - Both key and value null (renders as empty string, reads back as nothing)
  
  Values may contain colons freely; whitespace inside a key or value is fine. `Tag.of(null, "value")` remains legal since `Tag.parse(":value")` still produces it from legacy data.

- **Tag.parse() stays lenient**: Deliberately accepts legacy stored forms and normalises them (strips whitespace, nulls empty halves). Everything it returns is now constructible, so reading old data never throws.

- **Tags.parse() collapse behavior**: Because it builds a `Set`, two stored strings normalising to the same tag collapse into one. Only affects legacy rows—no two constructible tags render alike.

- **Exact matching, not prefix**: `Tag.of("customer")` and `Tag.of("customer", "123")` are different tags. A query for the first does not match events carrying the second. This is enforced on every backend (Set containment in memory, `text[]` containment in PostgreSQL).

- **Comprehensive test coverage**:
  - `TagRoundTripTest`: TCK test verifying every constructible tag survives the round trip and is found by queries, including awkward characters (colons in values, unicode, JSON, SQL injection attempts, etc.)
  - `TagTest`: Unit tests pinning down rejection of ambiguous shapes and acceptance of legacy forms
  - `TagsTest`: Tests for set collapse, exact matching, and parse leniency

- **Bug fixes**:
  - `PostgresEventStorageImpl`: Fixed array sizing bug—`new String[size]` leaves trailing nulls if size > actual elements; changed to `new String[0]` for proper dynamic sizing
  - `JsonEventCodec` and `JsonBookmarkCodec`: Fixed null key handling—`asText()` on JSON null renders empty string, which Tag now rejects; use `asText(null)` to preserve nulls

## Implementation Details

The string form is the only thing persisted and matched:
- PostgreSQL backend: stores `Tags.toStrings()` in `text[]` column, queries with `event_tags @> ARRAY[...]` built from the same rendering
- In-memory backends: match on `Tag` records directly, so they cannot fail the way a text backend can—which is why this stayed invisible until now

The bijection between `toString()` and `parse()` is what makes this work. Before this change, `Tag.of("k", "")` was stored as `"k:"`, read back as `Tag.of("k")`, and a query for `Tag.of("k")` (stored form `"k"`) found nothing—an event visibly carrying a tag that a query for that tag could not find, with no exception raised anywhere.

Now the mistake surfaces at construction, where it belongs.

https://claude.ai/code/session_017jUYBkwmRshdTxKaKAM22z