### PR TITLE
Guard btree_gin extension creation against privilege and concurrency issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,7 +768,35 @@ can pass all of it and still violate the boundary in production.
 - Uses HikariCP for connection pooling
 - Separate DataSource for monitoring queries (optional, defaults to main DataSource)
 - Tests use Testcontainers for isolated PostgreSQL instances
-- Requires the `btree_gin` extension (a standard contrib extension, available on the major managed Postgres offerings). Schema initialization runs `CREATE EXTENSION IF NOT EXISTS btree_gin` and schema validation requires `idx_events_stream_tags`, a combined stream+tags GIN index that serves DCB reads scoping by stream *and* filtering by tags in one index. The B-tree indexes are retained for ordered stream replay (GIN cannot serve `ORDER BY`)
+- Requires the `btree_gin` extension (a standard contrib extension, available on the major managed Postgres offerings). Schema initialization installs it and schema validation requires `idx_events_stream_tags`, a combined stream+tags GIN index that serves DCB reads scoping by stream *and* filtering by tags in one index. The B-tree indexes are retained for ordered stream replay (GIN cannot serve `ORDER BY`)
+- **Installing that extension needs `CREATE` on the *database*, which is not `CREATE` on the schema.**
+  `btree_gin` is *trusted* (PG13+), so no superuser is involved — but a role granted `CREATE` on its
+  schema and nothing on the database, the ordinary locked-down deployment, creates every table, index,
+  function and trigger here and then cannot create the extension. Because the schema scripts are one
+  transaction, that is not a missing index: the whole schema rolls back and the store does not start.
+  See "Database privileges" in the postgres module's README for the table of what each
+  `DatabaseInitMode` needs.
+  - **The DBA-installs-it-once split is the recommended answer, and it costs the application role
+    nothing afterwards.** `ensure-schema.sql` pre-checks `pg_extension` and skips the statement
+    entirely when the extension is present, so an unprivileged role starts against it indefinitely —
+    not even a `NOTICE`. (A bare `CREATE EXTENSION IF NOT EXISTS` would also have worked, since
+    PostgreSQL's `IF NOT EXISTS` short-circuit precedes its privilege check, but it puts a `NOTICE` in
+    every startup log and issues DDL a `VALIDATE`-style deployment has no business issuing.)
+  - **The remaining failure names its remedies.** A `RAISE` in the `insufficient_privilege` handler
+    reports the extension, the privilege distinction, and both ways out (`CREATE EXTENSION btree_gin`
+    once, or `GRANT CREATE ON DATABASE`), instead of a bare `permission denied to create extension`
+    wrapped in `Failed to execute database script`.
+  - **The schema advisory lock does not cover this statement**, because it is keyed on the table prefix
+    while an extension is database-scoped. Two stores with *different* prefixes starting together on a
+    database without `btree_gin` therefore raced on `pg_extension_name_index` exactly as the tables
+    used to race on `pg_type_typname_nsp_index` — the loser rolling its whole schema back. The block
+    swallows `duplicate_object` and `unique_violation`: by the time either surfaces the winner has
+    committed (a conflicting catalog insert blocks until it does), so the opclasses the index needs are
+    visible to the loser's transaction, and it goes on to create its index.
+  - **Where the extension lives is not a constraint.** `CREATE EXTENSION btree_gin SCHEMA extensions`,
+    the convention on several managed offerings, serves the index with no `search_path` change and no
+    `USAGE` grant on that schema — default operator class resolution is not `search_path`-filtered.
+  - `PostgresBtreeGinPrivilegeTest` pins all four down per backend (16, 17, 18).
 - **Ordering is the `(event_tx, event_position)` tuple everywhere — reads, the `until` boundary, and the
   optimistic-locking check.** `event_position` is a `bigserial` taken at insert time and `event_tx` is
   `pg_current_xact_id()`, assigned independently, so the two orders genuinely disagree: a transaction can

--- a/sliceworkz-eventstore-infra-postgres/README.md
+++ b/sliceworkz-eventstore-infra-postgres/README.md
@@ -7,6 +7,67 @@ Use 'drop-schema.sql' to drop existing schema objects before recreating.
  
 
 
