### PR TITLE
Fix AppendCriteria null handling and optimistic locking semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,17 @@ mvn clean install -DskipTests
 - If new matching events are found after the reference, append fails with `OptimisticLockingException`
 - Use `AppendCriteria.none()` for simple appends without locking
 - Use `AppendCriteria.of(eventQuery, reference)` or `AppendCriteria.of(eventFilter, reference)` for conditional appends
+- **`expectedLastEventReference()` is never null**, whichever factory or constructor produced the criteria — the
+  compact constructor normalises a null to `Optional.empty()`. `none()` used to put a literal null there, so the
+  most common criteria in the library threw an NPE on `.isPresent()` and both in-tree backends carried their own
+  null guard; a third-party `EventStorage` had to guess the same one
+- **"No criteria" and "an empty expected reference" are different things, and only `isNone()` distinguishes
+  them.** `isNone()` is derived from the filter being `matchNone`, independently of the reference. An empty
+  reference under a *real* filter means "I decided on an empty stream", which is still a consistency boundary:
+  any matching event in the stream is a new relevant fact and must raise `OptimisticLockingException` (see
+  `OptimisticLockingTest.testOptimisticLockingSucceedsWhenExpectingEmptyStreamAndStreamIsNotEmpty`). A backend
+  skipping the check when the reference is absent is a silent loss of optimistic locking; `AppendCriteriaTest`
+  in the TCK pins both halves down
 
 **Projection:**
 - Combines an `EventQuery` with an `EventHandler`

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/AppendCriteria.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/AppendCriteria.java
@@ -37,16 +37,29 @@ import org.sliceworkz.eventstore.query.EventQuery;
  * Simple appends without locking (without relevant facts to consider) are possible with AppendCriteria.none()
  *
  * @param eventFilter the filter defining which events are relevant for the consistency check
