### PR TITLE
Identify idempotency violations by index name, not message text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -816,6 +816,25 @@ can pass all of it and still violate the boundary in production.
   not a correctness-of-operation one.
 - `stream_purpose` defaults to `'default'` in the DDL, matching `EventStreamId.DEFAULT_PURPOSE`. On a database created before this alignment (default was `''`), operators doing raw SQL inserts should run `ALTER TABLE <prefix>events ALTER COLUMN stream_purpose SET DEFAULT 'default';` — no data migration is needed since all events written through the library bind the purpose explicitly
 - **Idempotency keys are scoped per event stream (context + purpose), not per storage/table.** Uniqueness is enforced by the partial unique index `idx_events_stream_idempotency` on `(stream_context, stream_purpose, idempotency_key) WHERE idempotency_key IS NOT NULL` (schema validation requires it), so the same key used on two unrelated streams does not collide and dedup behaviour does not depend on how storage instances / prefixes are wired at runtime. The `idempotency_key` is persisted and surfaced on `StoredEvent` when reading (it is not exposed on the public `Event` record). A duplicate append is still silently ignored (returns an empty result). On a database created before this change (when `idempotency_key` had a table-wide `UNIQUE`), migrate with: `ALTER TABLE <prefix>events DROP CONSTRAINT <prefix>events_idempotency_key_key; CREATE UNIQUE INDEX <prefix>idx_events_stream_idempotency ON <prefix>events (stream_context, stream_purpose, idempotency_key) WHERE idempotency_key IS NOT NULL;` — no data migration is needed
+  - **The duplicate is recognised by the index the server names, never by the message text.** Both the
+    append and the import path go through `isIdempotencyKeyViolation`, which pairs SQLSTATE 23505 with
+    `PSQLException.getServerErrorMessage().getConstraint()` — populated with the *index* name for a bare
+    `CREATE UNIQUE INDEX`, and compared case-insensitively against `<prefix>idx_events_stream_idempotency`
+    because PostgreSQL folds the unquoted identifier in the DDL. Two things make the message text unusable
+    here, and only one of them is obvious. The subtle one is the table prefix: it is caller-supplied and
+    validated only as `[a-zA-Z0-9_]+_`, so a prefix containing the word "idempotency" puts that word into
+    `<prefix>events_pkey` and `<prefix>events_event_id_key` as well, and a substring match then swallows
+    *every* unique violation the table can raise — reporting a successful de-duplication for an append that
+    wrote nothing. (The other, message translation under a non-English `lc_messages`, turns out **not** to
+    bite: an index name is an identifier, so it appears verbatim in the French and Japanese messages too.
+    Verified, not assumed.) `EventStreamIdempotencyTest` builds its store with exactly such a prefix and
+    pins a generated `event_id` with a `BEFORE INSERT` trigger, so the misrouting fails the build rather
+    than passing silently
+  - **Identifier length is a coupling to keep in mind.** PostgreSQL truncates identifiers at 63 bytes, which
+    would break an exact-name comparison; `MAX_PREFIX_LENGTH` (32) keeps the longest generated index name at
+    61 characters, so it cannot happen. Raising that cap needs this comparison revisited — and, more
+    urgently, would let two of the schema's index names truncate to the same string, at which point
+    `CREATE UNIQUE INDEX IF NOT EXISTS` silently does nothing and idempotency uniqueness stops existing
 - **Importing needed no DDL change**: `event_id` is already a plain `UUID NOT NULL UNIQUE` and `event_timestamp` is nullable with a `CURRENT_TIMESTAMP` default, so both can be supplied explicitly. `importEvents` binds them per row, chunks statements at 5000 rows (9 params/row against the 65535-parameter wire ceiling) inside a single transaction, and matches `RETURNING` rows **by event_id** rather than by row order — with `ON CONFLICT` the returned rows are a subset of the input, so position in the result set means nothing. Conflicts are routed by constraint name from `PSQLException.getServerErrorMessage().getConstraint()`, not by matching message text
 - **Imported event ids must be UUIDs** (the `::uuid` cast); `importEvents` validates this up front to give a clear error rather than an opaque cast failure
 - **`timestamptz` keeps microseconds and rounds anything finer**, so a nanosecond-precision timestamp (as an in-memory store produces) lands up to half a microsecond away from where it started. This is the only lossy part of an inmem → Postgres → inmem round trip; `EventImportRoundTripTest` pins it down

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -64,6 +64,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.postgresql.PGConnection;
 import org.postgresql.PGNotification;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sliceworkz.eventstore.events.Bookmark;