+## Database privileges
+
+What the application role needs depends on the `DatabaseInitMode` it starts with, and on one thing
+that is not a table: the **`btree_gin` extension**, which the combined stream+tags GIN index
+(`idx_events_stream_tags`) is built on and which schema validation requires.
+
+| mode | what the role must be allowed to do |
+|---|---|
+| `NONE`, `VALIDATE` | `CONNECT`, `USAGE` on the schema, and no DDL at all — see the runtime grants below |
+| `ENSURE` (default) | the above, plus `CREATE` on the **schema** — and, *only if `btree_gin` is not installed yet*, `CREATE` on the **database** |
+| `INITIALIZE` | the above, plus ownership of the store's tables and functions (it drops them) |
+
+Every mode needs these at runtime. They come for free when the role created the tables itself; when a
+DBA created them, they have to be granted:
+
+```sql
+GRANT SELECT, INSERT                 ON <prefix>events    TO <role>;
+GRANT SELECT, INSERT, UPDATE, DELETE ON <prefix>bookmarks TO <role>;
+GRANT USAGE                          ON SEQUENCE <prefix>events_event_position_seq TO <role>;
+```
+
+Events are never updated or deleted — the store only ever appends to that table.
+
+**`CREATE` on the schema and `CREATE` on the database are different privileges**, and this is the
+one place the difference shows. `btree_gin` is a *trusted* extension (PostgreSQL 13+), so installing
+it needs no superuser — but it does need `CREATE` on the current database. The common locked-down
+setup grants `CREATE` on the schema only, which is a role that can create every table, index,
+function and trigger in this schema and *cannot* create the extension.
+
+Two ways to run `ENSURE` under such a role, both fine:
+
+```sql
+-- either: a DBA installs it once, and the application role never needs the privilege
+CREATE EXTENSION btree_gin;
+
+-- or: grant it, for the first start at least
+GRANT CREATE ON DATABASE <database> TO <role>;
+```
+
+The first is the recommended split. The schema script *pre-checks* whether the extension is
+installed, so once it is, the extension statement never runs again — an unprivileged role starts
+against it indefinitely, and there is no `NOTICE` in the log either. A store that hits neither
+option fails to start (the script is a single transaction, so nothing is half-created) with an
+error that names both remedies.
+
+Extension placement does not matter: `CREATE EXTENSION btree_gin SCHEMA extensions`, the convention
+on several managed offerings, serves the index just as well, and the application role needs no
+`USAGE` on that schema — resolving the default GIN operator class for `text` is not filtered by
+`search_path`.
+
+Check the privileges of a role before deploying it:
+
+```sql
+SELECT has_database_privilege('<role>', current_database(), 'CREATE') AS can_create_extension,
+       has_schema_privilege('<role>', current_schema(), 'CREATE')     AS can_create_tables,
+       EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'btree_gin') AS extension_installed;
+```
+
+`can_create_extension` only has to be true when `extension_installed` is false.
+
+
 ## Example queries 
 
 Specific syntax is used on on GIN-indexed Tags:

--- a/sliceworkz-eventstore-infra-postgres/SCHEMA-MIGRATION.md
+++ b/sliceworkz-eventstore-infra-postgres/SCHEMA-MIGRATION.md
@@ -311,6 +311,25 @@ only a `NOTICE … skipping`. So the DBA-installs-once / app-runs-unprivileged s
 today for that line, which softens review item 14 considerably. It is still worth splitting the
 extension out so a `VALIDATE`-only app never issues DDL at all.
 
+> **Update: the extension statement is now guarded, and two things the correction above missed have
+> been fixed with it.** Re-measured on the PostgreSQL 16 floor:
+>
+> - The privilege that matters is `CREATE` on the **database**, and the deployment that trips over it
+>   is not an exotic one: `GRANT CREATE ON SCHEMA app TO app_role` with nothing on the database is a
+>   role that creates every table, index, function and trigger in `ensure-schema.sql` and fails on this
+>   single statement. Since §2's fix made the scripts one transaction, that failure rolls the whole
+>   schema back — the store does not start, having created nothing, on a bare "permission denied".
+> - The per-prefix schema advisory lock from §2 does **not** serialize this statement, because an
+>   extension is database-scoped. Two stores with different prefixes starting together on a database
+>   without `btree_gin` race on `pg_extension_name_index` — the same class of catalog race §2 fixed for
+>   tables, reproduced here as `duplicate key value violates unique constraint "pg_extension_name_index"`.
+>
+> `ensure-schema.sql` now pre-checks `pg_extension` (so the installed case issues no DDL at all and
+> logs no `NOTICE`, which is the "split it out" ask above), swallows `duplicate_object` /
+> `unique_violation` as a concurrent installer, and turns `insufficient_privilege` into an error naming
+> both remedies. `PostgresBtreeGinPrivilegeTest` covers all of it; the postgres README carries the
+> privilege table. A `VALIDATE`/`NONE` app still issues no DDL, as before.
+
 For the split deployment (app runs `NONE` or `VALIDATE`, a DBA applies DDL) the mechanism must emit
 its steps as a script a DBA can apply. The project already has exactly this wiring: the
 `quickstart.ddl.sql` DBA script is **generated at build time** from `ensure-schema.sql` by the

