### PR TITLE
Fix listener re-delivery loop when returning null

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,22 @@ contained, logged at ERROR, and the next subscriber still gets the notification.
 - `AppendListenerFailureTest` in the TCK pins it per backend: a throwing subscriber does not starve the one
   behind it, and notifications keep arriving for both afterwards.
 
+**A listener that returns null is caught up, not asking to be told again.** `OptimizingAppendListenerDecorator`
+keeps delivering until the listener has reached the target it was notified about, and it used to learn that
+only from a non-null return — so a null left it with nothing to compare against and nothing to reach, and it
+re-delivered the same target without pausing: ~700.000 deliveries a second on one pinned virtual thread.
+
+- **The ordinary listener hits this, not an exotic one.** `Projector.eventsAppended` returns
+  `run().lastEventReference()`, which is null whenever the query matched no events — so *any* subscribed
+  projector whose event type had not occurred yet burned a core from the first unrelated append to its
+  stream until the first matching one. Nothing threw, nothing was logged, and it cleared itself the moment
+  one matching event arrived, which is why it survived: it looks like load, not like a bug.
+- Null and a reference *behind* the target now mean the same thing — caught up to the target. Nothing is
+  lost by that: the next append carries a later reference, which is after this one and so still delivered.
+- The interface has always documented the return as "never null"; `Projector` has always violated it, so
+  null is given a defined meaning rather than left to whoever reads the contract more carefully.
+- `AppendListenerFailureTest.testListenerReportingNoProgressIsNotRedeliveredTo` pins it per backend.
+
 ### Metrics: what the stream meters cost, and the cap on `purpose`
 
 Every meter the store registers is tagged `context`, `purpose`, `typed`, `storage`, and two of them

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventStreamEventuallyConsistentAppendListener.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventStreamEventuallyConsistentAppendListener.java
@@ -132,7 +132,13 @@ public interface EventStreamEventuallyConsistentAppendListener {
 	 * @param atLeastUntil reference to at least the last appended event, never null
 	 * @return the reference to the last event actually processed or queried by this listener,
 	 *         which may be equal to or ahead of the {@code atLeastUntil} parameter if the
-	 *         listener proactively queried further events; never null
+	 *         listener proactively queried further events. A reference <em>behind</em>
+	 *         {@code atLeastUntil}, and null for "I processed nothing", both mean this listener is
+	 *         caught up to {@code atLeastUntil}: the store stops delivering and the next append is
+	 *         what brings it back. Returning null to ask to be told again does not work — it used to
+	 *         make the store re-deliver without pausing, which is why null now has a defined meaning
+	 *         rather than being left to the caller. {@link org.sliceworkz.eventstore.projection.Projector}
+	 *         returns null whenever its query matched no events
 	 */
 	EventReference eventsAppended ( EventReference atLeastUntil );
 

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/OptimizingAppendListenerDecorator.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/OptimizingAppendListenerDecorator.java
@@ -156,9 +156,18 @@ public class OptimizingAppendListenerDecorator implements EventStreamEventuallyC
             
             try {
                 EventReference lastSeenByDelegate = delegate.eventsAppended(target);
-                if ( lastSeenByDelegate != null ) {
-                	lastNotifiedReference.set(lastSeenByDelegate.happenedAfter(target)?lastSeenByDelegate:target);
-                }
+                // Advance to the target whatever the delegate reports, and past it only when it reports
+                // going further. Null -- "I processed nothing" -- has to count as reaching the target too,
+                // because this loop only stops once the target has been reached: a delegate that keeps
+                // returning null left it with nothing to compare against and nothing to reach, so it
+                // re-delivered the same target without pausing, measured at ~700.000 deliveries a second
+                // on one pinned virtual thread. That is not an exotic listener. Projector.eventsAppended
+                // returns run().lastEventReference(), which is null whenever the query matched no events,
+                // so any subscribed projector whose event type had not occurred yet burned a core from the
+                // first unrelated append to its stream until the first matching one -- nothing failing,
+                // nothing logged, just a core gone. No notification is lost by advancing here: the next
+                // append carries a later reference, which is after this one and so still delivered.
+                lastNotifiedReference.set((lastSeenByDelegate != null) && lastSeenByDelegate.happenedAfter(target)? lastSeenByDelegate:target);
             } finally {
                 lock.lock();
                 updateInProgress = false;

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/AppendListenerFailureTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/AppendListenerFailureTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.sliceworkz.eventstore.events.Event;
@@ -89,5 +90,47 @@ public class AppendListenerFailureTest extends AbstractEventStoreTest {
 		waitBecauseOfEventualConsistency(() -> seenByBystander.contains(secondAppend));
 
 		assertTrue(seenByBystander.size() >= 2, "expected notifications for both appends, saw " + seenByBystander);
+	}
+
+	/**
+	 * A listener saying it processed nothing is saying it is caught up, not asking to be told again.
+	 * <p>
+	 * The decorator stops delivering once the listener has reached the target it was notified about, and it
+	 * used to learn that only from a non-null return — so a listener returning null left it with nothing to
+	 * compare against and nothing to reach, and it re-delivered the same target without pausing. Not an
+	 * exotic listener either: {@code Projector.eventsAppended} returns {@code run().lastEventReference()},
+	 * which is null whenever the query matched no events, so any subscribed projector whose event type had
+	 * not occurred yet burned a core from the first unrelated append to its stream until the first matching
+	 * one — nothing thrown, nothing logged.
+	 * <p>
+	 * The bound is loose on purpose. The distinction being drawn is not a subtle one: before this, a single
+	 * append produced deliveries at roughly 700.000 a second for as long as the process ran, so anything in
+	 * single figures separates "restrained" from "spinning" without depending on timing.
+	 */
+	@ForEachBackend
+	void testListenerReportingNoProgressIsNotRedeliveredTo ( ) {
+		AtomicInteger deliveries = new AtomicInteger();
+		List<EventReference> seenByBystander = new CopyOnWriteArrayList<>();
+
+		stream.subscribe((EventStreamEventuallyConsistentAppendListener) atLeastUntil -> {
+			deliveries.incrementAndGet();
+			return null; // "I processed nothing" -- what Projector returns when its query matched no events
+		});
+		stream.subscribe((EventStreamEventuallyConsistentAppendListener) atLeastUntil -> {
+			seenByBystander.add(atLeastUntil);
+			return atLeastUntil;
+		});
+
+		EventReference appended =
+			stream.append(AppendCriteria.none(), Event.of(new FirstDomainEvent("1"), Tags.none())).getLast().reference();
+
+		// the bystander is what makes a low delivery count meaningful: it proves the notification round trip
+		// ran, so a bounded count is restraint rather than the notification never having arrived
+		waitBecauseOfEventualConsistency(() -> seenByBystander.contains(appended));
+		waitBecauseOfEventualConsistency(() -> deliveries.get() >= 1);
+
+		int settled = deliveries.get();
+		assertTrue(settled <= 10,
+			"one append must not be re-delivered to a listener reporting no progress, but it was delivered " + settled + " times");
 	}
 }


### PR DESCRIPTION
## Summary

Fix a performance issue in `OptimizingAppendListenerDecorator` where listeners returning null were re-delivered to indefinitely without pausing, causing CPU starvation. The decorator now treats null and references behind the target as equivalent to "caught up", stopping re-delivery until the next append.

## Changes

- **`OptimizingAppendListenerDecorator.notifyDecoratedListener()`**: Changed the logic that advances `lastNotifiedReference` to treat null returns the same as references behind the target — both now mean the listener is caught up to the target. Previously, null left the decorator with nothing to compare against, causing it to re-deliver the same target in a tight loop (~700,000 deliveries/second on a pinned virtual thread).

- **`EventStreamEventuallyConsistentAppendListener` interface documentation**: Updated the contract for `eventsAppended()` to document that null and references behind `atLeastUntil` both mean "caught up", and that null is now a defined behavior rather than undefined. Added context that `Projector.eventsAppended()` returns null when its query matches no events, making this a real-world issue for any subscribed projector whose event type hasn't occurred yet.

- **`AppendListenerFailureTest.testListenerReportingNoProgressIsNotRedeliveredTo()`**: Added a new TCK test that verifies a listener returning null is not re-delivered to excessively. The test uses a bystander listener to confirm the notification round trip completed, then asserts the null-returning listener received at most 10 deliveries for a single append (separating "restrained" from "spinning" behavior).

- **`CLAUDE.md`**: Documented the issue and fix in the project conventions, explaining the root cause, why it affects ordinary listeners like `Projector`, and how the fix maintains backward compatibility.

## Implementation Details

The fix is minimal and safe: instead of only advancing `lastNotifiedReference` when the delegate returns non-null, it now always advances to at least the target. This works because:
- The next append carries a later reference, which is after the current target and will still be delivered
- No notification is lost by advancing here
- The interface contract is updated to give null a defined meaning rather than leaving it undefined
- Existing code that returns a reference continues to work exactly as before

https://claude.ai/code/session_01TEqyLx6ahzpdfhog25K5PV