- * @param expectedLastEventReference the last known Event matching the filter that our decision was based upon, or Optional.empty() for none assumed (empty EventStream)
+ * @param expectedLastEventReference the last known Event matching the filter that our decision was based upon, or Optional.empty() for none assumed (empty EventStream).
+ *                                   Never null — a null handed to the canonical constructor is normalised to Optional.empty().
  */
 public record AppendCriteria ( EventFilter eventFilter, Optional<EventReference> expectedLastEventReference ) {
+
+	/**
+	 * Normalises a null expectedLastEventReference into {@link Optional#empty()}, so this record can never hold
+	 * a null in that component regardless of how it was built. Callers — including third-party {@code EventStorage}
+	 * implementations — can therefore call {@link #expectedLastEventReference()} and use the Optional directly.
+	 *
+	 * @param eventFilter the filter defining which events are relevant for the consistency check
+	 * @param expectedLastEventReference the last known matching Event, or Optional.empty() (or null, normalised here) for none
+	 */
+	public AppendCriteria {
+		expectedLastEventReference = expectedLastEventReference == null ? Optional.empty() : expectedLastEventReference;
+	}
 
 	/**
 	 * Specifies that no AppendCriteria should be applied, so the append will be carried out regardless of the history.
 	 * @return AppendCriteria without conditional appends
 	 */
 	public static final AppendCriteria none ( ) {
-		return new AppendCriteria(EventFilter.matchNone(), null);
+		return new AppendCriteria(EventFilter.matchNone(), Optional.empty());
 	}
 
 	/**

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -287,8 +287,10 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		
 		List<StoredEvent> result = Collections.emptyList();
 		
-		// if we should just append and not check, or no reference was present to a last event id (empty stream)
-		if ( appendCriteria.isNone() || appendCriteria.expectedLastEventReference() == null ) {
+		// if we should just append and not check
+		// (an empty expectedLastEventReference is NOT this case: it means "I decided on an empty stream",
+		//  which still has to be verified — see the else branch, which queries from the start of the stream)
+		if ( appendCriteria.isNone() ) {
 			result = addAndNotifyListeners(events);
 			
 		// otherwise, we'll need to be aware of any optimistic locking issues

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -1394,7 +1394,7 @@ public class PostgresEventStorageImpl implements EventStorage {
 					}
 				}
 
-				if ( appendCriteria.expectedLastEventReference() != null && appendCriteria.expectedLastEventReference().isPresent()  ) {
+				if ( appendCriteria.expectedLastEventReference().isPresent() ) {
 
 					// Look for events after the expected last one, over the same (tx, position) order
 					// readers see and EventReference.happenedAfter defines. See addCursorBoundary: on a

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/AppendCriteriaTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/AppendCriteriaTest.java
@@ -1,0 +1,155 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.sliceworkz.eventstore.EventStoreFactory;
+import org.sliceworkz.eventstore.events.EphemeralEvent;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.query.EventFilter;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.stream.OptimisticLockingException;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.SecondDomainEvent;
+
+/**
+ * The {@link AppendCriteria} record contract every backend — and every caller inspecting the criteria
+ * it is handed — may rely on: {@code expectedLastEventReference()} is never null, whichever factory or
+ * constructor produced the criteria, and {@code isNone()} is derived from the filter alone.
+ *
+ * {@code AppendCriteria.none()} used to put a literal null in that Optional component, so the most common
+ * criteria in the library threw a NullPointerException on {@code .isPresent()}. Both in-tree backends
+ * carried their own null guard around it; a third-party {@link org.sliceworkz.eventstore.spi.EventStorage}
+ * had to guess the same one.
+ */
+public class AppendCriteriaTest extends AbstractEventStoreTest {
+
+	private static final String UNITTEST_BOUNDEDCONTEXT = "unittest";
+
+	@ForEachBackend
+	void testNoneCarriesAnEmptyOptionalAndNotNull() {
+		AppendCriteria none = AppendCriteria.none();
+
+		assertNotNull(none.expectedLastEventReference(), "AppendCriteria.none() must not hold a null Optional");
+		assertTrue(none.expectedLastEventReference().isEmpty(), "AppendCriteria.none() expects no last event reference");
+		assertTrue(none.isNone(), "AppendCriteria.none() must report isNone()");
+	}
+
+	@ForEachBackend
+	void testEveryConstructionPathNormalisesNullToEmpty() {
+		// the of(...) factories already used Optional.ofNullable
+		assertNotNull(AppendCriteria.of(EventQuery.matchAll(), null).expectedLastEventReference());
+		assertTrue(AppendCriteria.of(EventQuery.matchAll(), null).expectedLastEventReference().isEmpty());
+		assertNotNull(AppendCriteria.of(EventFilter.matchAll(), null).expectedLastEventReference());
+		assertTrue(AppendCriteria.of(EventFilter.matchAll(), null).expectedLastEventReference().isEmpty());
+
+		// ... and the canonical constructor normalises a null handed to it directly
+		assertNotNull(new AppendCriteria(EventFilter.matchAll(), null).expectedLastEventReference(),
+				"the canonical constructor must normalise a null reference into Optional.empty()");
+		assertTrue(new AppendCriteria(EventFilter.matchAll(), null).expectedLastEventReference().isEmpty());
+
+		// a reference that is given survives untouched
+		EventReference reference = EventReference.create(42, 42);
+		assertEquals(Optional.of(reference), AppendCriteria.of(EventQuery.matchAll(), reference).expectedLastEventReference());
+	}
+
+	@ForEachBackend
+	void testIsNoneIsDerivedFromTheFilterAloneAndNotFromTheReference() {
+		EventReference reference = EventReference.create(42, 42);
+
+		// a matchNone filter is 'no criteria', with or without a reference on it
+		assertTrue(AppendCriteria.of(EventFilter.matchNone(), reference).isNone(),
+				"isNone() must follow the filter, not the presence of a reference");
+		assertTrue(AppendCriteria.of(EventFilter.matchNone(), null).isNone());
+
+		// and a real filter is never 'no criteria', not even without a reference (that is 'I expect an empty stream')
+		assertFalse(AppendCriteria.of(EventFilter.matchAll(), null).isNone(),
+				"an absent reference means 'I decided on an empty stream', which is still a consistency boundary");
+		assertFalse(AppendCriteria.of(EventFilter.matchAll(), reference).isNone());
+	}
+
+	@ForEachBackend
+	void testAppendWithNoneIgnoresHistory() {
+		EventStream<MockDomainEvent> eventStream = createEventStream();
+
+		EphemeralEvent<FirstDomainEvent> first = Event.of(new FirstDomainEvent("test1"), Tags.none());
+		eventStream.append(AppendCriteria.none(), Collections.singletonList(first));
+
+		// appending with none() over a non-empty stream must still not raise: it reads no boundary at all
+		EphemeralEvent<SecondDomainEvent> second = Event.of(new SecondDomainEvent("test2"), Tags.none());
+		eventStream.append(AppendCriteria.none(), Collections.singletonList(second));
+
+		assertEquals(2, eventStream.query(EventQuery.matchAll()).count(), "both events should be appended with none()");
+	}
+
+	@ForEachBackend
+	void testAppendWithAReferenceStillLocksAsBefore() {
+		EventStream<MockDomainEvent> eventStream = createEventStream();
+
+		EphemeralEvent<FirstDomainEvent> first = Event.of(new FirstDomainEvent("test1"), Tags.none());
+		Event<MockDomainEvent> stored = eventStream.append(AppendCriteria.none(), Collections.singletonList(first)).get(0);
+
+		// up-to-date reference: append goes through
+		AppendCriteria upToDate = AppendCriteria.of(EventQuery.matchAll(), stored.reference());
+		eventStream.append(upToDate, Collections.singletonList(Event.of(new SecondDomainEvent("test2"), Tags.none())));
+		assertEquals(2, eventStream.query(EventQuery.matchAll()).count());
+
+		// the same reference is now stale — a new relevant fact sits after it
+		assertThrows(OptimisticLockingException.class,
+				() -> eventStream.append(upToDate, Collections.singletonList(Event.of(new SecondDomainEvent("test3"), Tags.none()))),
+				"a stale reference must still raise an OptimisticLockingException");
+		assertEquals(2, eventStream.query(EventQuery.matchAll()).count(), "the failed append must not have stored anything");
+	}
+
+	@ForEachBackend
+	void testAppendWithoutAReferenceStillMeansExpectAnEmptyStream() {
+		EventStream<MockDomainEvent> eventStream = createEventStream();
+
+		// an empty Optional is not 'no criteria': against an empty stream the append succeeds ...
+		AppendCriteria expectingEmpty = AppendCriteria.of(EventQuery.matchAll(), null);
+		eventStream.append(expectingEmpty, Collections.singletonList(Event.of(new FirstDomainEvent("test1"), Tags.none())));
+		assertEquals(1, eventStream.query(EventQuery.matchAll()).count());
+
+		// ... and against a stream that is no longer empty it must not
+		assertThrows(OptimisticLockingException.class,
+				() -> eventStream.append(expectingEmpty, Collections.singletonList(Event.of(new SecondDomainEvent("test2"), Tags.none()))),
+				"criteria with an empty reference expect an empty stream, and must lock when it is not");
+		assertEquals(1, eventStream.query(EventQuery.matchAll()).count(), "the failed append must not have stored anything");
+	}
+
+	private EventStream<MockDomainEvent> createEventStream() {
+		return EventStoreFactory.get().eventStore(eventStorage()).getEventStream(EventStreamId.forContext(UNITTEST_BOUNDEDCONTEXT), MockDomainEvent.class);
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in `AppendCriteria` where `null` values in `expectedLastEventReference` could cause `NullPointerException` when calling `.isPresent()`. It also clarifies the semantic distinction between "no criteria" (`isNone()`) and "expecting an empty stream" (empty `Optional`), ensuring optimistic locking works correctly in both cases.

## Key Changes

- **AppendCriteria canonical constructor**: Added a compact constructor that normalizes `null` `expectedLastEventReference` to `Optional.empty()`, ensuring the field is never null regardless of construction path
- **AppendCriteria.none()**: Changed from returning `new AppendCriteria(EventFilter.matchNone(), null)` to `new AppendCriteria(EventFilter.matchNone(), Optional.empty())` for consistency
- **InMemoryEventStorageImpl**: Removed null check `appendCriteria.expectedLastEventReference() == null` since the field can no longer be null; now only `isNone()` determines whether to skip locking
- **PostgresEventStorageImpl**: Removed redundant null check before calling `.isPresent()` on `expectedLastEventReference()`
- **AppendCriteriaTest**: Added comprehensive TCK test suite validating:
  - `none()` always carries an empty Optional, never null
  - All construction paths normalize null to `Optional.empty()`
  - `isNone()` is derived from filter alone, independent of reference presence
  - Empty reference under a real filter still enforces optimistic locking (expects empty stream)
  - Stale references still raise `OptimisticLockingException` as before
- **Documentation**: Updated CLAUDE.md to document the contract and clarify the semantic difference between "no criteria" and "empty stream expectation"

## Implementation Details

The fix ensures that third-party `EventStorage` implementations can safely call `expectedLastEventReference().isPresent()` without null guards. The distinction between `isNone()` (no consistency boundary) and an empty `Optional` (consistency boundary expecting empty stream) is now enforced at the record level, preventing silent loss of optimistic locking when a reference is absent but a real filter is present.

https://claude.ai/code/session_01Ue1Q9k3vyzRwsDYnKMQuuK