--- a/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
@@ -86,7 +86,50 @@ CREATE TABLE IF NOT EXISTS events (
 	-- btree_gin extension to index the scalar stream columns alongside the tag array.
 	-- NB: GIN cannot serve ORDER BY event_position, so the B-tree indexes are kept for
 	-- ordered stream replay; this index is additive, for stream-scoped tag lookups.
-	CREATE EXTENSION IF NOT EXISTS btree_gin;
+	--
+	-- Guarded rather than a bare CREATE EXTENSION IF NOT EXISTS. Both reasons concern only the very
+	-- first start against a database that does not have the extension yet -- afterwards this is a
+	-- catalog read that issues no DDL at all -- but on that first start the whole script is one
+	-- transaction, so a failure here rolls the entire schema back and the store does not come up.
+	--
+	-- Privileges. btree_gin is trusted (since PostgreSQL 13), so no superuser is needed -- but
+	-- installing it requires CREATE on the *database*, which is a different privilege from CREATE on
+	-- the schema. The ordinary locked-down setup (GRANT CREATE ON SCHEMA app TO app_role, nothing on
+	-- the database) is therefore a role that creates every other object in this script and fails on
+	-- this one statement, with a bare "permission denied to create extension" as the only clue. The
+	-- pre-check is what makes the DBA-installs-it-once split work: an unprivileged role runs this
+	-- script forever after without touching the extension. The handler makes the remaining case name
+	-- its two remedies instead of leaving them to be deduced.
+	--
+	-- Concurrency. An extension is database-scoped, while the schema advisory lock the caller holds is
+	-- keyed on the table prefix -- so two stores with *different* prefixes starting together are not
+	-- serialized against each other here, and race on pg_extension_name_index exactly as the tables
+	-- used to race on pg_type_typname_nsp_index before that lock existed. duplicate_object (the
+	-- extension appeared between the check and the CREATE) and unique_violation (the raw catalog
+	-- conflict) both mean the same harmless thing: someone else has just installed it. By the time
+	-- either surfaces the winner has committed -- a conflicting catalog insert blocks until it does --
+	-- so the opclasses the index below needs are visible to this transaction.
+	DO $ext$ BEGIN
+	  IF NOT EXISTS ( SELECT 1 FROM pg_extension WHERE extname = 'btree_gin' ) THEN
+	    BEGIN
+	      CREATE EXTENSION btree_gin;
+	    EXCEPTION
+	      WHEN duplicate_object OR unique_violation THEN
+	        NULL;
+	      WHEN insufficient_privilege THEN
+	        RAISE EXCEPTION 'The eventstore requires the btree_gin extension, and this role may not create it'
+	          USING ERRCODE = 'insufficient_privilege',
+	                DETAIL  = 'btree_gin is a trusted extension, so no superuser is involved, but creating it '
+	                          'requires CREATE on the current database -- a different privilege from CREATE on '
+	                          'the schema. That is why this role can create every other object in the event '
+	                          'store schema and not this one. It is needed for the combined stream+tags GIN '
+	                          'index, which schema validation requires.',
+	                HINT    = 'Either have a DBA run "CREATE EXTENSION btree_gin;" in this database once, after '
+	                          'which this schema script needs no extra privilege at any later start, or grant '
+	                          'the privilege with "GRANT CREATE ON DATABASE <database> TO <role>;".';
+	    END;
+	  END IF;
+	END $ext$;
 	CREATE INDEX IF NOT EXISTS idx_events_stream_tags ON events USING GIN (
 	    stream_context,
 	    stream_purpose,

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
@@ -86,7 +86,50 @@ CREATE TABLE IF NOT EXISTS PREFIX_events (
 	-- btree_gin extension to index the scalar stream columns alongside the tag array.
 	-- NB: GIN cannot serve ORDER BY event_position, so the B-tree indexes are kept for
 	-- ordered stream replay; this index is additive, for stream-scoped tag lookups.
-	CREATE EXTENSION IF NOT EXISTS btree_gin;
+	--
+	-- Guarded rather than a bare CREATE EXTENSION IF NOT EXISTS. Both reasons concern only the very
+	-- first start against a database that does not have the extension yet -- afterwards this is a
+	-- catalog read that issues no DDL at all -- but on that first start the whole script is one
+	-- transaction, so a failure here rolls the entire schema back and the store does not come up.
+	--
+	-- Privileges. btree_gin is trusted (since PostgreSQL 13), so no superuser is needed -- but
+	-- installing it requires CREATE on the *database*, which is a different privilege from CREATE on
+	-- the schema. The ordinary locked-down setup (GRANT CREATE ON SCHEMA app TO app_role, nothing on
+	-- the database) is therefore a role that creates every other object in this script and fails on
+	-- this one statement, with a bare "permission denied to create extension" as the only clue. The
+	-- pre-check is what makes the DBA-installs-it-once split work: an unprivileged role runs this
+	-- script forever after without touching the extension. The handler makes the remaining case name
+	-- its two remedies instead of leaving them to be deduced.
+	--
+	-- Concurrency. An extension is database-scoped, while the schema advisory lock the caller holds is
+	-- keyed on the table prefix -- so two stores with *different* prefixes starting together are not
+	-- serialized against each other here, and race on pg_extension_name_index exactly as the tables
+	-- used to race on pg_type_typname_nsp_index before that lock existed. duplicate_object (the
+	-- extension appeared between the check and the CREATE) and unique_violation (the raw catalog
+	-- conflict) both mean the same harmless thing: someone else has just installed it. By the time
+	-- either surfaces the winner has committed -- a conflicting catalog insert blocks until it does --
+	-- so the opclasses the index below needs are visible to this transaction.
+	DO $ext$ BEGIN
+	  IF NOT EXISTS ( SELECT 1 FROM pg_extension WHERE extname = 'btree_gin' ) THEN
+	    BEGIN
+	      CREATE EXTENSION btree_gin;
+	    EXCEPTION
+	      WHEN duplicate_object OR unique_violation THEN
+	        NULL;
+	      WHEN insufficient_privilege THEN
+	        RAISE EXCEPTION 'The eventstore requires the btree_gin extension, and this role may not create it'
+	          USING ERRCODE = 'insufficient_privilege',
+	                DETAIL  = 'btree_gin is a trusted extension, so no superuser is involved, but creating it '
+	                          'requires CREATE on the current database -- a different privilege from CREATE on '
+	                          'the schema. That is why this role can create every other object in the event '
+	                          'store schema and not this one. It is needed for the combined stream+tags GIN '
+	                          'index, which schema validation requires.',
+	                HINT    = 'Either have a DBA run "CREATE EXTENSION btree_gin;" in this database once, after '
+	                          'which this schema script needs no extra privilege at any later start, or grant '
+	                          'the privilege with "GRANT CREATE ON DATABASE <database> TO <role>;".';
+	    END;
+	  END IF;
+	END $ext$;
 	CREATE INDEX IF NOT EXISTS PREFIX_idx_events_stream_tags ON PREFIX_events USING GIN (
 	    stream_context,
 	    stream_purpose,

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresBtreeGinPrivilegeTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/PostgresBtreeGinPrivilegeTest.java
@@ -1,0 +1,374 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PSQLException;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.spi.EventStorage;
+import org.sliceworkz.eventstore.spi.EventStorageException;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * What the {@code btree_gin} line in {@code ensure-schema.sql} does to a role that is not allowed to
+ * create an extension — and to two stores that try to create it at the same moment.
+ * <p>
+ * The extension is needed for {@code idx_events_stream_tags}, the combined stream+tags GIN index that
+ * schema validation requires. It is <em>trusted</em>, so no superuser is involved, but installing it
+ * requires {@code CREATE} on the <em>database</em> — a different privilege from {@code CREATE} on the
+ * schema. The ordinary locked-down deployment grants the latter and not the former, which used to make
+ * the store fail to start on a bare {@code permission denied to create extension}: the whole script is
+ * one transaction, so the entire schema rolled back with it, and the remedy had to be deduced from a
+ * message that named none.
+ * <p>
+ * The scenarios here pin down the deployment shapes that must keep working, and the two that were
+ * broken:
+ * <ul>
+ *   <li>a DBA installs the extension once and the application role, which may not create one, starts
+ *       against it forever after — the pre-check means the extension statement never runs at all;</li>
+ *   <li>when it genuinely cannot be installed, the failure names both remedies;</li>
+ *   <li>two stores with different table prefixes starting together no longer race each other on
+ *       {@code pg_extension_name_index} — the schema advisory lock is keyed on the prefix, and an
+ *       extension is database-scoped, so that lock does not serialize them here;</li>
+ *   <li>an extension installed into a schema of its own — the convention on several managed
+ *       offerings — still serves the index, even without {@code USAGE} on that schema.</li>
+ * </ul>
+ * <p>
+ * Each scenario works in a database of its own. The shared {@code integration-tests-db} carries the
+ * schemas of every other test in the JVM, and an extension is database-scoped: dropping
+ * {@code btree_gin} there would take their combined index with it.
+ */
+public class PostgresBtreeGinPrivilegeTest {
+
+	private static final String PASSWORD = "pwd";
+
+	abstract static class Tests {
+
+		final String image;
+
+		Tests ( String image ) {
+			this.image = image;
+		}
+
+		/**
+		 * The deployment the documentation recommends: a DBA installs the extension once, the
+		 * application role may not create one, and every start from then on works.
+		 * <p>
+		 * This works because PostgreSQL's {@code IF NOT EXISTS} short-circuit precedes its privilege
+		 * check — and because the script now pre-checks {@code pg_extension} and does not issue the
+		 * statement at all. The second start asserts the property that matters operationally: this is
+		 * not a one-off blessing of a fresh database, it is every restart of every instance.
+		 */
+		@Test
+		public void testUnprivilegedRoleStartsWhenTheExtensionIsAlreadyInstalled ( ) throws Exception {
+			String database = "btreegin_preinstalled";
+			String role = "btreegin_preinstalled_role";
+			String prefix = "bgpre_";
+
+			createUnprivilegedRoleAndDatabase(database, role);
+			PostgresContainer.asSuperuserIn(image, database, statement ->
+				statement.execute("CREATE EXTENSION btree_gin"));
+
+			try ( HikariDataSource dataSource = appDataSource(database, role) ) {
+				ensure(prefix, dataSource, "first-start").close();
+
+				assertTrue(indexExists(dataSource, prefix + "idx_events_stream_tags"),
+					"the unprivileged role created the combined stream+tags index against the pre-installed extension");
+
+				// the ordinary restart: still no privilege, still fine
+				ensure(prefix, dataSource, "second-start").close();
+			}
+		}
+
+		/**
+		 * When the extension is genuinely absent and the role genuinely cannot create it, the failure
+		 * names the two ways out instead of leaving them to be deduced.
+		 * <p>
+		 * The second assertion is the one that explains why this matters more than an unhelpful message:
+		 * the script is a single transaction, so this does not degrade to "the store starts without one
+		 * index" — nothing at all is created and the store does not come up.
+		 */
+		@Test
+		public void testUncreatableExtensionFailsWithAnActionableError ( ) throws Exception {
+			String database = "btreegin_denied";
+			String role = "btreegin_denied_role";
+			String prefix = "bgdenied_";
+
+			createUnprivilegedRoleAndDatabase(database, role);
+
+			try ( HikariDataSource dataSource = appDataSource(database, role) ) {
+				EventStorageException thrown = assertThrows(EventStorageException.class,
+					() -> ensure(prefix, dataSource, "denied"));
+
+				String reported = report(thrown);
+				assertTrue(reported.contains("btree_gin"),
+					"the failure names the extension, got: " + reported);
+				assertTrue(reported.contains("CREATE EXTENSION btree_gin"),
+					"the failure offers the DBA-installs-it-once remedy, got: " + reported);
+				assertTrue(reported.contains("GRANT CREATE ON DATABASE"),
+					"the failure offers the grant-the-privilege remedy, got: " + reported);
+
+				assertEquals(0, relationsWithPrefix(dataSource, prefix),
+					"the script is one transaction: a schema half-created here would be worse than none");
+			}
+		}
+
+		/**
+		 * Two stores with different table prefixes, starting together against a database that does not
+		 * have the extension yet, both come up.
+		 * <p>
+		 * They are <em>not</em> serialized against each other: the schema advisory lock is keyed on the
+		 * table prefix, while an extension is database-scoped, so this is the same catalog race the
+		 * tables used to lose on {@code pg_type_typname_nsp_index} before that lock existed — 64 of 80
+		 * instances failed to start, then. The loser's whole transaction rolls back, so it is not a
+		 * missing index, it is an instance that does not boot.
+		 * <p>
+		 * Whether the race is actually joined on a given run is a matter of timing, so this is a
+		 * regression guard rather than a proof: it fails most of the time against a bare
+		 * {@code CREATE EXTENSION IF NOT EXISTS}, and never against the guarded block.
+		 */
+		@Test
+		public void testConcurrentStartsUnderDifferentPrefixesDoNotRaceOnTheExtension ( ) throws Exception {
+			String database = "btreegin_concurrent";
+			String role = "btreegin_concurrent_role";
+			int instances = 6;
+
+			createUnprivilegedRoleAndDatabase(database, role);
+			// this role may create the extension -- the race is between equals, not a privilege problem
+			PostgresContainer.asSuperuser(image, statement ->
+				statement.execute("GRANT CREATE ON DATABASE " + database + " TO " + role));
+
+			List<HikariDataSource> pools = new ArrayList<>();
+			List<EventStorage> started = new ArrayList<>();
+			AtomicReference<Exception> failure = new AtomicReference<>();
+			CountDownLatch startGate = new CountDownLatch(1);
+			CountDownLatch finished = new CountDownLatch(instances);
+			ExecutorService executor = Executors.newFixedThreadPool(instances);
+
+			try {
+				for ( int i = 0; i < instances; i++ ) {
+					// a pool per instance, as separate application instances would have -- one shared pool
+					// would have to hold two monitor connections per store on top of the schema work
+					HikariDataSource dataSource = appDataSource(database, role);
+					pools.add(dataSource);
+					String prefix = "bgconc" + i + "_";
+					executor.submit(() -> {
+						try {
+							startGate.await();
+							EventStorage storage = ensure(prefix, dataSource, "concurrent-" + prefix);
+							synchronized ( started ) {
+								started.add(storage);
+							}
+						} catch (Exception e) {
+							failure.compareAndSet(null, e);
+						} finally {
+							finished.countDown();
+						}
+					});
+				}
+
+				startGate.countDown();
+				assertTrue(finished.await(120, TimeUnit.SECONDS), "all instances finished starting");
+
+				if ( failure.get() != null ) {
+					throw new AssertionError("an instance failed to start: " + report(failure.get()), failure.get());
+				}
+				assertEquals(instances, started.size(), "every instance started");
+
+				try ( HikariDataSource dataSource = appDataSource(database, role) ) {
+					for ( int i = 0; i < instances; i++ ) {
+						assertTrue(indexExists(dataSource, "bgconc" + i + "_idx_events_stream_tags"),
+							"instance " + i + " created its combined stream+tags index, so it saw the extension "
+								+ "whether it installed it or lost the race for it");
+					}
+				}
+			} finally {
+				executor.shutdownNow();
+				started.forEach(EventStorage::close);
+				pools.forEach(HikariDataSource::close);
+			}
+		}
+
+		/**
+		 * An extension installed into a schema of its own — the convention on several managed offerings
+		 * — still serves the index.
+		 * <p>
+		 * Worth pinning rather than assuming: the index below names no operator class, so it depends on
+		 * PostgreSQL resolving the <em>default</em> GIN opclass for {@code text}, and that resolution is
+		 * not filtered by {@code search_path}. The application role here has neither the schema on its
+		 * {@code search_path} nor {@code USAGE} on it, and the index is still created.
+		 */
+		@Test
+		public void testExtensionInItsOwnSchemaStillServesTheIndex ( ) throws Exception {
+			String database = "btreegin_ownschema";
+			String role = "btreegin_ownschema_role";
+			String prefix = "bgschema_";
+
+			createUnprivilegedRoleAndDatabase(database, role);
+			PostgresContainer.asSuperuserIn(image, database, statement -> {
+				statement.execute("CREATE SCHEMA extensions");
+				statement.execute("CREATE EXTENSION btree_gin SCHEMA extensions");
+			});
+
+			try ( HikariDataSource dataSource = appDataSource(database, role) ) {
+				ensure(prefix, dataSource, "own-schema").close();
+
+				assertTrue(indexExists(dataSource, prefix + "idx_events_stream_tags"),
+					"the combined index resolves btree_gin's opclasses from another schema");
+			}
+		}
+
+		// ---------------------------------------------------------------- helpers
+
+		/**
+		 * A database of this test's own, and a role that may create everything in its schema and no
+		 * extension: {@code CREATE} on the schema, nothing on the database.
+		 */
+		private void createUnprivilegedRoleAndDatabase ( String database, String role ) throws SQLException {
+			// database first: a role cannot be dropped while it still owns objects anywhere in the cluster
+			PostgresContainer.createDatabase(image, database);
+			PostgresContainer.createRole(image, role, PASSWORD);
+			PostgresContainer.asSuperuserIn(image, database, statement ->
+				statement.execute("GRANT CREATE, USAGE ON SCHEMA public TO " + role));
+		}
+
+		private HikariDataSource appDataSource ( String database, String role ) {
+			return PostgresContainer.dataSource(image, database, role, PASSWORD);
+		}
+
+		private EventStorage ensure ( String prefix, DataSource dataSource, String name ) {
+			return PostgresEventStorage.newBuilder()
+				.name(name).prefix(prefix).dataSource(dataSource)
+				.ensureDatabase().build();
+		}
+
+		/**
+		 * Everything the operator gets to read: the exception chain's messages, plus the DETAIL and HINT
+		 * the server attached, which is where the remedies live.
+		 */
+		private String report ( Throwable thrown ) {
+			StringBuilder reported = new StringBuilder();
+			for ( Throwable t = thrown; t != null; t = t.getCause() ) {
+				reported.append(t.getMessage()).append('\n');
+				if ( t instanceof PSQLException psql && psql.getServerErrorMessage() != null ) {
+					reported.append(psql.getServerErrorMessage().getDetail()).append('\n')
+							.append(psql.getServerErrorMessage().getHint()).append('\n');
+				}
+			}
+			return reported.toString();
+		}
+
+		private boolean indexExists ( DataSource dataSource, String indexName ) throws SQLException {
+			return queryString(dataSource,
+				"SELECT indexname FROM pg_indexes WHERE schemaname = current_schema() AND indexname = '"
+					+ indexName + "'") != null;
+		}
+
+		private int relationsWithPrefix ( DataSource dataSource, String prefix ) throws SQLException {
+			return Integer.parseInt(queryString(dataSource,
+				"SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+					+ "WHERE n.nspname = current_schema() AND c.relname LIKE '" + prefix + "%'"));
+		}
+
+		private String queryString ( DataSource dataSource, String sql ) throws SQLException {
+			try ( Connection connection = dataSource.getConnection();
+				  Statement statement = connection.createStatement();
+				  ResultSet rs = statement.executeQuery(sql) ) {
+				return rs.next() ? rs.getString(1) : null;
+			}
+		}
+	}
+
+	/**
+	 * The oldest supported major version. Trusted extensions arrived in PostgreSQL 13, so the floor is
+	 * the version where this behaviour is least safe to assume.
+	 */
+	@Nested
+	class OnPostgres16 extends Tests {
+
+		OnPostgres16 ( ) { super(PostgresContainer.IMAGE_PG16); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG16);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG16);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG16);
+		}
+	}
+
+	@Nested
+	class OnPostgres17 extends Tests {
+
+		OnPostgres17 ( ) { super(PostgresContainer.IMAGE_PG17); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG17);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG17);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG17);
+		}
+	}
+
+	@Nested
+	class OnPostgres18 extends Tests {
+
+		OnPostgres18 ( ) { super(PostgresContainer.IMAGE_PG18); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG18);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG18);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18);
+		}
+	}
+
+}

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
@@ -25,6 +25,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -78,10 +79,7 @@ public class PostgresContainer {
 	}
 
 	public static DataSource dataSource ( String image ) {
-		PostgreSQLContainer container = CONTAINERS.get(image);
-		if ( container == null ) {
-			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
-		}
+		PostgreSQLContainer container = container(image);
 		HikariConfig config = new HikariConfig();
 		config.setUsername(container.getUsername());
 		config.setPassword(container.getPassword());
@@ -99,6 +97,96 @@ public class PostgresContainer {
 		if ( dataSource != null && !dataSource.isClosed() ) {
 			dataSource.close();
 		}
+	}
+
+	/**
+	 * A pool for another database and another role in the same container, <em>not</em> tracked in the
+	 * per-image slot {@link #dataSource(String)} uses — the caller closes what it gets.
+	 * <p>
+	 * Needed by tests that manipulate database-scoped state, an installed extension above all: the
+	 * shared {@code integration-tests-db} carries the schemas of every other test in the JVM, and
+	 * dropping {@code btree_gin} there would take their combined stream+tags index with it. Such a test
+	 * creates its own database with {@link #createDatabase} and works in there.
+	 *
+	 * @param image    the container to connect to
+	 * @param database a database in that container, e.g. one made by {@link #createDatabase}
+	 * @param username the role to connect as, e.g. one made by {@link #createRole}
+	 * @param password that role's password
+	 * @return a pool the caller is responsible for closing
+	 */
+	public static HikariDataSource dataSource ( String image, String database, String username, String password ) {
+		HikariConfig config = new HikariConfig();
+		config.setUsername(username);
+		config.setPassword(password);
+		config.setJdbcUrl(jdbcUrl(image, database));
+		return new HikariDataSource(config);
+	}
+
+	/** JDBC url for another database in the given container, as the superuser's url minus its database. */
+	public static String jdbcUrl ( String image, String database ) {
+		return "jdbc:postgresql://" + container(image).getHost() + ":"
+			+ container(image).getFirstMappedPort() + "/" + database;
+	}
+
+	/**
+	 * Creates a database in the given container, dropping any leftover of the same name first.
+	 * <p>
+	 * {@code CREATE DATABASE} cannot run inside a transaction block, so this deliberately uses a plain
+	 * autocommit connection rather than going through a pool with a transaction on it.
+	 */
+	public static void createDatabase ( String image, String database ) throws SQLException {
+		asSuperuser(image, statement -> {
+			statement.execute("DROP DATABASE IF EXISTS " + database);
+			statement.execute("CREATE DATABASE " + database);
+		});
+	}
+
+	/**
+	 * Creates a login role, dropping any leftover of the same name first. Roles are cluster-wide, so
+	 * the name has to be unique across every test sharing a container, not just within a database.
+	 */
+	public static void createRole ( String image, String role, String password ) throws SQLException {
+		asSuperuser(image, statement -> {
+			statement.execute("DROP ROLE IF EXISTS " + role);
+			statement.execute("CREATE ROLE " + role + " LOGIN PASSWORD '" + password + "'");
+		});
+	}
+
+	/** Runs statements as the container's superuser, against its default database. */
+	public static void asSuperuser ( String image, SqlWork work ) throws SQLException {
+		asSuperuser(image, container(image).getJdbcUrl(), work);
+	}
+
+	/**
+	 * Runs statements as the container's superuser, against a named database — schema-level and
+	 * extension-level work has to happen inside the database it concerns, unlike a {@code GRANT} on the
+	 * database itself, which can be issued from anywhere in the cluster.
+	 */
+	public static void asSuperuserIn ( String image, String database, SqlWork work ) throws SQLException {
+		asSuperuser(image, jdbcUrl(image, database), work);
+	}
+
+	private static void asSuperuser ( String image, String url, SqlWork work ) throws SQLException {
+		PostgreSQLContainer container = container(image);
+		try ( Connection connection = DriverManager.getConnection(
+					url, container.getUsername(), container.getPassword());
+			  Statement statement = connection.createStatement() ) {
+			work.run(statement);
+		}
+	}
+
+	/** Statements to run on a connection this helper owns. */
+	@FunctionalInterface
+	public interface SqlWork {
+		void run ( Statement statement ) throws SQLException;
+	}
+
+	private static PostgreSQLContainer container ( String image ) {
+		PostgreSQLContainer container = CONTAINERS.get(image);
+		if ( container == null ) {
+			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
+		}
+		return container;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Hardens the `btree_gin` extension creation in schema initialization scripts to handle privilege constraints and concurrent installation attempts. The extension is required for the combined stream+tags GIN index but needs `CREATE` on the *database* — a different privilege from `CREATE` on the schema. This change ensures the store starts reliably across different deployment configurations.

## Key Changes

- **Schema script hardening** (`ensure-schema.sql` and `quickstart.ddl.sql`):
  - Replaced bare `CREATE EXTENSION IF NOT EXISTS btree_gin` with a guarded `DO` block
  - Pre-checks `pg_extension` catalog to skip the statement entirely when extension exists (avoiding privilege checks on subsequent starts)
  - Catches `duplicate_object` and `unique_violation` exceptions to handle concurrent installation races between stores with different table prefixes
  - Catches `insufficient_privilege` and raises a detailed exception naming both remedies: DBA-installs-once or grant `CREATE ON DATABASE`
  - Detailed comments explaining privilege model, concurrency behavior, and deployment options

- **Test infrastructure** (`PostgresContainer.java`):
  - Added `dataSource(image, database, username, password)` for creating pools against arbitrary databases and roles
  - Added `createDatabase(image, database)` to create isolated test databases
  - Added `createRole(image, role, password)` to create test roles with specific privileges
  - Added `asSuperuser()` and `asSuperuserIn()` helpers for running DDL as superuser
  - Added `SqlWork` functional interface for statement execution
  - Refactored common container lookup into `container()` helper

- **Comprehensive test suite** (`PostgresBtreeGinPrivilegeTest.java`):
  - Tests the recommended DBA-installs-once deployment: unprivileged role starts against pre-installed extension
  - Tests failure case: unprivileged role gets actionable error naming both remedies
  - Tests concurrent starts: multiple stores with different prefixes starting together both succeed (regression guard for catalog race)
  - Tests extension in separate schema: index creation works even without `USAGE` on the extension's schema
  - Runs against PostgreSQL 16, 17, and 18 (oldest supported major version through latest)

- **Documentation** (`README.md` and `CLAUDE.md`):
  - Added "Database privileges" section explaining what each `DatabaseInitMode` requires
  - Clarified the distinction between `CREATE` on schema vs. database
  - Documented both deployment paths and how to verify privileges before deployment
  - Updated project overview to reflect the guarded extension creation and privilege model

## Notable Implementation Details

- The pre-check (`IF NOT EXISTS ... SELECT FROM pg_extension`) is what makes the DBA-installs-once split work: an unprivileged role runs the script indefinitely without touching the extension after the first start
- The exception handler catches both `duplicate_object` (extension appeared between check and CREATE) and `unique_violation` (raw catalog conflict), both harmless when concurrent stores race
- The schema advisory lock (keyed on table prefix) does *not* serialize extension creation (database-scoped), so the race is real and must be handled
- Extension placement is flexible: `CREATE EXTENSION btree_gin SCHEMA extensions` works fine, and the application role needs no `USAGE` on that schema
- Each test scenario uses its own database to avoid interfering with the shared `integration-tests-db` that other tests depend on

https://claude.ai/code/session_011JT7QDMGCf4VYgzdWkEtg4