### PR TITLE
Document PostgreSQL RETURNING order preservation in append()

### DIFF
--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -1329,6 +1329,26 @@ public class PostgresEventStorageImpl implements EventStorage {
 		}
 	}
 
+	/**
+	 * Appends events, pairing each {@code RETURNING} row with the input event at the same index.
+	 * <p>
+	 * Nothing promises that order — {@code RETURNING} is not in the SQL standard, and PostgreSQL
+	 * documents only "a row per row actually inserted". It holds because the {@code NOT EXISTS} below
+	 * is <em>uncorrelated</em>: it references the events table and bound parameters, never a column of
+	 * {@code new_events}. PostgreSQL therefore evaluates it once as an InitPlan and applies it as a
+	 * One-Time Filter over the VALUES list, and every node in that plan preserves order. Being
+	 * all-or-nothing is also what makes the {@code storedEvents.size() != events.size()} check below a
+	 * sound conflict detector — the statement inserts every row or none, never a subset.
+	 * <p>
+	 * Correlating that predicate with {@code new_events} would let the planner turn it into an
+	 * anti-join, which reorders and would silently mispair every event with another's id and position.
+	 * Note the rows would still carry ascending positions, since the reordering precedes the insert, so
+	 * a defensive monotonicity check would not catch it.
+	 * <p>
+	 * {@code importEvents} keys on the id it supplied instead, because {@code ON CONFLICT} makes its
+	 * result a subset of its input. That is not an option here: from PG18 the id comes from a
+	 * server-side {@code uuidv7()}, and {@code RETURNING} cannot return a source-only ordinal to key on.
+	 */
 	@Override
 	public List<StoredEvent> append(AppendCriteria appendCriteria, Optional<EventStreamId> streamId, List<EventToStore> events) {
 		checkNotClosed();


### PR DESCRIPTION
## Summary
Added comprehensive documentation to the `append()` method in `PostgresEventStorageImpl` explaining the critical assumptions about PostgreSQL's `RETURNING` clause behavior that enable correct event-to-result pairing.

## Key Changes
- Added detailed JavaDoc explaining why `RETURNING` row order is preserved in the current implementation
- Documented the uncorrelated `NOT EXISTS` predicate as the key to maintaining order through PostgreSQL's query planner
- Explained the all-or-nothing insert semantics that make the `storedEvents.size() != events.size()` conflict detection sound
- Warned against correlating the predicate with `new_events`, which would allow the planner to reorder rows via anti-join and silently mispair events
- Clarified why `importEvents` uses a different keying strategy (on supplied id) versus `append()` (which cannot use `ON CONFLICT` due to server-side UUID generation in PG18+)

## Notable Implementation Details
The documentation emphasizes that:
- The order preservation is not guaranteed by SQL standard but relies on PostgreSQL's specific query planning behavior
- The `InitPlan` evaluation of the uncorrelated predicate as a One-Time Filter preserves order across the VALUES list
- A defensive monotonicity check would not catch silent reordering that occurs before the insert
- The inability to use `ON CONFLICT` for keying in `append()` (unlike `importEvents`) stems from server-side `uuidv7()` generation where `RETURNING` cannot return a source-only ordinal

https://claude.ai/code/session_01JBdkFdTW5xgSmwMkSeiG9H