### PR TITLE
Make batch durability guarantees explicit in projector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,39 @@ mvn clean install -DskipTests
 - Used for building read models from event streams
 - Optionally defines an `initQuery()` for the savepoint pattern (see below)
 
+**BatchAwareProjection — the seam between a projection's own store and the bookmark:**
+- A `BatchAwareProjection` commits its own work in `afterBatch`, and the bookmark saying how far it has
+  come lives in the event store. There is no transaction across the two, so the ordering is the whole
+  guarantee: **the batch is committed first and bookmarked second**, which makes a crash in that window
+  cost a re-projection and never a silent skip. At-least-once, deliberately, in that direction
+- **The bookmark is placed after every batch, not once per run.** It used to be written after the whole
+  `run()` loop, so a catch-up that committed 2000 batches and then died replayed all of them — the window
+  was the entire run rather than the 500 events the batch boundary suggests. The cost of the change is one
+  bookmark upsert per batch during a replay, which is what the bookmark is for
+- **A batch that fails takes the projector's cursor back with it.** `afterBatch` is called inside the
+  try, not from a `finally`: a commit that throws now rolls `lastEventReference` back to where the batch
+  started and is reported as a `ProjectorException` like any other projection failure. Before, it escaped
+  the projector as a bare `RuntimeException` **past** the bookmark placement while the in-memory cursor
+  stayed advanced — so the rolled-back batch's events were skipped for good, and a later successful batch
+  bookmarked over the hole. Nothing threw where anyone would see it, and downstream the untyped throwable
+  missed the `catch ( ProjectorException )` that would have stopped the processor, landing in a catch-all
+  that immediately looped: a projection whose commits kept failing re-queried and re-projected at full
+  thread speed
+- **A batch is ended exactly once.** `cancelBatch` is not called after an `afterBatch` that threw — that
+  projection has already released what it held — and a `cancelBatch` that throws is logged and attached
+  to the original failure as a **suppressed** exception rather than replacing it. It used to replace it,
+  so a poison event whose rollback also failed was reported as a rollback problem, sending whoever read
+  the log to the wrong store. `BatchAwareProjection.cancelBatch` had always documented the containment;
+  only now does it happen
+- **Where a re-projection would duplicate rather than merely repeat, the projection should hold its own
+  position.** `afterBatch` is handed the batch's last `EventReference` for exactly this: write it into the
+  same store, in the same transaction, and resume from it. Two stores that cannot share a transaction
+  cannot be made exactly-once any other way. `sliceworkz-eventmodeling`'s `SqlReadModelProjector` is the
+  worked example
+- `ProjectorBatchDurabilityTest` in the TCK pins all of it per backend: the bookmark visible from inside
+  the *second* batch already names the first, a failed commit is a `ProjectorException` and its events
+  come round again, and a failing rollback keeps the cause
+
 **Projection initQuery (Savepoint Pattern):**
 - Projections can define an optional `initQuery()` (default returns `null`) that runs before the main `eventQuery()`
 - Enables the savepoint pattern: a backward query with limit 1 finds the most recent savepoint event that summarizes prior state

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/BatchAwareProjection.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/BatchAwareProjection.java
@@ -118,8 +118,12 @@ public interface BatchAwareProjection<EVENT_TYPE> extends Projection<EVENT_TYPE>
 	 * After this method is called, the exception will be wrapped in a {@link ProjectorException}
 	 * and propagated to the caller.  No call to {@link #afterBatch(Optional)} will follow after this one.
 	 * <p>
+	 * It is <b>not</b> called after an {@link #afterBatch(Optional)} that threw: a batch is ended
+	 * exactly once, and a projection whose commit failed has already released what it held.
+	 * <p>
 	 * This method should handle exceptions gracefully and should not throw exceptions itself.
-	 * Any exceptions thrown from this method will be logged but otherwise ignored.
+	 * Any exception thrown from this method is logged and attached to the failure being handled as a
+	 * suppressed exception — it never replaces it, because the cause is what the caller needs.
 	 *
 	 * @see #beforeBatch()
 	 * @see #afterBatch(Optional)
@@ -133,7 +137,22 @@ public interface BatchAwareProjection<EVENT_TYPE> extends Projection<EVENT_TYPE>
 	 * {@link #when(org.sliceworkz.eventstore.events.Event)}. Use this to commit transactions,
 	 * flush accumulated changes, or clean up resources.
 	 * <p>
-	 * This method is not called if {@link #cancelBatch()} was called due to an error. 
+	 * This method is not called if {@link #cancelBatch()} was called due to an error.
+	 * <p>
+	 * <b>Throwing means the batch did not land.</b> The {@link Projector} treats it exactly like a
+	 * failure during processing: the exception is wrapped in a {@link ProjectorException} and reported
+	 * to the caller, and the projector's cursor is taken back to where the batch started, so the
+	 * events are offered again on the next run rather than skipped. Do not swallow a failed commit
+	 * here — a projection that reports success for work it did not persist loses those events with
+	 * nothing raised anywhere.
+	 * <p>
+	 * <b>Why {@code lastEventReference} is handed over.</b> The projector bookmarks it in the event
+	 * store <i>after</i> this method returns, so a crash in that window re-projects the batch. Where
+	 * that would duplicate rather than merely repeat work — a projection writing to a durable store of
+	 * its own — record this reference in that same store, inside the same transaction this method
+	 * commits, and resume from it. That makes the projection's own store the authority on how far it
+	 * has come, which is the only way to be exactly-once across two stores that cannot share a
+	 * transaction. The alternative is to make {@code when} idempotent.
 	 *
 	 * @param lastEventReference the reference of the last event processed in this batch,
 	 *                          or empty if no events matched the projection's query

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/projection/Projector.java
@@ -314,6 +314,9 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 
 			Optional<EventReference> lastReadAtStart = lastEventReference;
 
+			// what the bookmark already holds, so a batch that moved nothing places nothing
+			Optional<EventReference> bookmarked = lastReadAtStart;
+
 			// in order to avoid memory issues, we'll loop in batches om MAX_EVENTS_PER_QUERY, until no more events are found in the stream
 			Limit limit =  Limit.to(maxEventsPerQuery).orIfLower(projection.eventQuery().limit());
 
@@ -327,6 +330,13 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 			while ( !done ) {
 
 				Batch batch = new Batch(projection);
+
+				// where this batch started. A batch that does not land takes the cursor back with it:
+				// the projection rolled its own work back, so a cursor left beyond it would skip those
+				// events for good on the next run
+				Optional<EventReference> cursorBeforeBatch = lastEventReference;
+				EventReference lastReadBeforeBatch = lastRead;
+
 				try {
 
 					queriesDone++;
@@ -359,13 +369,25 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 					if ( !done && limit.isSet() && storedEventsCount.get() < limit.value() ) {
 						done = true;
 					}
+
+					// Ending the batch belongs inside the try, not in a finally. A projection commits
+					// here, and a commit that fails means this batch did not land -- which has to reach
+					// the catch below so the cursor goes back and the caller is told, rather than
+					// escaping past the bookmark as a bare RuntimeException.
+					batch.stopBatchIfNeeded(lastEventReference);
+
 				} catch ( Throwable t ) {
-					batch.failBatchIfNeeded();
+					batch.failBatchIfNeeded(t);
+					lastEventReference = cursorBeforeBatch;
+					lastRead = lastReadBeforeBatch;
 					exception = new ProjectorException(t, currentEventReference);
 					break;
-				} finally {
-					batch.stopBatchIfNeeded(lastEventReference);
 				}
+
+				// The batch is durable now, so the bookmark may record it -- and does so per batch
+				// rather than per run, because everything committed before a crash and not bookmarked
+				// is projected a second time on restart.
+				bookmarked = placeBookmarkIfMoved(bookmarked);
 
 				if ( queryTotalLimit.isSet() && eventsStreamed >= queryTotalLimit.value() ) {
 					break;
@@ -376,17 +398,33 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 				}
 			}
 
-
-			// if we have something new to put in the bookmark
 			if ( bookmarkReader != null && lastEventReference != null && lastEventReference.isPresent() ) {
-				if ( !lastEventReference.equals(lastReadAtStart)) {
-					es.placeBookmark(bookmarkReader, lastEventReference.get(), bookmarkTags);
-				}
 				LOGGER.debug("readmodel {} updated until {} with {} queries", projection, lastEventReference, queriesDone);
 			}
-			
-			
+
+
 			return new ProjectorRunResult ( new ProjectorMetrics ( eventsStreamed, eventsHandled, queriesDone, lastEventReference==null?null:lastEventReference.orElse(null), mostRecentEventReference), exception );
+		}
+
+		/**
+		 * Writes the bookmark when the cursor has moved past what it already holds, and reports where
+		 * it now stands.
+		 * <p>
+		 * Called once per committed batch. The ordering is load-bearing and one-directional: the batch
+		 * is durable before the bookmark names it, so a crash in between costs a re-projection of that
+		 * batch and never a silently skipped one. That is what makes projection at-least-once rather
+		 * than at-most-once, and it is why a projection writing to a store of its own wants to record
+		 * its own position inside its own transaction -- see {@link BatchAwareProjection#afterBatch}.
+		 */
+		private Optional<EventReference> placeBookmarkIfMoved ( Optional<EventReference> bookmarked ) {
+			if ( bookmarkReader == null || lastEventReference == null || lastEventReference.isEmpty() ) {
+				return bookmarked;
+			}
+			if ( lastEventReference.equals(bookmarked) ) {
+				return bookmarked;
+			}
+			es.placeBookmark(bookmarkReader, lastEventReference.get(), bookmarkTags);
+			return lastEventReference;
 		}
 	
 		private Event<CONSUMED_EVENT_TYPE> offerEventToProjection ( Event<CONSUMED_EVENT_TYPE> e, Projection<CONSUMED_EVENT_TYPE> projection, EventReference until, Batch batch ) {
@@ -1003,9 +1041,11 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 	 * and invoking the appropriate lifecycle methods at the correct times:
 	 * <ul>
 	 *   <li>{@link #startBatchIfNeeded(Event)} - Calls {@link BatchAwareProjection#beforeBatch()} before the first event</li>
-	 *   <li>{@link #failBatchIfNeeded()} - Calls {@link BatchAwareProjection#cancelBatch()} on error</li>
+	 *   <li>{@link #failBatchIfNeeded(Throwable)} - Calls {@link BatchAwareProjection#cancelBatch()} on error</li>
 	 *   <li>{@link #stopBatchIfNeeded(Optional)} - Calls {@link BatchAwareProjection#afterBatch(Optional)} after the batch</li>
 	 * </ul>
+	 * <p>
+	 * A batch is ended exactly once — by one of the last two, never both.
 	 * <p>
 	 * If the projection does not implement {@link BatchAwareProjection}, all methods are no-ops.
 	 */
@@ -1013,7 +1053,11 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 
 		private BatchAwareProjection<CONSUMED_EVENT_TYPE> batchAwareProjection;
 		private boolean started;
-		private boolean failed;
+
+		// afterBatch or cancelBatch has been entered. A batch is ended exactly once, whichever way it
+		// went: a projection whose commit threw has already released whatever it held, and rolling it
+		// back afterwards would be a second ending of a transaction that no longer exists
+		private boolean ended;
 
 		/**
 		 * Creates a new Batch instance for the given projection.
@@ -1051,12 +1095,29 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 		 * Cancels the batch if needed by calling {@link BatchAwareProjection#cancelBatch()}.
 		 * <p>
 		 * This method is called when an exception occurs during batch processing.
-		 * It will only invoke the callback if the batch was actually started.
+		 * It will only invoke the callback if the batch was actually started and has not already
+		 * been ended by {@link #stopBatchIfNeeded(Optional)}.
+		 * <p>
+		 * A {@code cancelBatch()} that throws is contained and attached to the failure that caused it
+		 * as a suppressed exception, never allowed to replace it: a rollback failing is a consequence
+		 * of whatever went wrong, and reporting the consequence instead of the cause is how a poison
+		 * event comes to be reported as a rollback problem. This is what
+		 * {@link BatchAwareProjection#cancelBatch()} has always documented.
+		 *
+		 * @param cause the failure being handled, which stays the one reported
 		 */
-		void failBatchIfNeeded ( ) {
-			if ( batchAwareProjection != null && started ) {
-				batchAwareProjection.cancelBatch();
-				failed = true;
+		void failBatchIfNeeded ( Throwable cause ) {
+			if ( batchAwareProjection != null && started && !ended ) {
+				ended = true;
+				try {
+					batchAwareProjection.cancelBatch();
+				} catch ( Throwable cancelFailure ) {
+					LOGGER.error("cancelBatch of {} failed while handling {} -- reporting the original failure",
+							projection, cause, cancelFailure);
+					if ( cause != null && cancelFailure != cause ) {
+						cause.addSuppressed(cancelFailure);
+					}
+				}
 			}
 		}
 
@@ -1064,12 +1125,16 @@ public class Projector<CONSUMED_EVENT_TYPE> implements EventStreamEventuallyCons
 		 * Stops the batch if needed by calling {@link BatchAwareProjection#afterBatch(Optional)}.
 		 * <p>
 		 * This method is called after successfully processing all events in a batch.
-		 * It will only invoke the callback if the batch was actually started.
+		 * It will only invoke the callback if the batch was actually started and has not already
+		 * been ended.
+		 * <p>
+		 * Anything it throws is the caller's to handle: it means the batch did not land.
 		 *
 		 * @param lastEventReference the reference of the last event processed, or empty if none
 		 */
 		void stopBatchIfNeeded ( Optional<EventReference> lastEventReference ) {
-			if ( batchAwareProjection != null && started && !failed ) {
+			if ( batchAwareProjection != null && started && !ended ) {
+				ended = true;
 				batchAwareProjection.afterBatch(lastEventReference);
 			}
 		}

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/projection/ProjectorBatchDurabilityTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/projection/ProjectorBatchDurabilityTest.java
@@ -1,0 +1,305 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck.projection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.projection.BatchAwareProjection;
+import org.sliceworkz.eventstore.projection.Projector;
+import org.sliceworkz.eventstore.projection.ProjectorException;
+import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.query.EventTypesFilter;
+import org.sliceworkz.eventstore.stream.AppendCriteria;
+import org.sliceworkz.eventstore.stream.EventStream;
+import org.sliceworkz.eventstore.stream.EventStreamId;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+import org.sliceworkz.eventstore.testing.tck.mockdomain.MockDomainEvent;
+import org.sliceworkz.eventstore.testing.tck.mockdomain.MockDomainEvent.FirstDomainEvent;
+
+/**
+ * What a batch boundary is worth to a projection that writes somewhere durable.
+ *
+ * <p>A {@link BatchAwareProjection} commits its own work in {@code afterBatch}, and the bookmark
+ * recording how far it has come lives in the event store — two stores with no transaction between
+ * them. Everything here is about the seam that leaves:
+ *
+ * <ul>
+ *   <li>the bookmark is written <b>per batch</b>, so a crash costs one batch and not the whole
+ *       catch-up run that had already committed twenty of them;</li>
+ *   <li>a batch whose commit <b>fails</b> takes the projector's cursor back with it, so its events
+ *       are offered again rather than skipped — the ordering is at-least-once, never at-most-once;</li>
+ *   <li>a failure is reported as a {@link ProjectorException} whatever part of the batch produced it,
+ *       so a caller that distinguishes projection failures from anything else still can;</li>
+ *   <li>a {@code cancelBatch} that throws never replaces the failure that caused it.</li>
+ * </ul>
+ */
+public class ProjectorBatchDurabilityTest extends AbstractEventStoreTest {
+
+	private static final String READER = "batch-durability";
+
+	private EventStream<MockDomainEvent> es;
+
+	@BeforeEach
+	void seedStream ( ) {
+		es = eventStore().getEventStream(EventStreamId.forContext("app").withPurpose("batchdurability"), MockDomainEvent.class);
+		for ( int i = 1; i <= 6; i++ ) {
+			es.append(AppendCriteria.none(), Collections.singletonList(Event.of(new FirstDomainEvent(String.valueOf(i)), Tags.none())));
+		}
+	}
+
+	/**
+	 * The bookmark moves while the run is still going. Read from inside the second batch it already
+	 * names the end of the first — where a bookmark placed once per run would still be absent, and a
+	 * crash anywhere in a long catch-up would replay every batch it had committed.
+	 */
+	@ForEachBackend
+	void aBookmarkIsPlacedAfterEveryBatchRatherThanOncePerRun ( ) {
+		RecordingProjection projection = new RecordingProjection();
+		projection.readBookmarkOnEachAfterBatch(es);
+
+		Projector<MockDomainEvent> projector = Projector.from(es).towards(projection)
+				.inBatchesOf(2)
+				.bookmarkProgress().withReader(READER).done()
+				.build();
+
+		projector.run();
+
+		assertEquals(3, projection.batchEnds().size(), "6 events in batches of 2 is three batches");
+
+		// what the bookmark held when each batch was about to commit
+		List<Optional<EventReference>> seen = projection.bookmarksSeen();
+		assertTrue(seen.get(0).isEmpty(), "nothing is bookmarked before the first batch commits");
+		assertEquals(projection.batchEnds().get(0), seen.get(1).orElse(null),
+				"the second batch sees the first one bookmarked -- the bookmark does not wait for the run to end");
+		assertEquals(projection.batchEnds().get(1), seen.get(2).orElse(null),
+				"and the third sees the second");
+
+		assertEquals(projection.batchEnds().get(2), es.getBookmark(READER).orElse(null),
+				"the run ends with the last batch bookmarked");
+	}
+
+	/**
+	 * A commit that fails means the batch did not land, and the events in it have to come round
+	 * again. Advancing the cursor past a rolled-back batch loses those events for good, with the
+	 * bookmark eventually written past the hole and nothing raised anywhere.
+	 */
+	@ForEachBackend
+	void aBatchWhoseCommitFailsIsProjectedAgainRatherThanSkipped ( ) {
+		RecordingProjection projection = new RecordingProjection();
+		projection.failCommitOfBatch(1);
+
+		Projector<MockDomainEvent> projector = Projector.from(es).towards(projection)
+				.inBatchesOf(2)
+				.bookmarkProgress().withReader(READER).readOnManualTriggerOnly().done()
+				.build();
+
+		ProjectorException failure = assertThrows(ProjectorException.class, projector::run,
+				"a failed commit is a projection failure, not a bare RuntimeException escaping the projector");
+		assertEquals("UNIT TEST FAKED COMMIT FAILURE", failure.getCause().getMessage());
+
+		assertTrue(es.getBookmark(READER).isEmpty(),
+				"nothing committed, so nothing is bookmarked");
+		assertEquals(2, projection.handled().size(), "the first batch was offered");
+
+		// the same events must be offered again -- the projector may not have moved past them
+		projection.handled().clear();
+		projector.run();
+
+		assertEquals(6, projection.handled().size(),
+				"every event is offered again, including the two whose batch failed to commit");
+	}
+
+	/** And the rest of the run is abandoned rather than committed on top of a batch that is not there. */
+	@ForEachBackend
+	void aBatchWhoseCommitFailsStopsTheRun ( ) {
+		RecordingProjection projection = new RecordingProjection();
+		projection.failCommitOfBatch(1);
+
+		Projector<MockDomainEvent> projector = Projector.from(es).towards(projection)
+				.inBatchesOf(2)
+				.bookmarkProgress().withReader(READER).readOnManualTriggerOnly().done()
+				.build();
+
+		assertThrows(ProjectorException.class, projector::run);
+
+		assertEquals(1, projection.batchesStarted(), "the batches behind a failed commit are not attempted");
+		assertEquals(0, projection.batchesCancelled(),
+				"and the batch is not cancelled on top of the commit that already ended it");
+	}
+
+	/**
+	 * The rollback is a consequence of the failure, so it never becomes the failure. Reporting a
+	 * rollback problem in place of the poison event that caused it sends whoever reads the log
+	 * looking in the wrong store.
+	 */
+	@ForEachBackend
+	void aRollbackThatFailsDoesNotReplaceTheFailureThatCausedIt ( ) {
+		RecordingProjection projection = new RecordingProjection();
+		projection.failOnEvent("2");
+		projection.failRollback();
+
+		Projector<MockDomainEvent> projector = Projector.from(es).towards(projection)
+				.inBatchesOf(2)
+				.bookmarkProgress().withReader(READER).readOnManualTriggerOnly().done()
+				.build();
+
+		ProjectorException failure = assertThrows(ProjectorException.class, projector::run);
+
+		assertEquals("UNIT TEST FAKED PROBLEM WITH EVENT PROCESSING", failure.getCause().getMessage(),
+				"the cause reported is the one that broke the batch");
+		assertEquals(1, failure.getCause().getSuppressed().length,
+				"the rollback failure is kept, attached to the cause rather than replacing it");
+		assertEquals("UNIT TEST FAKED ROLLBACK FAILURE", failure.getCause().getSuppressed()[0].getMessage());
+
+		assertTrue(es.getBookmark(READER).isEmpty(), "a batch that failed is not bookmarked");
+	}
+
+	/** A batch that never reached its first matching event has nothing to roll back either. */
+	@ForEachBackend
+	void aProjectionFailureRollsTheBatchBackAndIsReportedWithItsCause ( ) {
+		RecordingProjection projection = new RecordingProjection();
+		projection.failOnEvent("4");
+
+		Projector<MockDomainEvent> projector = Projector.from(es).towards(projection)
+				.inBatchesOf(2)
+				.bookmarkProgress().withReader(READER).readOnManualTriggerOnly().done()
+				.build();
+
+		ProjectorException failure = assertThrows(ProjectorException.class, projector::run);
+		assertSame(RuntimeException.class, failure.getCause().getClass());
+
+		assertEquals(1, projection.batchesCancelled(), "the failing batch is rolled back");
+		assertEquals(projection.batchEnds().get(0), es.getBookmark(READER).orElse(null),
+				"the batch that did commit stays bookmarked -- its work is durable and must not be repeated");
+		assertFalse(projection.batchEnds().isEmpty());
+	}
+
+	/**
+	 * A projection recording everything the projector did to it, and able to fail at each of the
+	 * three points a real one can: handling an event, committing, and rolling back.
+	 */
+	private static class RecordingProjection implements BatchAwareProjection<MockDomainEvent> {
+
+		private final List<EventReference> handled = new ArrayList<>();
+		private final List<EventReference> batchEnds = new ArrayList<>();
+		private final List<Optional<EventReference>> bookmarksSeen = new ArrayList<>();
+
+		private int batchesStarted;
+		private int batchesCancelled;
+
+		private EventStream<MockDomainEvent> bookmarkSource;
+		private int commitFailsOnBatch = -1;
+		private String failOnEvent;
+		private boolean rollbackFails;
+
+		private EventReference lastInBatch;
+
+		void readBookmarkOnEachAfterBatch ( EventStream<MockDomainEvent> source ) {
+			this.bookmarkSource = source;
+		}
+
+		void failCommitOfBatch ( int batchNumber ) {
+			this.commitFailsOnBatch = batchNumber;
+		}
+
+		void failOnEvent ( String id ) {
+			this.failOnEvent = id;
+		}
+
+		void failRollback ( ) {
+			this.rollbackFails = true;
+		}
+
+		List<EventReference> handled ( ) {
+			return handled;
+		}
+
+		List<EventReference> batchEnds ( ) {
+			return batchEnds;
+		}
+
+		List<Optional<EventReference>> bookmarksSeen ( ) {
+			return bookmarksSeen;
+		}
+
+		int batchesStarted ( ) {
+			return batchesStarted;
+		}
+
+		int batchesCancelled ( ) {
+			return batchesCancelled;
+		}
+
+		@Override
+		public EventQuery eventQuery ( ) {
+			return EventQuery.forEvents(EventTypesFilter.of(FirstDomainEvent.class), Tags.none());
+		}
+
+		@Override
+		public void when ( Event<MockDomainEvent> event ) {
+			if ( failOnEvent != null && event.data() instanceof FirstDomainEvent first && failOnEvent.equals(first.value()) ) {
+				throw new RuntimeException("UNIT TEST FAKED PROBLEM WITH EVENT PROCESSING");
+			}
+			handled.add(event.reference());
+			lastInBatch = event.reference();
+		}
+
+		@Override
+		public void beforeBatch ( ) {
+			batchesStarted++;
+			lastInBatch = null;
+		}
+
+		@Override
+		public void afterBatch ( Optional<EventReference> lastEventReference ) {
+			if ( bookmarkSource != null ) {
+				bookmarksSeen.add(bookmarkSource.getBookmark(READER));
+			}
+			if ( batchesStarted == commitFailsOnBatch ) {
+				throw new RuntimeException("UNIT TEST FAKED COMMIT FAILURE");
+			}
+			if ( lastInBatch != null ) {
+				batchEnds.add(lastInBatch);
+			}
+		}
+
+		@Override
+		public void cancelBatch ( ) {
+			batchesCancelled++;
+			if ( rollbackFails ) {
+				throw new RuntimeException("UNIT TEST FAKED ROLLBACK FAILURE");
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

This change makes the durability guarantees of batch-aware projections explicit and correct in the `Projector` implementation. Previously, bookmarks were placed once per run and failures during `afterBatch()` could silently skip events. Now, bookmarks are placed after every committed batch, failed batches take the cursor back, and batch lifecycle is properly managed to ensure at-least-once semantics.

## Key Changes

- **Per-batch bookmark placement**: Bookmarks are now written after every successfully committed batch rather than once at the end of the entire run. This reduces the replay window from the entire catch-up run to a single batch on crash.

- **Batch failure handling**: When `afterBatch()` throws, the projector's cursor is rolled back to where the batch started, ensuring those events are offered again on the next run rather than silently skipped. The failure is wrapped in `ProjectorException` like any other projection failure.

- **Batch lifecycle management**: A batch is now ended exactly once — either by `afterBatch()` or `cancelBatch()`, never both. This prevents double-ending of transactions and ensures proper resource cleanup.

- **Failure containment**: When `cancelBatch()` throws during error handling, the exception is logged and attached as a suppressed exception to the original failure rather than replacing it. This ensures the poison event is reported, not the rollback problem.

- **Cursor management**: Added explicit tracking of cursor position before each batch (`cursorBeforeBatch`, `lastReadBeforeBatch`) to enable proper rollback when a batch fails to commit.

- **Documentation**: Updated `BatchAwareProjection` javadoc to clarify the new semantics, particularly that `afterBatch()` throwing means the batch did not land and events will be re-projected, and that projections should record their own position in their own transaction for exactly-once semantics.

- **TCK test**: Added `ProjectorBatchDurabilityTest` to verify per-backend that:
  - Bookmarks are visible from inside the second batch (already naming the first)
  - Failed commits are reported as `ProjectorException` and events are re-projected
  - Failing rollbacks keep the original cause
  - Batches that fail stop the run rather than continuing

## Implementation Details

The key ordering change is moving `batch.stopBatchIfNeeded()` from a `finally` block into the `try` block, so that a commit failure is caught and handled like any other projection failure. The cursor is explicitly restored on catch, and bookmark placement happens after the catch block only if the batch succeeded.

The `Batch` class now tracks `ended` instead of `failed` to enforce the exactly-once guarantee, and `failBatchIfNeeded()` now takes the `Throwable` cause to enable proper exception chaining.

https://claude.ai/code/session_011axAjcvQDnbCYxaWTJVch7