@@ -499,7 +500,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 			checkIndex(readConnection, prefix + "idx_events_tags");
 			checkIndex(readConnection, prefix + "idx_events_stream_tags");
 			checkIndex(readConnection, prefix + "idx_events_stream_position");
-			checkIndex(readConnection, prefix + "idx_events_stream_idempotency");
+			checkIndex(readConnection, idempotencyIndexName());
 			checkIndex(readConnection, prefix + "idx_bookmarks_event_id");
 
 			LOGGER.info("Database schema validation completed successfully for prefix '{}'", prefix);
@@ -1481,10 +1482,12 @@ public class PostgresEventStorageImpl implements EventStorage {
 					}
 
 					// idempotency conflict: a duplicate (stream, idempotency_key) is silently ignored.
-					// Detect via SQLState 23505 (unique_violation) on the stream-scoped idempotency index,
-					// rather than a substring match on the whole message: this survives the constraint/index
-					// rename and keeps an event_id uniqueness collision from being misrouted into this branch.
-					if ( "23505".equals(e.getSQLState()) && e.getMessage() != null && e.getMessage().contains("idempotency") ) {
+					// Detected via SQLState 23505 (unique_violation) on the stream-scoped idempotency index,
+					// by the index name the server reports rather than a substring match on the message: the
+					// message is translated under a non-English lc_messages, and matching it as a substring
+					// also swallows an event_id or primary-key violation whenever the table prefix happens to
+					// contain the word "idempotency".
+					if ( isIdempotencyKeyViolation(e) ) {
 						return Collections.emptyList();
 					} else {
 						throw new EventStorageException("SQLException during append", e);
@@ -1659,6 +1662,77 @@ public class PostgresEventStorageImpl implements EventStorage {
 		return id.value().toLowerCase(Locale.ROOT);
 	}
 
+	/** SQLSTATE for {@code unique_violation}. */
+	private static final String UNIQUE_VIOLATION = "23505";
+
+	/** Unprefixed name of the partial unique index that scopes idempotency keys to a stream. */
+	private static final String IDEMPOTENCY_INDEX = "idx_events_stream_idempotency";
+
+	/**
+	 * Name of the stream-scoped idempotency index for this storage's table prefix, as
+	 * {@code ensure-schema.sql} writes it.
+	 * <p>
+	 * The identifier there is unquoted, so the server folds it to lower case — hence the
+	 * case-insensitive comparison in {@link #isIdempotencyKeyViolation}. It also truncates identifiers
+	 * at 63 bytes, which this name cannot reach: {@code MAX_PREFIX_LENGTH} caps the prefix at 32
+	 * characters, leaving 61 at most.
+	 *
+	 * @return the unprefixed index name with this storage's prefix applied
+	 */
+	private String idempotencyIndexName ( ) {
+		return prefix + IDEMPOTENCY_INDEX;
+	}
+
+	/**
+	 * The structured error the server sent with a failure, or {@code null} for any {@link SQLException}
+	 * that does not carry one — anything not raised by the server, and anything the driver produced
+	 * itself.
+	 *
+	 * @param e the failure to inspect
+	 * @return the server error message, or {@code null}
+	 */
+	private static ServerErrorMessage serverError ( SQLException e ) {
+		return e instanceof PSQLException psqlException ? psqlException.getServerErrorMessage() : null;
+	}
+
+	/**
+	 * The constraint or index the server blamed for a failed statement, or {@code null} if it did not
+	 * say.
+	 * <p>
+	 * This is the field PostgreSQL fills in on a unique violation, and it names the offending
+	 * <em>index</em> for a violation of a bare {@code CREATE UNIQUE INDEX} just as it names the
+	 * constraint for a table constraint. It is the only structured way to tell one unique violation on
+	 * the events table from another: the message text is translated when the server runs under a
+	 * non-English {@code lc_messages}, and matching it as a substring also picks up the prefixed names
+	 * of the <em>other</em> unique keys on the table.
+	 *
+	 * @param e the failure to inspect
+	 * @return the constraint/index name, or {@code null} if the server did not report one
+	 */
+	private static String serverConstraintName ( SQLException e ) {
+		ServerErrorMessage serverError = serverError(e);
+		return serverError == null ? null : serverError.getConstraint();
+	}
+
+	/**
+	 * Whether a failure is a duplicate of an idempotency key already used on the same stream, as opposed
+	 * to any other unique violation the events table can raise.
+	 * <p>
+	 * Routed by the index name the server reports rather than by the exception message, so that it is
+	 * unaffected by the server's message locale and cannot be triggered by a violation of
+	 * {@code <prefix>events_pkey} or {@code <prefix>events_event_id_key} — which a substring match on
+	 * the message does whenever the caller-supplied table prefix happens to contain the word
+	 * "idempotency". Silently swallowing one of those would report a successful de-duplication for an
+	 * append that in fact wrote nothing.
+	 *
+	 * @param e the failure to classify
+	 * @return {@code true} if the stream-scoped idempotency index rejected the row
+	 */
+	private boolean isIdempotencyKeyViolation ( SQLException e ) {
+		return UNIQUE_VIOLATION.equals(e.getSQLState())
+				&& idempotencyIndexName().equalsIgnoreCase(serverConstraintName(e));
+	}
+
 	/**
 	 * Turns a failed import into the most specific exception the server error allows.
 	 * <p>
@@ -1668,20 +1742,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 	 * server does not supply a parseable DETAIL the conflict is still reported, without the specifics.
 	 */
 	private EventStorageException classifyImportFailure ( SQLException e, List<EventToImport> events ) {
-		if ( !"23505".equals(e.getSQLState()) ) {
+		if ( !UNIQUE_VIOLATION.equals(e.getSQLState()) ) {
 			return new EventStorageException("SQLException during import", e);
 		}
 
-		String constraint = null;
-		String detail = null;
-		if ( e instanceof PSQLException psqlException && psqlException.getServerErrorMessage() != null ) {
-			constraint = psqlException.getServerErrorMessage().getConstraint();
-			detail = psqlException.getServerErrorMessage().getDetail();
-		}
+		ServerErrorMessage serverError = serverError(e);
+		List<String> conflictingValues = parseConflictValues(serverError == null ? null : serverError.getDetail());
 
-		List<String> conflictingValues = parseConflictValues(detail);
-
-		if ( constraint != null && constraint.contains("idempotency") ) {
+		if ( isIdempotencyKeyViolation(e) ) {
 			// DETAIL reports (stream_context, stream_purpose, idempotency_key)=(ctx, purpose, key)
 			EventToImport conflicting = conflictingValues.size() == 3
 					? events.stream()

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventStreamIdempotencyTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventStreamIdempotencyTest.java
@@ -1,0 +1,176 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorageException;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.EventStoreBackend.Capability;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.StorageOptions;
+import org.sliceworkz.eventstore.testing.tck.mockdomain.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mockdomain.MockDomainEvent.FirstDomainEvent;
+
+/**
+ * What an idempotency key does, and — just as important — what it must not do.
+ * <p>
+ * A duplicate key on the same stream is swallowed: the append writes nothing and reports nothing,
+ * which is the whole point of the mechanism. That makes the branch that recognises the duplicate the
+ * one place in the write path where a wrong answer is invisible. Recognise too little and a caller
+ * that expected de-duplication gets an exception; recognise too much and a write that genuinely
+ * failed is reported as a successful de-duplication, with the events silently absent.
+ * <p>
+ * <b>Why this store is built with a table prefix containing the word "idempotency".</b> That is not
+ * decoration. A backend deriving object names from the prefix ends up with names like
+ * {@code idempotency_events_event_id_key} for the <em>other</em> unique keys on its table, so a
+ * backend recognising the duplicate by looking for that word somewhere in the driver's error message
+ * — rather than by identifying the constraint that actually rejected the row — silently swallows
+ * every unique violation the table can raise. The prefix is caller-supplied and validated only as
+ * {@code [a-zA-Z0-9_]+_}, so nothing stops one being chosen. Backends that do not support prefixes
+ * ignore it and the scenarios still hold.
+ */
+public class EventStreamIdempotencyTest extends AbstractEventStoreTest {
+
+	/** Also the table prefix on SQL backends — see the class javadoc for why this word. */
+	private static final String PREFIX = "idempotency_";
+
+	private EventStream<MockDomainEvent> stream;
+
+	@Override
+	protected StorageOptions storageOptions ( ) {
+		return StorageOptions.defaults().withPrefix(PREFIX);
+	}
+
+	@BeforeEach
+	void openStream ( ) {
+		stream = eventStore().getEventStream(EventStreamId.forContext("app").withPurpose("default"), MockDomainEvent.class);
+	}
+
+	@ForEachBackend
+	void duplicateIdempotencyKeyOnTheSameStreamIsDeduplicated ( ) {
+
+		List<Event<MockDomainEvent>> first = stream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("1"), Tags.none()).withIdempotencyKey("order-4711"));
+		assertEquals(1, first.size());
+
+		// same key, same stream: silently ignored, reported as an empty result
+		List<Event<MockDomainEvent>> repeat = stream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("2"), Tags.none()).withIdempotencyKey("order-4711"));
+		assertEquals(0, repeat.size());
+
+		// and the second event really is absent, rather than written and merely not returned
+		List<Event<MockDomainEvent>> stored = stream.query(EventQuery.matchAll()).toList();
+		assertEquals(1, stored.size());
+		assertEquals(new FirstDomainEvent("1"), stored.getFirst().data());
+	}
+
+	@ForEachBackend
+	void theSameIdempotencyKeyOnAnotherStreamIsAppended ( ) {
+
+		EventStream<MockDomainEvent> otherStream = eventStore()
+				.getEventStream(EventStreamId.forContext("app-other").withPurpose("default"), MockDomainEvent.class);
+
+		List<Event<MockDomainEvent>> first = stream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("1"), Tags.none()).withIdempotencyKey("order-4711"));
+		assertEquals(1, first.size());
+
+		// dedup is scoped to the logical stream, so the same key on another one is a different event
+		List<Event<MockDomainEvent>> onOtherStream = otherStream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("2"), Tags.none()).withIdempotencyKey("order-4711"));
+		assertEquals(1, onOtherStream.size());
+		assertNotEquals(first.getFirst().reference(), onOtherStream.getFirst().reference());
+
+		assertEquals(1, stream.query(EventQuery.matchAll()).count());
+		assertEquals(1, otherStream.query(EventQuery.matchAll()).count());
+	}
+
+	/**
+	 * An event id colliding with one already stored is a different failure, and must surface as one.
+	 * <p>
+	 * Reaching it needs the id an append generates to be forced to a known value, which no API
+	 * offers — an event id is the store's to mint — so this goes in behind the store's back and is
+	 * skipped on backends that cannot offer that. A store that mistakes this for a duplicate
+	 * idempotency key returns an empty list, telling the caller its event was de-duplicated when in
+	 * fact nothing was written and the reason was unrelated.
+	 */
+	@ForEachBackend(requires = Capability.RAW_STORAGE_ACCESS)
+	void anEventIdCollisionIsNotMistakenForADuplicateIdempotencyKey ( ) throws Exception {
+
+		pinGeneratedEventIdTo("00000000-0000-7000-8000-000000000001");
+
+		// no idempotency key anywhere in this scenario: the only uniqueness in play is the event id
+		List<Event<MockDomainEvent>> first = stream.append(AppendCriteria.none(),
+				Event.of(new FirstDomainEvent("1"), Tags.none()));
+		assertEquals(1, first.size());
+
+		// the point of the assertion is that it throws at all: a store misreading this as a duplicate
+		// idempotency key returns an empty list instead, which is indistinguishable from a successful
+		// de-duplication
+		assertThrows(EventStorageException.class, () ->
+				stream.append(AppendCriteria.none(), Event.of(new FirstDomainEvent("2"), Tags.none())));
+
+		assertEquals(1, stream.query(EventQuery.matchAll()).count());
+	}
+
+	/**
+	 * Overrides the id the store generates, so that the next append collides with the previous one.
+	 * <p>
+	 * A {@code BEFORE INSERT} trigger rather than a prepared row, because the store mints the id
+	 * inside the INSERT — server-side on PostgreSQL 18 and up — so there is nothing to predict and
+	 * nothing to bind.
+	 *
+	 * @param eventId the id every appended row will be given
+	 */
+	private void pinGeneratedEventIdTo ( String eventId ) throws Exception {
+		DataSource dataSource = dataSource().orElseThrow();
+		try ( Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement() ) {
+			// CREATE OR REPLACE, because the store's per-test reset drops and recreates its tables --
+			// taking the trigger with them -- but leaves a function of its own naming behind
+			statement.execute("""
+				CREATE OR REPLACE FUNCTION %spin_event_id ( ) RETURNS TRIGGER AS $$
+				BEGIN
+					NEW.event_id := '%s'::uuid;
+					RETURN NEW;
+				END;
+				$$ LANGUAGE plpgsql
+				""".formatted(PREFIX, eventId));
+			statement.execute("""
+				CREATE TRIGGER %spin_event_id_trigger
+				BEFORE INSERT ON %sevents
+				FOR EACH ROW EXECUTE FUNCTION %spin_event_id()
+				""".formatted(PREFIX, PREFIX, PREFIX));
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

Fix idempotency key duplicate detection to use the constraint/index name reported by the PostgreSQL server rather than substring matching on the exception message. This prevents false positives when the table prefix contains the word "idempotency", which would cause unrelated unique violations (event_id or primary key) to be silently swallowed and reported as successful de-duplications.

## Key Changes

- **PostgresEventStorageImpl**: Refactored duplicate idempotency key detection to use `PSQLException.getServerErrorMessage().getConstraint()` paired with SQLSTATE 23505, comparing the constraint name case-insensitively against the expected index name. This replaces the previous substring match on the exception message.
  - Added `isIdempotencyKeyViolation()` method that checks both SQLSTATE and constraint name
  - Added `serverError()` and `serverConstraintName()` helper methods to extract structured error information
  - Added constants `UNIQUE_VIOLATION` and `IDEMPOTENCY_INDEX` for clarity
  - Added `idempotencyIndexName()` method to compute the prefixed index name
  - Updated both the append path and import path to use the new detection logic
  - Updated schema validation to use `idempotencyIndexName()` instead of hardcoded name

- **EventStreamIdempotencyTest**: New comprehensive test class that validates idempotency behavior and specifically tests the edge case where the table prefix contains "idempotency":
  - Tests that duplicate keys on the same stream are silently ignored
  - Tests that the same key on different streams produces separate events
  - Tests that event_id collisions are not mistaken for idempotency key duplicates (via a `BEFORE INSERT` trigger that pins the generated event_id)

- **CLAUDE.md**: Updated documentation to explain the constraint-name-based detection approach and the rationale for avoiding message text matching, including the subtle coupling to table prefix length.

## Notable Implementation Details

- The server reports the constraint/index name in the structured `ServerErrorMessage` for unique violations, which is unaffected by the server's `lc_messages` locale setting (identifiers appear verbatim in translated messages)
- PostgreSQL truncates identifiers at 63 bytes; `MAX_PREFIX_LENGTH` (32) ensures the longest generated index name stays at 61 characters, preventing truncation issues
- The test uses a `BEFORE INSERT` trigger to force event_id collisions, demonstrating that the fix correctly distinguishes between idempotency key violations and other unique violations

https://claude.ai/code/session_015u5YRTMUs6indeAo5GELdy