### PR TITLE
Remove Loki logging integration from benchmark module

### DIFF
--- a/sliceworkz-eventstore-benchmark/pom.xml
+++ b/sliceworkz-eventstore-benchmark/pom.xml
@@ -41,8 +41,7 @@
 		
 		<javalin.version>7.2.2</javalin.version>
 		<logback.version>1.6.1</logback.version>
-		<loki-logback.version>2.1.0</loki-logback.version>
-		
+
 	</properties>
 	
 	<dependencies>
@@ -74,12 +73,7 @@
 			<artifactId>logback-classic</artifactId>
 			<version>${logback.version}</version>
 		</dependency>
-	    <dependency>
-	        <groupId>com.github.loki4j</groupId>
-	        <artifactId>loki-logback-appender</artifactId>
-	        <version>${loki-logback.version}</version>
-	    </dependency>
-	    
+
 		<dependency>
 		    <groupId>org.postgresql</groupId>
 		    <artifactId>postgresql</artifactId>

--- a/sliceworkz-eventstore-benchmark/src/main/resources/logback.xml
+++ b/sliceworkz-eventstore-benchmark/src/main/resources/logback.xml
@@ -20,26 +20,6 @@
 -->
 <configuration>
 
-    <!-- loki appender -->
-    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>http://localhost:3100/loki/api/v1/push</url>
-	        <!--<useProtobufApi>true</useProtobufApi>-->
-        </http>
-            <labels>
-            	app=eventstore-benchmark
-            </labels>
-            <message>
-                <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
-            </message>
-        <structuredMetadata>off</structuredMetadata>
-	    <batch>
-	        <!--<maxItems>1</maxItems>-->
-	        <timeoutMs>1000</timeoutMs>
-	    </batch>
-	    <verbose>true</verbose>
-    </appender>
-    
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
@@ -55,11 +35,6 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <!-- ENABLE THIS TO SEND LOGFILES TO LOKI (RUN VIA `docker compose up`) 
-        <appender-ref ref="LOKI"/>
-        -->
-    </root>  
-    
-    <logger name="com.github.loki4j" level="WARN"/>
+    </root>
 
 </configuration>


### PR DESCRIPTION
## Summary
Removes the Loki4j logging appender configuration and dependency from the eventstore-benchmark module. This simplifies the logging setup by removing the optional distributed logging capability that was not actively used.

## Changes
- **logback.xml**: Removed the entire Loki appender configuration block, including HTTP endpoint setup, labels, message patterns, and batch settings
- **logback.xml**: Removed commented-out Loki appender reference from the root logger and the Loki logger level configuration
- **pom.xml**: Removed the `loki-logback.version` property definition
- **pom.xml**: Removed the `loki-logback-appender` dependency

## Details
The benchmark module now uses only the console appender for logging, reducing external dependencies and simplifying the logging configuration. The Loki integration was previously optional (commented out) and required Docker Compose to be running, making it an unnecessary dependency for the core benchmark functionality.

https://claude.ai/code/session_01NKMCrqqcnhpcCvXJbFEw1e