### PR TITLE
Add typed exceptions for serialization and deserialization failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,67 @@ still raises.
 timestamp directly into a store — useful for fixtures, but it bypasses `append()` and everything that path
 guarantees.
 
+### When a payload cannot be converted
+
+The serde layer throws two named types, both unchecked, both in the **api** module
+(`org.sliceworkz.eventstore.events`) so a caller never imports from `...impl.serde` to catch one. It used to
+throw a bare `RuntimeException` in fourteen places, several with no message of their own and two with no
+cause, which left "the event cannot be read" and "the database is down" distinguishable only by matching on
+message text.
+
+- **`EventSerializationException`** — from `append`, for a payload that cannot be written. Nothing is stored.
+- **`EventDeserializationException`** — for a stored event this stream's type mappings cannot read. Carries
+  `getEventType()` (the name in *storage*, which is not necessarily a type any current class claims) and
+  `getReference()`.
+
+**Neither is ever worth retrying, and that is the whole point of the split.** A failure to convert a payload
+is a property of the payload and the mappings, identical on the next attempt and on every other instance; an
+`EventStorageException` from the same call may be a dropped connection. A retry loop that cannot tell them
+apart either retries forever on a poison event or gives up on a blip.
+
+- **A deserialization failure is a poison event, not a broken store.** The storage read *succeeded*. The
+  realistic causes are configuration and history rather than bugs: a stream opened without the root class
+  covering a stored type, a record that has since lost a component the stored JSON still carries
+  (`FAIL_ON_UNKNOWN_PROPERTIES` is enabled deliberately), a renamed event class, or an `@Upcast` throwing on
+  legacy data that does not satisfy a current validation rule.
+- **`getReference()` is what makes the type useful rather than merely tidy.** The serde is handed a type name
+  and two JSON strings and cannot say *which* stored event failed, so `EventStreamImpl.enrich` attaches the
+  reference on the way out (`withReference`, which carries message, cause and stack trace over). Its `id()`
+  goes to `getEventById` on a **raw** stream — one with no mappings has nothing to fail on — so the stored
+  JSON can be read even though the typed stream chokes on it.
+- **Through a `Projector` the type is the *only* signal.** `run()` wraps everything it catches in
+  `ProjectorException`, so a dropped connection and an unreadable event arrive identically; `getCause()`
+  being an `EventDeserializationException` is what separates them. Careful:
+  `ProjectorException.getEventReference()` is the last event *handled*, and the offending event never
+  reached the projection — `EventDeserializationException.getReference()` is the one that names it.
+- **Deserialization is lazy, so it surfaces from the caller's terminal operation**, not from `query()`.
+  `getEventById` is eager and throws directly. `append` deserializes the events it just wrote in order to
+  return them, so a payload that serializes but cannot be read back fails *there*, as a deserialization
+  failure, with the event already stored.
+
+**Misconfiguration is `IllegalArgumentException`, not a serde type.** A `@LegacyEvent` on a class registered
+as current, a current class registered as legacy, and an upcaster that cannot be instantiated are all
+properties of the `Class` handed to `getEventStream`; they fail at stream creation, before anything is read
+or written, and there is no recovery but to fix the code. Two checks in the same method were already typed
+that way (duplicate event name, non-sealed interface), so this is consistency rather than new surface. The
+messages now name the upcaster *and* the event class and keep the reflective cause — a bare
+`RuntimeException(NoSuchMethodException)` said neither.
+
+**Why there is no common root for everything the library throws.** A root only pays for itself if catching
+"anything from this library" is useful, and it is not: the failures need opposite responses
+(`OptimisticLockingException` → retry immediately; `EventStorageException` → retry with backoff; serde →
+never), so a root would mostly encourage the broad catch this split exists to avoid. It would also be
+incomplete — the registration failures are `IllegalArgumentException` and would sit outside it — and
+reparenting `OptimisticLockingException` and `ProjectorException`, which callers already catch by name, is a
+change to load-bearing public API for no demonstrated caller. The two types here extend `RuntimeException`
+directly and nothing depends on that, so a root stays cheap to add if a caller ever turns up who needs one.
+
+`SerdeFailureTest` in the TCK pins all of this down per backend: the reference that comes back really does
+identify the offending stored event (it is fetched again in raw mode), an upcaster that throws is reported as
+an upcaster rather than as a parse failure, and the exception is wrapped exactly once — the typed serde used
+to catch its own exception and re-wrap it, so the message naming the missing type only ever reached a user as
+the cause of a second, vaguer one.
+
 ## Testing
 
 Testing support lives in **`sliceworkz-eventstore-testing`**, a published module (compile scope; add

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventDeserializationException.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventDeserializationException.java
@@ -1,0 +1,169 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.events;
+
+import java.util.Optional;
+
+/**
+ * Thrown when a stored event cannot be read back through the event types a stream was opened with.
+ *
+ * <h2>What it means, and what it does not</h2>
+ * <strong>This is a poison event, not a broken store.</strong> The storage read succeeded — the row is
+ * there, and the bytes came back. What failed is the conversion of one event's payload into a domain
+ * object, which makes it a property of that event plus this stream's type mappings. Reading it again
+ * changes nothing, and neither does reading it from another instance: <strong>it is never worth
+ * retrying.</strong> A {@link org.sliceworkz.eventstore.spi.EventStorageException} from the same call
+ * may well be transient and is worth retrying, and that distinction is the reason this type exists.
+ * <p>
+ * It is also not necessarily a bug. The realistic causes are configuration and history:
+ * <ul>
+ *   <li>the stream was opened without the event root class that covers this stored type, so nothing
+ *       knows how to read it — {@code getEventType()} names the type that has no mapping;</li>
+ *   <li>the record has since lost a component the stored JSON still carries (the store enables
+ *       {@code FAIL_ON_UNKNOWN_PROPERTIES} deliberately), or an event class was renamed, so the old
+ *       name has no current class — see "Event type names are wire format" in the project docs;</li>
+ *   <li>an {@link Upcast} threw on legacy data that does not satisfy a current validation rule.</li>
+ * </ul>
+ *
+ * <h2>Where it surfaces</h2>
+ * Deserialization is lazy: it happens as the {@link java.util.stream.Stream} returned by
+ * {@code query()} is consumed, so this is thrown from the caller's terminal operation, not from
+ * {@code query()} itself. It also surfaces from
+ * {@link org.sliceworkz.eventstore.stream.EventSink#append} (which reads the appended events back) and
+ * from {@link org.sliceworkz.eventstore.stream.EventSource#getEventById}.
+ * <p>
+ * Through a {@link org.sliceworkz.eventstore.projection.Projector} it arrives wrapped: {@code run()}
+ * throws {@link org.sliceworkz.eventstore.projection.ProjectorException}, whose {@code getCause()} is
+ * this exception. Note that
+ * {@link org.sliceworkz.eventstore.projection.ProjectorException#getEventReference()} then names the
+ * last event the projection successfully <em>handled</em> — the offending event never reached it, so it
+ * cannot be the one reported there. {@link #getReference()} is what names the event that failed.
+ *
+ * <h2>Handling: skipping a poison event</h2>
+ * <pre>{@code
+ * try {
+ *     projector.run();
+ * } catch (ProjectorException e) {
+ *     if ( e.getCause() instanceof EventDeserializationException poison ) {
+ *         EventReference ref = poison.getReference().orElseThrow();
+ *         deadLetter(ref, poison.getEventType());
+ *         // resume past it: a projector's position is set at build time
+ *         projector = Projector.from(stream).towards(projection).startingAfter(ref).build();
+ *     }
+ * }
+ * }</pre>
+ * {@link #getReference()} carries an {@link EventReference}, whose {@link EventReference#id()} can be
+ * handed to {@link org.sliceworkz.eventstore.stream.EventSource#getEventById} on a stream opened in raw
+ * mode ({@code eventStore.getEventStream(EventStreamId.anyContext())}) to inspect the stored JSON
+ * without needing a mapping for it.
+ *
+ * @see EventSerializationException
+ * @see org.sliceworkz.eventstore.spi.EventStorageException
+ */
+public class EventDeserializationException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final transient EventType eventType;
+	private final transient EventReference reference;
+
+	/**
+	 * Constructs a new EventDeserializationException for the given stored event type, with no reference.
+	 * <p>
+	 * This is the form the serialization layer throws: it is handed a type and a payload, and does not
+	 * know which stored event they came from. The stream layer attaches the reference via
+	 * {@link #withReference(EventReference)} before the exception reaches the caller.
+	 *
+	 * @param eventType the type the event was stored under, never null
+	 * @param message the detail message explaining what failed
+	 */
+	public EventDeserializationException ( EventType eventType, String message ) {
+		this(eventType, message, null, null);
+	}
+
+	/**
+	 * Constructs a new EventDeserializationException for the given stored event type, with no reference.
+	 *
+	 * @param eventType the type the event was stored under, never null
+	 * @param message the detail message explaining what failed
+	 * @param cause the underlying failure, typically a Jackson exception or a failure thrown by an
+	 *        {@link Upcast}
+	 */
+	public EventDeserializationException ( EventType eventType, String message, Throwable cause ) {
+		this(eventType, message, cause, null);
+	}
+
+	/**
+	 * Constructs a new EventDeserializationException naming both the stored event type and the event.
+	 *
+	 * @param eventType the type the event was stored under, never null
+	 * @param message the detail message explaining what failed
+	 * @param cause the underlying failure, or null
+	 * @param reference the reference of the stored event that could not be read, or null if not known
+	 */
+	public EventDeserializationException ( EventType eventType, String message, Throwable cause, EventReference reference ) {
+		super(message, cause);
+		this.eventType = eventType;
+		this.reference = reference;
+	}
+
+	/**
+	 * Returns the type the event was stored under.
+	 * <p>
+	 * This is the name in storage, which is not necessarily a type any class on the classpath still
+	 * claims — a renamed or retired event class is exactly the case where that happens.
+	 *
+	 * @return the stored event type, never null
+	 */
+	public EventType getEventType ( ) {
+		return eventType;
+	}
+
+	/**
+	 * Returns the reference of the stored event that could not be read.
+	 * <p>
+	 * Present whenever the exception reached the caller through a stream operation, which is every path
+	 * an application sees. It is empty only when the serialization layer is driven directly.
+	 *
+	 * @return the reference of the offending stored event, or empty if it is not known
+	 */
+	public Optional<EventReference> getReference ( ) {
+		return Optional.ofNullable(reference);
+	}
+
+	/**
+	 * Returns a copy of this exception naming the stored event it came from.
+	 * <p>
+	 * Used by the stream layer, which knows which stored event was being read and the serialization layer
+	 * does not. Message, cause and stack trace are carried over, so nothing about the original failure is
+	 * lost — only the reference is added.
+	 *
+	 * @param eventReference the reference of the stored event that could not be read
+	 * @return a copy carrying the reference, or this exception unchanged if it already has one
+	 */
+	public EventDeserializationException withReference ( EventReference eventReference ) {
+		if ( this.reference != null ) {
+			return this;
+		}
+		EventDeserializationException copy =
+				new EventDeserializationException(eventType, getMessage(), getCause(), eventReference);
+		copy.setStackTrace(getStackTrace());
+		return copy;
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventSerializationException.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/EventSerializationException.java
@@ -1,0 +1,87 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.events;
+
+/**
+ * Thrown when an event payload cannot be written to its stored form.
+ * <p>
+ * This is the append-side counterpart of {@link EventDeserializationException}, and it surfaces from
+ * {@link org.sliceworkz.eventstore.stream.EventSink#append} while the event being appended is converted
+ * to JSON. The event has <em>not</em> been stored when this is thrown.
+ *
+ * <h2>What it means, and what it does not</h2>
+ * A serialization failure is a property of the payload class, not of the store: the same event will fail
+ * the same way on every attempt, on every backend. <strong>It is never worth retrying.</strong> That is
+ * the distinction this type exists to make — a
+ * {@link org.sliceworkz.eventstore.spi.EventStorageException} from the same {@code append} call may well
+ * be transient (a dropped connection, a pool timeout) and is worth retrying, and before this type existed
+ * the two could only be told apart by matching on message text.
+ * <p>
+ * The usual causes are a record component Jackson cannot write, a derived accessor that emits a property,
+ * or a custom serializer rejecting a value. The underlying Jackson failure is always available via
+ * {@link #getCause()}; it carries the field path and is normally the most informative part.
+ *
+ * <h2>Handling</h2>
+ * <pre>{@code
+ * try {
+ *     stream.append(criteria, Event.of(payload, tags));
+ * } catch (OptimisticLockingException e) {
+ *     // a new relevant fact -- re-read, re-decide, retry
+ * } catch (EventSerializationException e) {
+ *     // permanent: this payload cannot be stored. Alert, do not retry.
+ *     LOGGER.error("unstorable event of type {}", e.getEventType(), e);
+ *     throw e;
+ * } catch (EventStorageException e) {
+ *     // possibly transient -- retry with backoff
+ * }
+ * }</pre>
+ *
+ * @see EventDeserializationException
+ * @see org.sliceworkz.eventstore.spi.EventStorageException
+ */
+public class EventSerializationException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final transient EventType eventType;
+
+	/**
+	 * Constructs a new EventSerializationException for the given event type.
+	 *
+	 * @param eventType the type of the event that could not be serialized, or null if it could not be determined
+	 * @param message the detail message explaining what failed
+	 * @param cause the underlying failure, typically a Jackson exception
+	 */
+	public EventSerializationException ( EventType eventType, String message, Throwable cause ) {
+		super(message, cause);
+		this.eventType = eventType;
+	}
+
+	/**
+	 * Returns the type of the event that could not be serialized.
+	 * <p>
+	 * This is {@link EventType#of(Object)} of the payload — that is, the simple name of its class, which is
+	 * also the name it would have been stored under.
+	 *
+	 * @return the event type, or null when the payload's type could not be determined (a null payload)
+	 */
+	public EventType getEventType ( ) {
+		return eventType;
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSink.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSink.java
@@ -117,6 +117,9 @@ public interface EventSink<DOMAIN_EVENT_TYPE> {
 	 * @param events the list of ephemeral events to append
 	 * @return a list of fully-formed Events with assigned references and metadata
 	 * @throws OptimisticLockingException if append criteria are violated (new relevant facts detected)
+	 * @throws org.sliceworkz.eventstore.events.EventSerializationException if an event's payload cannot be
+	 *         written; nothing is stored. A property of the payload class, so never worth retrying —
+	 *         unlike an {@link org.sliceworkz.eventstore.spi.EventStorageException} from the same call
 	 * @see AppendCriteria
 	 */
 	List<Event<DOMAIN_EVENT_TYPE>> append ( AppendCriteria appendCriteria, List<EphemeralEvent<? extends DOMAIN_EVENT_TYPE>> events );
@@ -140,6 +143,7 @@ public interface EventSink<DOMAIN_EVENT_TYPE> {
 	 * @return a list of fully-formed Events with assigned references and metadata
 	 * @throws OptimisticLockingException if append criteria are violated (new relevant facts detected)
 	 * @throws IllegalArgumentException if the target stream is not compatible with this EventSink's stream ID, or if the target stream is read-only
+	 * @throws org.sliceworkz.eventstore.events.EventSerializationException if an event's payload cannot be written; nothing is stored
 	 * @see #append(AppendCriteria, List)
 	 */
 	List<Event<DOMAIN_EVENT_TYPE>> append ( AppendCriteria appendCriteria, List<EphemeralEvent<? extends DOMAIN_EVENT_TYPE>> events, EventStreamId streamToAppendTo );
@@ -154,6 +158,7 @@ public interface EventSink<DOMAIN_EVENT_TYPE> {
 	 * @param event the ephemeral event to append
 	 * @return a list containing the single fully-formed Event with assigned reference and metadata
 	 * @throws OptimisticLockingException if append criteria are violated
+	 * @throws org.sliceworkz.eventstore.events.EventSerializationException if the event's payload cannot be written; nothing is stored
 	 */
 	default List<Event<DOMAIN_EVENT_TYPE>> append ( AppendCriteria appendCriteria, EphemeralEvent<? extends DOMAIN_EVENT_TYPE> event ) {
 		return append(appendCriteria, Collections.singletonList(event));

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -197,6 +197,11 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 * The cursor is purely a technical optimization — it does not affect which events match the query,
 	 * only where the scan starts. The 'until' reference in the EventQuery is the functional boundary
 	 * that determines query results.
+	 * <p>
+	 * <strong>Deserialization is lazy.</strong> Storage has finished reading by the time this returns, but
+	 * each event's payload is converted as the returned Stream is consumed — so an
+	 * {@link org.sliceworkz.eventstore.events.EventDeserializationException} for a stored event this
+	 * stream's type mappings cannot read is thrown from the caller's terminal operation, not from here.
 	 *
 	 * @param query the query criteria specifying which events to retrieve and in which direction
 	 * @param cursor optional reference for pagination (after for forward, before for backward), null to start from the beginning/end
@@ -291,6 +296,11 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 *
 	 * @param eventId the unique identifier of the stored event to retrieve
 	 * @return a list of events produced from the stored event, or an empty list if not found
+	 * @throws org.sliceworkz.eventstore.events.EventDeserializationException if the stored event cannot be
+	 *         read through this stream's type mappings. Unlike {@link #query(EventQuery)} this method is
+	 *         eager, so the failure surfaces here — which makes a raw-mode stream
+	 *         ({@code eventStore.getEventStream(EventStreamId.anyContext())}) the way to inspect an event
+	 *         a typed stream chokes on
 	 */
 	List<Event<DOMAIN_EVENT_TYPE>> getEventById ( EventId eventId );
 

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -42,6 +42,7 @@ import org.sliceworkz.eventstore.MeterOptions;
 import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EphemeralEvent;
 import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventDeserializationException;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.Tags;
@@ -666,7 +667,15 @@ public class EventStoreImpl implements EventStore {
 
 		@SuppressWarnings("unchecked")
 		private Stream<Event<EVENT_TYPE>> enrich ( StoredEvent storedEvent, QueryDirection direction ) {
-			List<TypeAndPayload> results = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
+			List<TypeAndPayload> results;
+			try {
+				results = serde.deserialize(new TypeAndSerializedPayload(storedEvent.type(), storedEvent.immutableData(), storedEvent.erasableData()));
+			} catch (EventDeserializationException e) {
+				// The serde is handed a type and two JSON strings, so it cannot say *which* stored event
+				// failed -- and that is the one fact a caller needs to dead-letter or skip a poison event.
+				// This is the only layer that knows both.
+				throw e.withReference(storedEvent.reference());
+			}
 			// For backward queries, reverse the upcasted sub-events so they appear in descending order,
 			// consistent with the overall backward traversal of stored events.
 			if ( direction == QueryDirection.BACKWARD ) {

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/AbstractEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/AbstractEventPayloadSerializerDeserializer.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 
 import org.sliceworkz.eventstore.events.Erasable;
+import org.sliceworkz.eventstore.events.EventSerializationException;
 import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.PartlyErasable;
 
@@ -96,6 +97,7 @@ public abstract class AbstractEventPayloadSerializerDeserializer implements Even
 	public TypeAndSerializedPayload serialize ( Object payload ) {
 		String immutableData = null;
 		String erasableData = null;
+		EventType eventType = payload == null ? null : EventType.of(payload);
 		try {
 
 			immutableData = immutableDataMapper
@@ -112,9 +114,16 @@ public abstract class AbstractEventPayloadSerializerDeserializer implements Even
 	        }
 	        
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to serialize event data", e);
+			// The payload class is named explicitly rather than left to the cause: a Jackson failure
+			// reports the field path it choked on, which is only half of "which event cannot be stored".
+			throw new EventSerializationException(eventType,
+					"Failed to serialize event data for type '%s' (%s): %s".formatted(
+							eventType == null ? "?" : eventType.name(),
+							payload == null ? "null payload" : payload.getClass().getName(),
+							e.getMessage()),
+					e);
 		}
-		return new TypeAndSerializedPayload(EventType.of(payload), immutableData, erasableData);
+		return new TypeAndSerializedPayload(eventType, immutableData, erasableData);
 	}
 
 	protected void deepMerge(ObjectNode target, ObjectNode source) {

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/RawEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/RawEventPayloadSerializerDeserializer.java
@@ -20,10 +20,10 @@ package org.sliceworkz.eventstore.impl.serde;
 import java.util.List;
 import java.util.Set;
 
+import org.sliceworkz.eventstore.events.EventDeserializationException;
 import org.sliceworkz.eventstore.events.EventType;
 
 import tools.jackson.core.JacksonException;
-import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -57,10 +57,13 @@ public class RawEventPayloadSerializerDeserializer extends AbstractEventPayloadS
 				object = nodeImmutableData; // with erasable merged in
 			}
 
-		} catch (DatabindException e) {
-			throw new RuntimeException("Failed to deserialize event data: DatabindException", e);
 		} catch (JacksonException e) {
-			throw new RuntimeException("Failed to deserialize event data: JacksonException", e);
+			// One catch, not two: DatabindException is a JacksonException, and naming which of the two
+			// it was added nothing the cause does not already say.
+			throw new EventDeserializationException(serialized.type(),
+					"Failed to parse stored JSON for event type '%s' in raw mode: %s".formatted(
+							serialized.type().name(), e.getOriginalMessage()),
+					e);
 		}
 		return List.of(new TypeAndPayload(serialized.type(), object));
 	}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/TypedEventPayloadSerializerDeserializer.java
@@ -27,12 +27,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.sliceworkz.eventstore.events.EventDeserializationException;
 import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.LegacyEvent;
 import org.sliceworkz.eventstore.events.Upcast;
 
 import tools.jackson.core.JacksonException;
-import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.node.ObjectNode;
 
 /**
@@ -57,21 +57,33 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 	
 	@Override
 	public List<TypeAndPayload> deserialize ( TypeAndSerializedPayload serialized ) {
-		List<TypeAndPayload> result;
-		try {
-			EventDeserializer deserializer = deserializers.get(serialized.type().name());
-			if ( deserializer == null  ) {
-				throw new RuntimeException("No mapping found for event type '" + serialized.type().name() + "'");
-			}
-			result = deserializer.deserialize(serialized.immutablePayload(), serialized.erasablePayload());
-		} catch (Exception e) {
-			if ( deserializers.keySet().isEmpty() ) {
-				throw new RuntimeException("Failed to deserialize event data for type '%s', no EventType mappings configured. Pass the Event root Class when creating the EventStream".formatted(serialized.type().name()) , e);
-			} else {
-				throw new RuntimeException("Failed to deserialize event data for type '%s', known mappings for %s".formatted(serialized.type().name(), deserializers.keySet()) , e);
-			}
+		EventType storedType = serialized.type();
+
+		// "No mapping" is resolved before the try rather than thrown inside it. It used to be thrown into
+		// the catch below and immediately re-wrapped, so the message naming the missing type only ever
+		// reached a user as the cause of a second, vaguer one.
+		EventDeserializer deserializer = deserializers.get(storedType.name());
+		if ( deserializer == null ) {
+			throw new EventDeserializationException(storedType, deserializers.isEmpty()
+					? "No mapping found for event type '%s': this stream has no event types registered. Pass the Event root Class when creating the EventStream."
+							.formatted(storedType.name())
+					: "No mapping found for event type '%s'. Known mappings: %s. Either the stream was opened without the Event root Class covering it, or the event class was renamed (its simple name is the stored name)."
+							.formatted(storedType.name(), knownMappings()));
 		}
-		return result;
+
+		try {
+			return deserializer.deserialize(serialized.immutablePayload(), serialized.erasablePayload());
+		} catch (EventDeserializationException e) {
+			// already precise about what failed -- wrapping it again would only bury the message
+			throw e;
+		} catch (RuntimeException e) {
+			throw new EventDeserializationException(storedType,
+					"Failed to deserialize event data for type '%s': %s".formatted(storedType.name(), e.getMessage()), e);
+		}
+	}
+
+	private String knownMappings ( ) {
+		return deserializers.keySet().stream().sorted().collect(Collectors.joining(", ", "[", "]"));
 	}
 	
 	@Override
@@ -102,34 +114,44 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 		if ( clazz.isAnnotationPresent(LegacyEvent.class)) {
 
 			if ( !assumeUpcasters ) {
-				throw new RuntimeException("Event type %s should not be annotated as a @LegacyEvent, or moved to the legacy Event types".formatted(clazz));
+				throw new IllegalArgumentException("Event type %s should not be annotated as a @LegacyEvent, or moved to the legacy Event types".formatted(clazz));
 			}
 
 			LegacyEvent annotation = clazz.getAnnotation(LegacyEvent.class);
+			Class<? extends Upcast<?,?>> upcastClass = annotation.upcast();
 			Upcast<Object, Object> upcast;
 			try {
-
-				upcast = (Upcast<Object, Object>) annotation.upcast().getDeclaredConstructor().newInstance(new Object[0]);
-
-				Set<EventType> targets = upcast.targetTypes().stream()
-						.map(EventType::of)
-						.collect(Collectors.toSet());
-				mostRecentTypes.put(eventType, targets);
-
-			} catch (NoSuchMethodException e) {
-				throw new RuntimeException(e);
+				upcast = (Upcast<Object, Object>) upcastClass.getDeclaredConstructor().newInstance(new Object[0]);
 			} catch (InvocationTargetException e) {
-				throw new RuntimeException(e);
-			} catch (InstantiationException e) {
-				throw new RuntimeException(e);
-			} catch (IllegalAccessException e) {
-				throw new RuntimeException(e);
+				// the constructor ran and threw: report what it threw, not the reflective wrapper
+				throw new IllegalArgumentException(
+						"Upcaster %s declared by @LegacyEvent on %s threw from its no-argument constructor: %s".formatted(
+								upcastClass.getName(), clazz.getName(), e.getTargetException()),
+						e.getTargetException());
+			} catch (ReflectiveOperationException e) {
+				// NoSuchMethod (no no-arg constructor -- an inner class needs to be static), Instantiation
+				// (abstract or an interface) or IllegalAccess (not public). All are "the annotation names a
+				// class that cannot be instantiated", and all three used to arrive as a bare
+				// RuntimeException naming neither the upcaster nor the event.
+				throw new IllegalArgumentException(
+						"Upcaster %s declared by @LegacyEvent on %s cannot be instantiated: %s. It needs a public no-argument constructor, and must be a concrete, non-inner (or static nested) class."
+								.formatted(upcastClass.getName(), clazz.getName(), e),
+						e);
 			}
-			eventDeserializer = new InstantiationAndUpcastEventDeserializer(eventDeserializer, upcast);
+
+			Set<Class<?>> targetClasses = upcast.targetTypes();
+			if ( targetClasses == null ) {
+				throw new IllegalArgumentException(
+						"Upcaster %s declared by @LegacyEvent on %s returned null from targetTypes(); return an empty Set for an upcaster that produces no events."
+								.formatted(upcastClass.getName(), clazz.getName()));
+			}
+			mostRecentTypes.put(eventType, targetClasses.stream().map(EventType::of).collect(Collectors.toSet()));
+
+			eventDeserializer = new InstantiationAndUpcastEventDeserializer(eventDeserializer, upcast, upcastClass);
 
 		} else {
 			if  ( assumeUpcasters ) {
-				throw new RuntimeException("legacy Event type %s should be annotated as a @LegacyEvent and configured with an Upcaster".formatted(clazz));
+				throw new IllegalArgumentException("legacy Event type %s should be annotated as a @LegacyEvent and configured with an Upcaster".formatted(clazz));
 			}
 			mostRecentTypes.put(eventType, Set.of(eventType)); // no upcasting needed
 		}
@@ -234,10 +256,14 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 					object = immutableDataMapper.treeToValue(nodeImmutableData, eventClass);
 				}
 
-			} catch (DatabindException e) {
-				throw new RuntimeException(e);
 			} catch (JacksonException e) {
-				throw new RuntimeException(e);
+				// One catch, not two: DatabindException is a JacksonException, and both used to throw a
+				// bare RuntimeException(e) -- no message of their own, so the only thing a user saw was
+				// Jackson's field-level complaint with nothing saying which event class it was aimed at.
+				throw new EventDeserializationException(eventType,
+						"Failed to deserialize stored event type '%s' onto %s: %s".formatted(
+								eventType.name(), eventClass.getName(), e.getOriginalMessage()),
+						e);
 			}
 			return List.of(new TypeAndPayload(eventType, object));
 		}
@@ -247,17 +273,35 @@ public class TypedEventPayloadSerializerDeserializer extends AbstractEventPayloa
 	class InstantiationAndUpcastEventDeserializer implements EventDeserializer {
 
 		private final Upcast<Object,Object> upcaster;
+		private final Class<?> upcasterClass;
 		private final EventDeserializer deser;
 
-		public InstantiationAndUpcastEventDeserializer ( EventDeserializer deser, Upcast<Object,Object> upcaster ) {
+		public InstantiationAndUpcastEventDeserializer ( EventDeserializer deser, Upcast<Object,Object> upcaster, Class<?> upcasterClass ) {
 			this.deser = deser;
 			this.upcaster = upcaster;
+			this.upcasterClass = upcasterClass;
 		}
 
 		@Override
 		public List<TypeAndPayload> deserialize ( String immutablePayload, String erasablePayload ) {
-			Object historicalEvent = deser.deserialize(immutablePayload, erasablePayload).getFirst().eventData();
-			List<Object> upcastedEvents = upcaster.upcast(historicalEvent);
+			TypeAndPayload historical = deser.deserialize(immutablePayload, erasablePayload).getFirst();
+			List<Object> upcastedEvents;
+			try {
+				upcastedEvents = upcaster.upcast(historical.eventData());
+			} catch (RuntimeException e) {
+				// An upcaster is application code running on the read path, and Upcast's own javadoc warns
+				// that legacy data may not satisfy a current record's validation. Its failure used to be
+				// indistinguishable from Jackson failing to parse the JSON; name the upcaster instead.
+				throw new EventDeserializationException(historical.type(),
+						"Upcaster %s threw while upcasting stored event type '%s': %s".formatted(
+								upcasterClass.getName(), historical.type().name(), e),
+						e);
+			}
+			if ( upcastedEvents == null ) {
+				throw new EventDeserializationException(historical.type(),
+						"Upcaster %s returned null for stored event type '%s'; return an empty List to drop an event."
+								.formatted(upcasterClass.getName(), historical.type().name()));
+			}
 			return upcastedEvents.stream()
 					.map(e -> new TypeAndPayload(EventType.of(e), e))
 					.toList();

--- a/sliceworkz-eventstore-infra-inmem/src/test/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImplTest.java
+++ b/sliceworkz-eventstore-infra-inmem/src/test/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImplTest.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventDeserializationException;
+import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorageImplTest.ProblematicParsing.ProblematicParsingRecord;
 import org.sliceworkz.eventstore.spi.EventStorage;
@@ -62,16 +64,21 @@ public class InMemoryEventStorageImplTest {
 		// no type mapping done
 		EventStore eventStore = InMemoryEventStorage.newBuilder().buildStore();
 		
-		RuntimeException e = assertThrows(RuntimeException.class, ()->
+		EventDeserializationException e = assertThrows(EventDeserializationException.class, ()->
 			eventStore.getEventStream(EventStreamId.forContext("ctx").withPurpose("purpose"), ProblematicParsing.class).append(
-					AppendCriteria.none(), 
+					AppendCriteria.none(),
 					Collections.singletonList(
 							Event.of(new ProblematicParsingRecord("value"), Tags.none())
 					)
 			)
 		);
-		assertEquals("Failed to deserialize event data for type 'ProblematicParsingRecord', known mappings for [ProblematicParsingRecord]", e.getMessage());
-		assertEquals("Unrecognized property \"derivedValueThatIsNotPartOfRecord\" (class org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorageImplTest$ProblematicParsing$ProblematicParsingRecord), not marked as ignorable (one known property: \"value\")", e.getCause().getCause().getMessage().split("\n")[0]);
+		// The event is written, and then fails on the way back out: append() returns enriched events, so
+		// a payload that serializes but cannot be read back surfaces as a deserialization failure.
+		assertEquals("Failed to deserialize stored event type 'ProblematicParsingRecord' onto org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorageImplTest$ProblematicParsing$ProblematicParsingRecord: Unrecognized property \"derivedValueThatIsNotPartOfRecord\" (class org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorageImplTest$ProblematicParsing$ProblematicParsingRecord), not marked as ignorable", e.getMessage());
+		// one wrapping layer, not two: Jackson's own complaint is the direct cause
+		assertEquals("Unrecognized property \"derivedValueThatIsNotPartOfRecord\" (class org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorageImplTest$ProblematicParsing$ProblematicParsingRecord), not marked as ignorable (one known property: \"value\")", e.getCause().getMessage().split("\n")[0]);
+		assertEquals(EventType.ofType("ProblematicParsingRecord"), e.getEventType());
+		assertTrue(e.getReference().isPresent(), "the stream layer should name the stored event that failed");
 	}
 	
 	sealed interface ProblematicParsing {

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventDeserializationEvolutionTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventDeserializationEvolutionTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.EventStoreFactory;
 import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventDeserializationException;
+import org.sliceworkz.eventstore.events.EventType;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
 import org.sliceworkz.eventstore.query.EventQuery;
@@ -109,10 +111,14 @@ public class EventDeserializationEvolutionTest extends AbstractEventStoreTest {
 				OrderEventV3WithRemovedField.class);
 
 		// This should fail because the stored JSON contains "product" which is unknown to V3
-		RuntimeException exception = assertThrows(RuntimeException.class,
+		EventDeserializationException exception = assertThrows(EventDeserializationException.class,
 				() -> v3Stream.query(EventQuery.matchAll()).toList());
 
-		assertEquals(true, exception.getMessage().contains("Failed to deserialize event data"),
+		assertEquals(EventType.ofType("OrderPlaced"), exception.getEventType());
+		assertEquals(true, exception.getMessage().contains("Failed to deserialize stored event type 'OrderPlaced'"),
 				"Expected deserialization failure due to unknown property, but got: " + exception.getMessage());
+		// the message names the record it could not be read onto, which is the half Jackson does not say
+		assertEquals(true, exception.getMessage().contains(OrderEventV3WithRemovedField.OrderPlaced.class.getName()),
+				"Expected the target record to be named, but got: " + exception.getMessage());
 	}
 }

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/SerdeFailureTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/SerdeFailureTest.java
@@ -1,0 +1,317 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventDeserializationException;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.EventSerializationException;
+import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.LegacyEvent;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.events.Upcast;
+import org.sliceworkz.eventstore.projection.Projection;
+import org.sliceworkz.eventstore.projection.Projector;
+import org.sliceworkz.eventstore.projection.ProjectorException;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+
+/**
+ * Pins down how the store reports a payload it cannot convert, in either direction.
+ *
+ * <h2>The three kinds, and why they are typed differently</h2>
+ * <ul>
+ *   <li><b>Misconfiguration</b> — a {@code @LegacyEvent} on a class registered as current, a current
+ *       class registered as legacy, an upcaster that cannot be instantiated. All are properties of the
+ *       {@code Class} handed to {@code getEventStream}, all fail at stream creation before anything is
+ *       read or written, and all are {@link IllegalArgumentException} — the same type the two
+ *       registration checks that were already typed (duplicate event name, non-sealed interface) use.</li>
+ *   <li><b>Write side</b> — {@link EventSerializationException} from {@code append}, for a payload that
+ *       cannot be written. The event is not stored.</li>
+ *   <li><b>Read side</b> — {@link EventDeserializationException} while a query result is consumed, for a
+ *       stored event this stream's mappings cannot read. The storage read succeeded; the event is a
+ *       poison event, and {@link EventDeserializationException#getReference()} names it.</li>
+ * </ul>
+ * None of the three is worth retrying, which is what separates them from
+ * {@link org.sliceworkz.eventstore.spi.EventStorageException}. Before these types existed all of it
+ * arrived as a bare {@code RuntimeException} and could only be told apart by matching on message text.
+ */
+public class SerdeFailureTest extends AbstractEventStoreTest {
+
+	private final EventStreamId streamId = EventStreamId.forContext("serde-failure").withPurpose("p");
+
+	// --- event definitions -------------------------------------------------------------------------
+
+	sealed interface OrderEvent {
+		record OrderPlaced ( String orderId ) implements OrderEvent { }
+	}
+
+	/** A second hierarchy, written to the same stream, that {@code OrderEvent} has no mapping for. */
+	sealed interface ShippingEvent {
+		record ParcelShipped ( String parcelId ) implements ShippingEvent { }
+	}
+
+	/** Serializes fine, cannot be read back: the derived accessor emits a property no component matches. */
+	sealed interface UnreadableEvent {
+		default String getDerived ( ) { return "x"; }
+		record Unreadable ( String value ) implements UnreadableEvent { }
+	}
+
+	/** A payload Jackson cannot write at all: the accessor throws. */
+	sealed interface UnwritableEvent {
+		record Unwritable ( String value ) implements UnwritableEvent {
+			@Override
+			public String value ( ) { throw new IllegalStateException("this value cannot be read"); }
+		}
+	}
+
+	// --- upcasters ---------------------------------------------------------------------------------
+
+	sealed interface CurrentEvent {
+		record Renamed ( String orderId ) implements CurrentEvent { }
+	}
+
+	/**
+	 * The historical hierarchy, as the reading side declares it. Its {@code LegacyPlaced} shares its
+	 * simple name — which is the stored name — with {@link Written#LegacyPlaced}, which is how a legacy
+	 * event gets written here in the first place: a class annotated {@code @LegacyEvent} cannot be
+	 * registered as a current type, so it cannot append.
+	 */
+	interface Historical {
+		@LegacyEvent(upcast = ThrowingUpcast.class)
+		record LegacyPlaced ( String orderId ) { }
+	}
+
+	/** The same stored event type, unannotated, so it can be appended. */
+	interface Written {
+		record LegacyPlaced ( String orderId ) { }
+	}
+
+	public static class ThrowingUpcast implements Upcast<Historical.LegacyPlaced, CurrentEvent> {
+		@Override
+		public List<CurrentEvent> upcast ( Historical.LegacyPlaced historicalEvent ) {
+			throw new IllegalArgumentException("legacy id %s does not satisfy the current rule".formatted(historicalEvent.orderId()));
+		}
+		@Override
+		public Set<Class<? extends CurrentEvent>> targetTypes ( ) {
+			return Set.of(CurrentEvent.Renamed.class);
+		}
+	}
+
+	@LegacyEvent(upcast = NoNoArgConstructorUpcast.class)
+	record LegacyUninstantiable ( String orderId ) { }
+
+	public static class NoNoArgConstructorUpcast implements Upcast<LegacyUninstantiable, CurrentEvent> {
+		public NoNoArgConstructorUpcast ( String required ) { /* deliberately not a no-arg constructor */ }
+		@Override
+		public List<CurrentEvent> upcast ( LegacyUninstantiable historicalEvent ) { return List.of(); }
+		@Override
+		public Set<Class<? extends CurrentEvent>> targetTypes ( ) { return Set.of(CurrentEvent.Renamed.class); }
+	}
+
+	// --- misconfiguration: fails at getEventStream, before anything is read or written --------------
+
+	@ForEachBackend
+	void anUninstantiableUpcasterIsRejectedAtStreamCreation ( ) {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> eventStore().getEventStream(streamId, CurrentEvent.class, LegacyUninstantiable.class));
+
+		// the whole point: the old bare RuntimeException(NoSuchMethodException) named neither class
+		assertTrue(e.getMessage().contains(NoNoArgConstructorUpcast.class.getName()),
+				"the upcaster that could not be instantiated should be named: " + e.getMessage());
+		assertTrue(e.getMessage().contains(LegacyUninstantiable.class.getName()),
+				"the legacy event declaring it should be named: " + e.getMessage());
+		assertInstanceOf(NoSuchMethodException.class, e.getCause(),
+				"the reflective failure should be preserved as the cause");
+	}
+
+	// --- write side ---------------------------------------------------------------------------------
+
+	@ForEachBackend
+	void anUnwritablePayloadFailsTheAppendWithASerializationException ( ) {
+		EventStream<UnwritableEvent> stream = eventStore().getEventStream(streamId, UnwritableEvent.class);
+
+		EventSerializationException e = assertThrows(EventSerializationException.class,
+				() -> stream.append(AppendCriteria.none(), Event.of(new UnwritableEvent.Unwritable("v"), Tags.none())));
+
+		assertEquals(EventType.ofType("Unwritable"), e.getEventType());
+		assertTrue(e.getMessage().contains("Unwritable"), e.getMessage());
+		assertTrue(e.getCause() != null, "Jackson's own failure should be preserved as the cause");
+
+		// nothing was stored
+		assertEquals(0, eventStore().getEventStream(streamId, UnwritableEvent.class).query(EventQuery.matchAll()).count());
+	}
+
+	// --- read side ----------------------------------------------------------------------------------
+
+	@ForEachBackend
+	void aStoredTypeThisStreamCannotMapFailsOnRead ( ) {
+		eventStore().getEventStream(streamId, ShippingEvent.class)
+				.append(AppendCriteria.none(), Event.of(new ShippingEvent.ParcelShipped("parcel-1"), Tags.none()));
+
+		EventStream<OrderEvent> orderStream = eventStore().getEventStream(streamId, OrderEvent.class);
+
+		EventDeserializationException e = assertThrows(EventDeserializationException.class,
+				() -> orderStream.query(EventQuery.matchAll()).toList());
+
+		assertEquals(EventType.ofType("ParcelShipped"), e.getEventType());
+		assertTrue(e.getMessage().contains("No mapping found for event type 'ParcelShipped'"), e.getMessage());
+		// the known mappings are listed, so the reader can see what this stream *can* read
+		assertTrue(e.getMessage().contains("OrderPlaced"), e.getMessage());
+	}
+
+	@ForEachBackend
+	void aStreamWithNoMappingsAtAllSaysSo ( ) {
+		eventStore().getEventStream(streamId, OrderEvent.class)
+				.append(AppendCriteria.none(), Event.of(new OrderEvent.OrderPlaced("order-1"), Tags.none()));
+
+		// A typed stream registered with nothing is a different mistake from one registered with the
+		// wrong thing, and the message says which. Object.class is the way to reach it: passing at least
+		// one root class selects the typed serde, and Object.class contributes no mappings to it.
+		EventDeserializationException e = assertThrows(EventDeserializationException.class,
+				() -> eventStore().getEventStream(streamId, Object.class).query(EventQuery.matchAll()).toList());
+
+		assertEquals(EventType.ofType("OrderPlaced"), e.getEventType());
+		assertTrue(e.getMessage().contains("Pass the Event root Class when creating the EventStream"), e.getMessage());
+	}
+
+	@ForEachBackend
+	void aDeserializationFailureNamesTheStoredEventThatFailed ( ) {
+		EventStream<UnreadableEvent> stream = eventStore().getEventStream(streamId, UnreadableEvent.class);
+
+		// append() reads its own events back, so the failure surfaces there
+		EventDeserializationException onAppend = assertThrows(EventDeserializationException.class,
+				() -> stream.append(AppendCriteria.none(), Event.of(new UnreadableEvent.Unreadable("v"), Tags.none())));
+
+		EventReference reference = onAppend.getReference()
+				.orElseThrow(() -> new AssertionError("the stream layer should attach the reference of the failing stored event"));
+
+		// and it is genuinely the offending event: raw mode has no mapping to fail on, so it reads back
+		List<Event<Object>> raw = eventStore().getEventStream(EventStreamId.anyContext()).getEventById(reference.id());
+		assertEquals(1, raw.size(), "the reference should identify a real stored event");
+		assertEquals(EventType.ofType("Unreadable"), raw.getFirst().type());
+
+		// the same failure on the read path, carrying the same reference
+		EventDeserializationException onRead = assertThrows(EventDeserializationException.class,
+				() -> eventStore().getEventStream(streamId, UnreadableEvent.class).query(EventQuery.matchAll()).toList());
+		assertEquals(reference.id(), onRead.getReference().orElseThrow().id());
+	}
+
+	@ForEachBackend
+	void anUpcasterThrowingIsReportedAsSuchRatherThanAsAParseFailure ( ) {
+		// write the legacy event under its stored name, then read it back through a stream that upcasts it
+		eventStore().getEventStream(streamId, Written.LegacyPlaced.class)
+				.append(AppendCriteria.none(), Event.of(new Written.LegacyPlaced("order-1"), Tags.none()));
+
+		EventStream<CurrentEvent> current = eventStore().getEventStream(streamId, CurrentEvent.class, Historical.LegacyPlaced.class);
+
+		EventDeserializationException e = assertThrows(EventDeserializationException.class,
+				() -> current.query(EventQuery.matchAll()).toList());
+
+		assertTrue(e.getMessage().contains(ThrowingUpcast.class.getName()),
+				"the upcaster that threw should be named, not just the event: " + e.getMessage());
+		assertInstanceOf(IllegalArgumentException.class, e.getCause(),
+				"what the upcaster threw should be the cause");
+		assertTrue(e.getReference().isPresent());
+	}
+
+	// --- one wrapping layer, not two ----------------------------------------------------------------
+
+	@ForEachBackend
+	void theCauseIsTheUnderlyingFailureAndNotASecondWrapper ( ) {
+		eventStore().getEventStream(streamId, UnreadableEvent.class);   // registers the mapping
+
+		EventDeserializationException e = assertThrows(EventDeserializationException.class,
+				() -> eventStore().getEventStream(streamId, UnreadableEvent.class)
+						.append(AppendCriteria.none(), Event.of(new UnreadableEvent.Unreadable("v"), Tags.none())));
+
+		assertFalse(e.getCause() instanceof EventDeserializationException,
+				"the serde used to wrap its own exception a second time, burying the useful message");
+		assertTrue(e.getMessage().contains(UnreadableEvent.Unreadable.class.getName()),
+				"the target record should be named in the message itself: " + e.getMessage());
+	}
+
+	@ForEachBackend
+	void withReferenceKeepsMessageCauseAndStackTrace ( ) {
+		Throwable cause = new IllegalStateException("boom");
+		EventDeserializationException original =
+				new EventDeserializationException(EventType.ofType("X"), "some message", cause);
+
+		EventDeserializationException withRef = original.withReference(EventReference.create(1, 1));
+
+		assertEquals("some message", withRef.getMessage());
+		assertSame(cause, withRef.getCause());
+		assertTrue(withRef.getReference().isPresent());
+		assertEquals(List.of(original.getStackTrace()), List.of(withRef.getStackTrace()));
+		// a reference already attached is not replaced by an outer layer
+		assertSame(withRef, withRef.withReference(EventReference.create(2, 2)));
+	}
+
+	// --- through a Projector -------------------------------------------------------------------------
+
+	@ForEachBackend
+	void aProjectorReportsThePoisonEventThroughItsCause ( ) {
+		EventStream<OrderEvent> writable = eventStore().getEventStream(streamId, OrderEvent.class);
+		writable.append(AppendCriteria.none(), Event.of(new OrderEvent.OrderPlaced("order-1"), Tags.none()));
+		eventStore().getEventStream(streamId, ShippingEvent.class)
+				.append(AppendCriteria.none(), Event.of(new ShippingEvent.ParcelShipped("parcel-2"), Tags.none()));
+
+		CountingProjection projection = new CountingProjection();
+		Projector<OrderEvent> projector = Projector.<OrderEvent>from(eventStore().getEventStream(streamId, OrderEvent.class))
+				.towards(projection).build();
+
+		ProjectorException e = assertThrows(ProjectorException.class, projector::run);
+
+		// A Projector wraps everything it catches, so the type of the cause is the only thing that
+		// separates "this event will never be readable" from "the database was briefly unavailable".
+		EventDeserializationException poison = assertInstanceOf(EventDeserializationException.class, e.getCause());
+		assertEquals(EventType.ofType("ParcelShipped"), poison.getEventType());
+
+		// ProjectorException's own reference is the last event *handled* -- never the offending one,
+		// which never reached the projection. getReference() is what names the poison event.
+		EventReference offending = poison.getReference().orElseThrow();
+		assertFalse(offending.equals(e.getEventReference()),
+				"the two references answer different questions and should not be confused");
+
+		// resuming past it makes progress possible again
+		assertEquals(1, projection.handled, "the readable event before the poison one was handled");
+	}
+
+	static class CountingProjection implements Projection<OrderEvent> {
+		int handled = 0;
+		@Override
+		public EventQuery eventQuery ( ) { return EventQuery.matchAll(); }
+		@Override
+		public void when ( Event<OrderEvent> event ) { handled++; }
+	}
+
+}

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/UpcastTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/UpcastTest.java
@@ -135,13 +135,15 @@ public class UpcastTest extends AbstractEventStoreTest {
 
 	@ForEachBackend
 	void testUpcastAnnotationNotAllowedOnCurrentEventVersions() {
-		RuntimeException e = assertThrows(RuntimeException.class,()->eventStore().getEventStream(streamId, CustomerHistoricalEvent.CustomerNameChanged.class));
+		// IllegalArgumentException, like the two neighbouring registration checks (duplicate event name,
+		// non-sealed interface): the argument passed to getEventStream is what is wrong.
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,()->eventStore().getEventStream(streamId, CustomerHistoricalEvent.CustomerNameChanged.class));
 		assertEquals("Event type class org.sliceworkz.eventstore.testing.tck.stream.UpcastTest$CustomerHistoricalEvent$CustomerNameChanged should not be annotated as a @LegacyEvent, or moved to the legacy Event types", e.getMessage());
 	}
 
 	@ForEachBackend
 	void testUpcastRequiredOnHistoricalEventVersions() {
-		RuntimeException e = assertThrows(RuntimeException.class,()->eventStore().getEventStream(streamId, OriginalEvent.CustomerRegistered.class, CustomerEvent.CustomerRenamed.class));
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,()->eventStore().getEventStream(streamId, OriginalEvent.CustomerRegistered.class, CustomerEvent.CustomerRenamed.class));
 		assertEquals("legacy Event type class org.sliceworkz.eventstore.testing.tck.stream.UpcastTest$CustomerEvent$CustomerRenamed should be annotated as a @LegacyEvent and configured with an Upcaster", e.getMessage());
 	}
 


### PR DESCRIPTION
## Summary

Replaces bare `RuntimeException` with two new typed exceptions for payload conversion failures: `EventSerializationException` (write-side) and `EventDeserializationException` (read-side). This enables callers to distinguish permanent failures (which should never be retried) from transient storage errors (which may be worth retrying).

## Key Changes

- **New exception types in API module** (`org.sliceworkz.eventstore.events`):
  - `EventSerializationException`: Thrown when `append()` cannot write a payload to JSON. The event is not stored.
  - `EventDeserializationException`: Thrown when a stored event cannot be read through the stream's type mappings. Carries `getEventType()` (the stored name) and `getReference()` (the offending event's location in storage).

- **Improved error reporting**:
  - Misconfiguration errors (e.g., `@LegacyEvent` on a current type, uninstantiable upcasters) now throw `IllegalArgumentException` with both the problematic class and the annotation/upcaster that declared it named in the message.
  - Deserialization failures no longer double-wrap exceptions, preserving the original Jackson error as the cause.
  - "No mapping found" errors now list known mappings and distinguish between "no types registered" and "type not in this stream's mappings".
  - Upcaster instantiation failures preserve the reflective cause and name both the upcaster class and the legacy event that declared it.

- **Reference attachment**: `EventDeserializationException.withReference()` allows the stream layer to attach the stored event's location without re-wrapping the message or cause, enabling callers to inspect the poison event via raw-mode `getEventById()`.

- **Updated serde implementations**:
  - `TypedEventPayloadSerializerDeserializer`: Resolves "no mapping" before attempting deserialization, throws typed exceptions with context.
  - `AbstractEventPayloadSerializerDeserializer`: Wraps Jackson failures in `EventSerializationException`.
  - `RawEventPayloadSerializerDeserializer`: Throws `EventDeserializationException` for parse failures.
  - `InstantiationAndUpcastEventDeserializer`: Reports upcaster failures with the upcaster class name.

- **Stream layer enrichment**: `EventStoreImpl` attaches the event reference to deserialization exceptions via `withReference()` before they reach the caller.

- **Comprehensive test coverage** (`SerdeFailureTest`):
  - Misconfiguration rejection at stream creation.
  - Write-side serialization failures.
  - Read-side deserialization failures with reference attachment.
  - Upcaster failures distinguished from parse failures.
  - Exception wrapping depth (no double-wrapping).
  - Projector integration (poison events wrapped in `ProjectorException`).

## Notable Implementation Details

- `EventDeserializationException.getReference()` returns `Optional`, empty only when thrown directly by the serde layer (before the stream layer can attach it).
- Upcaster instantiation errors are `IllegalArgumentException` (configuration, fails at stream creation) rather than deserialization errors (runtime, fails during query).
- The distinction between "no types registered" and "type not in mappings" helps callers diagnose whether they forgot to pass the root class or passed the wrong one.
- `withReference()` preserves stack trace and cause, making it safe for the stream layer to attach location information without losing the original failure details.

https://claude.ai/code/session_01Hxabygc78DamjFnvLLYXam