### PR TITLE
Add lease-based leader election support to EventStore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,52 @@ re-delivered the same target without pausing: ~700.000 deliveries a second on on
   null is given a defined meaning rather than left to whoever reads the contract more carefully.
 - `AppendListenerFailureTest.testListenerReportingNoProgressIsNotRedeliveredTo` pins it per backend.
 
+### Leases: electing one processor among several instances
+
+**The storage can hold named leases, which is what a framework builds leader election on** — one
+instance of a deployment holds a lease and processes; the others stand by and take over when it
+expires or is released. Three optional SPI methods on `EventStorage` (`UnsupportedOperationException`
+defaults, the `importEvents` precedent; `Capability.LEASE` gates the TCK scenarios, and its
+`supports()` default answers **false**, so a backend written before leases existed skips them —
+which is also why `supports()` is now an exhaustive switch rather than "true for anything new"):
+
+- **`requestLease(LeaseRequest)` is acquisition, renewal and contender registration in one call**,
+  made periodically by every contender (a third of the ttl is a sensible interval). It answers
+  `LEADER`, `STANDBY`, or `LEADER_STEP_DOWN_REQUESTED` — still leader, but a live contender with a
+  **strictly higher** priority is waiting, so finish the current work and `releaseLease`. The storage
+  never revokes a live lease itself; a step-down is always the holder's own act. Equal priority never
+  triggers a step-down
+- **Expiry is judged on the storage's clock, never a contender's.** A lease whose heartbeat is older
+  than the ttl it was requested with is expired and acquirable. Contenders only ever measure
+  durations on their own clocks (their polling interval, the time since their last *confirmed*
+  renewal) — the single-writer guarantee is "storage-clock expiry plus self-demotion on the caller
+  clock before the ttl", and it holds up to a caller paused beyond its ttl, which no lease can
+  prevent and the fencing token exists to expose
+- **The fencing token strictly increases on every ownership change and never resets** — a release
+  *backdates the heartbeat* rather than deleting the row, precisely so the token survives (the TCK
+  caught the delete-based version minting token 1 twice). Renewals keep the token
+- **In-memory backends contend for real within one storage instance** (the same `synchronized` that
+  gives them DCB atomicity), so a single process trivially wins everything while a test can genuinely
+  elect between two contenders on any backend. The fs decorator forwards explicitly and deliberately
+  does not persist leases: a lease held by a process that no longer runs must expire, not be
+  resurrected on reload
+- **On Postgres, leases are two tables outside the event log** (`<prefix>leases`,
+  `<prefix>lease_contenders`), written in one short transaction on the ordinary pool, serialized per
+  lease by a `pg_advisory_xact_lock` on a NUL-prefixed scope (`leaseLockKey`, sharing
+  `advisoryLockKey` with the append and schema locks, colliding with neither). Consequences worth
+  spelling out: election traffic takes no lock any event query or append takes; a waiting contender
+  holds no transaction id, and the lease writes are milliseconds — so leases neither pin
+  `pg_snapshot_xmin` nor are subject to it (which is also why a lease is deliberately **not**
+  modelled as events: event reads sit behind the xmin barrier, and one long writing transaction
+  anywhere in the cluster would make every lease look expired at once). All timestamps compare via
+  `now()` in SQL only. `checkDatabase()` validates both tables, so `VALIDATE`/`NONE` deployments
+  notice an un-migrated database; the README's privilege table carries the grants (the leases table
+  needs no `DELETE` — releases update; contender rows are pruned, so that table does)
+- `LeaseTest` in the TCK pins the state machine per backend: acquire/renew/expire/release, the
+  step-down protocol and its lapse with a dead contender, fencing monotonicity across takeovers and
+  releases, independence of distinct leases, post-close behaviour — and, load-bearing above all,
+  that exactly one of N concurrent contenders wins an acquirable lease
+
 ### Metrics: what the stream meters cost, and the cap on `purpose`
 
 Every meter the store registers is tagged `context`, `purpose`, `typed`, `storage`, and two of them

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Lease.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/events/Lease.java
@@ -1,0 +1,70 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.events;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A named lease held by a single owner, used to elect one processor among several instances.
+ * <p>
+ * Leases are produced by {@code requestLease(...)} on the
+ * {@link org.sliceworkz.eventstore.spi.EventStorage} SPI and surfaced as a snapshot list via
+ * {@code getLeases()}. A lease is <em>live</em> while its {@link #heartbeatAt()} is younger than the
+ * time-to-live it was requested with, measured on the <b>storage's clock</b> — never on any
+ * contender's clock. An expired lease is not removed; it merely becomes acquirable, and the next
+ * successful acquisition overwrites it with a higher {@link #fencingToken()}.
+ * <p>
+ * The fencing token increases strictly on every change of ownership and is stable across renewals
+ * by the same owner, so work stamped with an older token can be recognised as coming from a
+ * superseded leader.
+ *
+ * @param leaseName    the globally unique name of the lease (storage-wide, like a bookmark reader)
+ * @param owner        the identifier of the owner currently holding (or last holding) the lease
+ * @param priority     the priority the owner requested the lease with; a live contender with a
+ *                     strictly higher priority makes the storage ask the owner to step down
+ * @param fencingToken monotonically increasing per ownership change, starting at 1 for the first owner
+ * @param acquiredAt   the storage-clock instant at which the current owner acquired the lease
+ * @param heartbeatAt  the storage-clock instant of the owner's most recent successful renewal
+ * @param ttl          the time-to-live the owner requested; the lease expires when
+ *                     {@link #heartbeatAt()} is older than this on the storage's clock
+ */
+public record Lease ( String leaseName, String owner, long priority, long fencingToken, Instant acquiredAt, Instant heartbeatAt, Duration ttl ) {
+
+	public Lease {
+		Objects.requireNonNull(leaseName, "leaseName must not be null");
+		Objects.requireNonNull(owner, "owner must not be null");
+		Objects.requireNonNull(acquiredAt, "acquiredAt must not be null");
+		Objects.requireNonNull(heartbeatAt, "heartbeatAt must not be null");
+		Objects.requireNonNull(ttl, "ttl must not be null");
+	}
+
+	/**
+	 * Whether this lease is expired — and so acquirable by any contender — at the given instant.
+	 * The instant must come from the same clock that produced {@link #heartbeatAt()}, i.e. the
+	 * storage's clock; comparing against a contender's clock is exactly what leases exist to avoid.
+	 *
+	 * @param now the current instant on the storage's clock
+	 * @return true when the last heartbeat is older than the lease's time-to-live
+	 */
+	public boolean isExpiredAt ( Instant now ) {
+		return heartbeatAt.plus(ttl).isBefore(now);
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -17,12 +17,15 @@
  */
 package org.sliceworkz.eventstore.spi;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.sliceworkz.eventstore.events.Bookmark;
+import org.sliceworkz.eventstore.events.Lease;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.EventType;
@@ -156,7 +159,8 @@ public interface EventStorage extends AutoCloseable {
 	 *   <li><b>Terminal.</b> A closed storage cannot be reopened.</li>
 	 *   <li><b>Operations throw afterwards.</b> {@link #query}, {@link #append}, {@link #importEvents},
 	 *       {@link #getEventById}, {@link #subscribe}, {@link #bookmark}, {@link #getBookmark},
-	 *       {@link #getBookmarks} and {@link #removeBookmark} throw
+	 *       {@link #getBookmarks}, {@link #removeBookmark}, {@link #requestLease},
+	 *       {@link #releaseLease} and {@link #getLeases} throw
 	 *       {@link EventStorageClosedException} once the storage is closed. Continuing to serve reads
 	 *       and writes while notifications are dead is not an acceptable alternative: it strands
 	 *       projections silently. {@link #name()} keeps working, so logging and diagnostics do not
@@ -582,6 +586,180 @@ public interface EventStorage extends AutoCloseable {
 	 * @see #getBookmark(String)
 	 */
 	List<Bookmark> getBookmarks ( );
+
+	/**
+	 * Requests — or renews — a named lease for the given owner, registering the owner as a live
+	 * contender either way. This is the single operation behind leader election: every contender
+	 * calls it periodically (well within {@link LeaseRequest#ttl()}), and the returned
+	 * {@link LeaseStatus} tells it what it is right now.
+	 * <p>
+	 * Semantics, which every implementation must honour identically:
+	 * <ul>
+	 *   <li><b>Acquisition.</b> If the lease does not exist, or exists but has expired — its last
+	 *       heartbeat is older than the time-to-live it was requested with, measured on the
+	 *       <b>storage's clock</b> — the caller becomes the owner. The fencing token is one higher
+	 *       than the previous owner's (starting at 1), and the response is {@link LeaseStatus#LEADER}.</li>
+	 *   <li><b>Renewal.</b> If the caller already owns the lease, its heartbeat and priority are
+	 *       refreshed and the fencing token is unchanged. The response is {@link LeaseStatus#LEADER} —
+	 *       unless a <em>live</em> contender with a <b>strictly higher</b> priority exists, in which
+	 *       case it is {@link LeaseStatus#LEADER_STEP_DOWN_REQUESTED}: the caller still holds the
+	 *       lease and remains the only legitimate processor, but is asked to finish its current work
+	 *       and {@link #releaseLease(String, String) release}. The storage never revokes a live lease
+	 *       itself; a leader that cannot step down safely may keep renewing. Contenders with an equal
+	 *       or lower priority never trigger a step-down request.</li>
+	 *   <li><b>Standby.</b> If another owner holds a live lease, the caller is recorded as a live
+	 *       contender at its requested priority and gets {@link LeaseStatus#STANDBY}. A contender is
+	 *       considered live while its own last request is younger than the time-to-live it passed.</li>
+	 * </ul>
+	 * <p>
+	 * The single-writer guarantee this gives a caller: between two calls that both returned
+	 * {@code LEADER} (or {@code LEADER_STEP_DOWN_REQUESTED}) no other owner has held the lease —
+	 * provided the caller stops acting as leader the moment it can no longer <em>confirm</em> a
+	 * renewal within the ttl it requested. A caller whose renewal call fails or hangs must demote
+	 * itself on its own clock rather than assume it is still the leader; expiry on the storage clock
+	 * plus self-demotion on the caller clock is what keeps two leaders from overlapping (modulo a
+	 * caller paused beyond its ttl, which no lease can prevent — the fencing token exists so such a
+	 * zombie's writes can be recognised).
+	 * <p>
+	 * Expiry never depends on any contender's clock, so contenders' clocks need not agree with each
+	 * other or with the storage. Callers only measure durations (their own polling interval and the
+	 * time since their last confirmed renewal), never compare instants across machines.
+	 *
+	 * @param request the lease name, owner identity, priority and time-to-live (must not be null)
+	 * @return the caller's resulting status, never null
+	 * @throws EventStorageException if an error occurs while reading or writing the lease
+	 * @throws UnsupportedOperationException if this storage implementation does not support leases
+	 * @see #releaseLease(String, String)
+	 * @see #getLeases()
+	 */
+	default LeaseResponse requestLease ( LeaseRequest request ) {
+		throw new UnsupportedOperationException("%s does not support leases".formatted(name()));
+	}
+
+	/**
+	 * Releases a lease held by the given owner, so the next {@link #requestLease(LeaseRequest)} by
+	 * any contender acquires it immediately instead of waiting out the time-to-live. The owner's
+	 * contender registration is withdrawn as well.
+	 * <p>
+	 * A release makes the lease immediately expired; it does not erase it. The record — most
+	 * importantly its fencing token — survives, so the next acquisition still increments over it:
+	 * fencing tokens stay strictly monotonic per lease across releases, never resetting.
+	 * <p>
+	 * Idempotent and forgiving: releasing a lease the owner does not hold — because it expired and
+	 * was taken over, or was never acquired — does nothing and does not throw. A release never
+	 * touches a lease currently held by a <em>different</em> owner.
+	 *
+	 * @param leaseName the name of the lease to release
+	 * @param owner the owner releasing it; only a lease held by exactly this owner is released
+	 * @throws EventStorageException if an error occurs while releasing the lease
+	 * @throws UnsupportedOperationException if this storage implementation does not support leases
+	 * @see #requestLease(LeaseRequest)
+	 */
+	default void releaseLease ( String leaseName, String owner ) {
+		throw new UnsupportedOperationException("%s does not support leases".formatted(name()));
+	}
+
+	/**
+	 * Retrieves all leases currently recorded by this storage, including expired ones that have not
+	 * been taken over yet (an expired lease keeps its last owner and heartbeat until someone else
+	 * acquires it — liveness is judged against {@link Lease#heartbeatAt()}, not against presence in
+	 * this list).
+	 * <p>
+	 * Like bookmarks, leases are addressed globally by name, so the returned list spans the entire
+	 * storage. The list is a snapshot taken at call time; order is unspecified.
+	 *
+	 * @return a snapshot list of all leases; empty if none exist
+	 * @throws EventStorageException if an error occurs while reading leases
+	 * @throws UnsupportedOperationException if this storage implementation does not support leases
+	 * @see Lease
+	 */
+	default List<Lease> getLeases ( ) {
+		throw new UnsupportedOperationException("%s does not support leases".formatted(name()));
+	}
+
+	/**
+	 * A request to acquire or renew a lease — the input to {@link #requestLease(LeaseRequest)}.
+	 * <p>
+	 * The time-to-live is the window within which the owner must renew: a lease whose last
+	 * heartbeat is older than this, on the storage's clock, is expired and acquirable by anyone.
+	 * The caller must therefore call {@link #requestLease(LeaseRequest)} well within every ttl —
+	 * a third of it is a sensible interval, leaving two failed attempts before leadership lapses.
+	 *
+	 * @param leaseName the globally unique name of the lease (must not be null or blank)
+	 * @param owner the identity of the requester; must be stable for the requester's lifetime and
+	 *              unique among contenders (must not be null or blank)
+	 * @param priority the requester's priority; a live contender with a strictly higher priority
+	 *                 makes the storage ask the current owner to step down
+	 * @param ttl the time-to-live of the granted or renewed lease (must be positive)
+	 */
+	record LeaseRequest ( String leaseName, String owner, long priority, Duration ttl ) {
+
+		public LeaseRequest {
+			Objects.requireNonNull(leaseName, "leaseName must not be null");
+			Objects.requireNonNull(owner, "owner must not be null");
+			Objects.requireNonNull(ttl, "ttl must not be null");
+			if ( leaseName.isBlank() ) {
+				throw new IllegalArgumentException("leaseName must not be blank");
+			}
+			if ( owner.isBlank() ) {
+				throw new IllegalArgumentException("owner must not be blank");
+			}
+			if ( ttl.isNegative() || ttl.isZero() ) {
+				throw new IllegalArgumentException("ttl must be positive, but was " + ttl);
+			}
+		}
+
+	}
+
+	/**
+	 * The outcome of a {@link #requestLease(LeaseRequest)} call.
+	 *
+	 * @param status what the caller is after this call — see {@link LeaseStatus}
+	 * @param fencingToken the lease's current fencing token: the caller's own token when it is the
+	 *                     leader, the current holder's when it is standing by. Strictly increases on
+	 *                     every ownership change, stable across renewals
+	 * @param currentOwner the owner holding the lease after this call (the caller itself when leader)
+	 */
+	record LeaseResponse ( LeaseStatus status, long fencingToken, String currentOwner ) {
+
+		public LeaseResponse {
+			Objects.requireNonNull(status, "status must not be null");
+			Objects.requireNonNull(currentOwner, "currentOwner must not be null");
+		}
+
+	}
+
+	/**
+	 * What a contender is, as answered by {@link #requestLease(LeaseRequest)}.
+	 *
+	 * @see LeaseResponse
+	 */
+	enum LeaseStatus {
+
+		/**
+		 * The caller holds the lease: it is the single legitimate processor until the ttl it
+		 * requested runs out, and renewing within the ttl extends that indefinitely.
+		 */
+		LEADER,
+
+		/**
+		 * The caller still holds the lease — everything {@link #LEADER} means still applies — but a
+		 * live contender with a strictly higher priority is waiting. The caller should finish its
+		 * current unit of work and {@link #releaseLease(String, String) release}, so the
+		 * higher-priority contender acquires on its next request instead of waiting out the ttl.
+		 * The storage never enforces this; a caller that keeps renewing keeps the lease.
+		 */
+		LEADER_STEP_DOWN_REQUESTED,
+
+		/**
+		 * Another owner holds a live lease. The caller has been recorded as a live contender at its
+		 * requested priority and should simply keep requesting: it acquires when the lease expires,
+		 * is released, or — if its priority is strictly higher — when the owner honours the
+		 * step-down request.
+		 */
+		STANDBY
+
+	}
 
 	/**
 	 * Notification sent when new events are appended to the event store.

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Lease;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.infra.inmem.InMemoryEventStorage;
 import org.sliceworkz.eventstore.query.EventQuery;
@@ -163,6 +164,25 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 	public void removeBookmark ( String reader ) {
 		delegate.removeBookmark(reader);
 		deleteBookmark(reader);
+	}
+
+	// Leases are deliberately NOT persisted: a lease held by a process that no longer runs must
+	// expire, not be resurrected on reload. Forwarded explicitly all the same — inheriting the SPI
+	// defaults would make this storage claim "unsupported" while its delegate supports them.
+
+	@Override
+	public LeaseResponse requestLease ( LeaseRequest request ) {
+		return delegate.requestLease(request);
+	}
+
+	@Override
+	public void releaseLease ( String leaseName, String owner ) {
+		delegate.releaseLease(leaseName, owner);
+	}
+
+	@Override
+	public List<Lease> getLeases ( ) {
+		return delegate.getLeases();
 	}
 
 	/**

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -17,6 +17,7 @@
  */
 package org.sliceworkz.eventstore.infra.inmem;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
+import org.sliceworkz.eventstore.events.Lease;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventQuery;
 import org.sliceworkz.eventstore.query.Limit;
@@ -122,6 +124,13 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	// (un)subscription, and notifying must not block appends.
 	private final CopyOnWriteArrayList<EventStoreListener> listeners = new CopyOnWriteArrayList<>();
 	private Map<String,Bookmark> bookmarks = new HashMap<>();
+	// Leases are runtime coordination state, not data: they are neither preloaded nor persisted (the
+	// filesystem-backed decorator snapshots events and bookmarks, deliberately not leases — a lease
+	// held by a process that no longer runs must expire, not be resurrected). Real contention happens
+	// within one storage instance, so tests can elect between two contenders on any backend; in a
+	// single-process deployment the only contender trivially wins.
+	private Map<String,Lease> leases = new HashMap<>();
+	private Map<String,Map<String,LeaseContender>> leaseContenders = new HashMap<>();
 	private JsonMapper jsonMapper;
 	private Limit absoluteLimit;
 	private long txCounter;
@@ -511,6 +520,67 @@ public class InMemoryEventStorageImpl implements EventStorage {
 		listeners.forEach(l->notifyQuietly(l, notification));
 	}
 
+	/*
+	 * Synchronized like every other state-touching operation here, which is what makes the
+	 * expiry check and the takeover one atomic step: two contenders racing an expired lease
+	 * cannot both acquire it.
+	 */
+	@Override
+	public synchronized LeaseResponse requestLease ( LeaseRequest request ) {
+		checkNotClosed();
+		if ( request == null ) {
+			throw new IllegalArgumentException("lease request must not be null");
+		}
+		Instant now = Instant.now();
+
+		// register (or refresh) the caller as a live contender, and prune contenders long gone
+		Map<String,LeaseContender> contenders = leaseContenders.computeIfAbsent(request.leaseName(), k -> new HashMap<>());
+		contenders.put(request.owner(), new LeaseContender(request.priority(), now, request.ttl()));
+		contenders.values().removeIf(c -> c.heartbeatAt().plus(c.ttl().multipliedBy(10)).isBefore(now));
+
+		Lease current = leases.get(request.leaseName());
+		boolean acquirable = current == null || current.isExpiredAt(now) || current.owner().equals(request.owner());
+		if ( !acquirable ) {
+			return new LeaseResponse(LeaseStatus.STANDBY, current.fencingToken(), current.owner());
+		}
+
+		boolean ownershipChange = current == null || !current.owner().equals(request.owner());
+		long fencingToken = current == null ? 1 : ownershipChange ? current.fencingToken() + 1 : current.fencingToken();
+		Instant acquiredAt = ownershipChange ? now : current.acquiredAt();
+		leases.put(request.leaseName(), new Lease(request.leaseName(), request.owner(), request.priority(), fencingToken, acquiredAt, now, request.ttl()));
+
+		boolean higherPriorityContenderWaiting = contenders.entrySet().stream()
+				.anyMatch(e -> !e.getKey().equals(request.owner())
+						&& e.getValue().priority() > request.priority()
+						&& !e.getValue().heartbeatAt().plus(e.getValue().ttl()).isBefore(now));
+		LeaseStatus status = higherPriorityContenderWaiting ? LeaseStatus.LEADER_STEP_DOWN_REQUESTED : LeaseStatus.LEADER;
+		return new LeaseResponse(status, fencingToken, request.owner());
+	}
+
+	@Override
+	public synchronized void releaseLease ( String leaseName, String owner ) {
+		checkNotClosed();
+		Lease current = leases.get(leaseName);
+		if ( current != null && current.owner().equals(owner) ) {
+			// force-expire rather than delete: the fencing token must survive the release, or the
+			// next owner would mint token 1 again and a superseded leader's stamp would look current
+			leases.put(leaseName, new Lease(leaseName, current.owner(), current.priority(), current.fencingToken(), current.acquiredAt(), Instant.EPOCH, current.ttl()));
+		}
+		Map<String,LeaseContender> contenders = leaseContenders.get(leaseName);
+		if ( contenders != null ) {
+			contenders.remove(owner);
+			if ( contenders.isEmpty() ) {
+				leaseContenders.remove(leaseName);
+			}
+		}
+	}
+
+	@Override
+	public synchronized List<Lease> getLeases ( ) {
+		checkNotClosed();
+		return List.copyOf(leases.values());
+	}
+
 	/**
 	 * Determines the effective limit to apply to a query based on both soft and absolute limits.
 	 * <p>
@@ -615,6 +685,13 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	 * is scoped per stream (context + purpose) rather than globally across the storage instance.
 	 */
 	private record IdempotencyScope ( EventStreamId stream, String idempotencyKey ) {
+	}
+
+	/**
+	 * A contender for a lease: its priority, and the heartbeat + ttl its liveness is judged by.
+	 * Liveness uses the contender's <em>own</em> requested ttl, mirroring how the lease itself expires.
+	 */
+	private record LeaseContender ( long priority, Instant heartbeatAt, Duration ttl ) {
 	}
 
 }

--- a/sliceworkz-eventstore-infra-postgres/README.md
+++ b/sliceworkz-eventstore-infra-postgres/README.md
@@ -23,12 +23,16 @@ Every mode needs these at runtime. They come for free when the role created the 
 DBA created them, they have to be granted:
 
 ```sql
-GRANT SELECT, INSERT                 ON <prefix>events    TO <role>;
-GRANT SELECT, INSERT, UPDATE, DELETE ON <prefix>bookmarks TO <role>;
+GRANT SELECT, INSERT                 ON <prefix>events           TO <role>;
+GRANT SELECT, INSERT, UPDATE, DELETE ON <prefix>bookmarks        TO <role>;
+GRANT SELECT, INSERT, UPDATE         ON <prefix>leases           TO <role>;
+GRANT SELECT, INSERT, UPDATE, DELETE ON <prefix>lease_contenders TO <role>;
 GRANT USAGE                          ON SEQUENCE <prefix>events_event_position_seq TO <role>;
 ```
 
-Events are never updated or deleted — the store only ever appends to that table.
+Events are never updated or deleted — the store only ever appends to that table. Lease rows are
+never deleted either (a release backdates the heartbeat so the fencing token survives), so the
+leases table needs no `DELETE`; contender rows are pruned, so that table does.
 
 **`CREATE` on the schema and `CREATE` on the database are different privileges**, and this is the
 one place the difference shows. `btree_gin` is a *trusted* extension (PostgreSQL 13+), so installing

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -71,6 +71,7 @@ import org.sliceworkz.eventstore.events.Bookmark;
 import org.sliceworkz.eventstore.events.EventId;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.EventType;
+import org.sliceworkz.eventstore.events.Lease;
 import org.sliceworkz.eventstore.events.Tag;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventFilter;
@@ -484,6 +485,10 @@ public class PostgresEventStorageImpl implements EventStorage {
 			// Check bookmarks table
 			checkBookmarksTable(readConnection);
 
+			// Check lease tables (leader election)
+			checkLeasesTable(readConnection);
+			checkLeaseContendersTable(readConnection);
+
 			// Check functions
 			checkFunction(readConnection, prefix + "notify_event_appended");
 			checkFunction(readConnection, prefix + "notify_bookmark_placed");
@@ -553,6 +558,42 @@ public class PostgresEventStorageImpl implements EventStorage {
 
 		// Check foreign key constraint
 		checkForeignKey(connection, tableName, "fk_bookmarks_event_id");
+
+		LOGGER.debug("Table {} validated successfully", tableName);
+	}
+
+	private void checkLeasesTable(Connection connection) throws SQLException {
+		String tableName = prefix + "leases";
+		LOGGER.debug("Checking table: {}", tableName);
+
+		if (!tableExists(connection, tableName)) {
+			throw new EventStorageException("Required table '%s' does not exist".formatted(tableName));
+		}
+
+		checkColumn(connection, tableName, "lease_name", "text", false);
+		checkColumn(connection, tableName, "lease_owner", "text", false);
+		checkColumn(connection, tableName, "priority", "bigint", false);
+		checkColumn(connection, tableName, "fencing_token", "bigint", false);
+		checkColumn(connection, tableName, "ttl_millis", "bigint", false);
+		checkColumn(connection, tableName, "acquired_at", "timestamp with time zone", false);
+		checkColumn(connection, tableName, "heartbeat_at", "timestamp with time zone", false);
+
+		LOGGER.debug("Table {} validated successfully", tableName);
+	}
+
+	private void checkLeaseContendersTable(Connection connection) throws SQLException {
+		String tableName = prefix + "lease_contenders";
+		LOGGER.debug("Checking table: {}", tableName);
+
+		if (!tableExists(connection, tableName)) {
+			throw new EventStorageException("Required table '%s' does not exist".formatted(tableName));
+		}
+
+		checkColumn(connection, tableName, "lease_name", "text", false);
+		checkColumn(connection, tableName, "contender", "text", false);
+		checkColumn(connection, tableName, "priority", "bigint", false);
+		checkColumn(connection, tableName, "ttl_millis", "bigint", false);
+		checkColumn(connection, tableName, "heartbeat_at", "timestamp with time zone", false);
 
 		LOGGER.debug("Table {} validated successfully", tableName);
 	}
@@ -1255,6 +1296,19 @@ public class PostgresEventStorageImpl implements EventStorage {
 	/** Lock scope used when an append is not confined to one fully specified stream. */
 	private static final String ANY_STREAM_SCOPE = "\u0000any-stream";
 
+	/**
+	 * Lock scope prefix for lease operations; see {@link #leaseLockKey}. NUL-prefixed like
+	 * {@link #SCHEMA_SCOPE}, so no stream scope can collide with it.
+	 */
+	private static final String LEASE_SCOPE = "\u0000lease";
+
+	/**
+	 * Statement that serializes the contenders for one lease; see {@link #leaseLockKey}. Textually the
+	 * same lock statement as the append and schema ones, kept separate because it serializes a
+	 * different thing.
+	 */
+	private static final String ACQUIRE_LEASE_LOCK = "SELECT pg_advisory_xact_lock(?)";
+
 	/** Separates the parts of a lock scope, so that ("ab","c") and ("a","bc") cannot hash alike. */
 	private static final char UNIT_SEPARATOR = '\u001F';
 
@@ -1305,6 +1359,22 @@ public class PostgresEventStorageImpl implements EventStorage {
 	 */
 	private long schemaLockKey ( ) {
 		return advisoryLockKey(SCHEMA_SCOPE);
+	}
+
+	/**
+	 * Advisory lock key that serializes {@code requestLease}/{@code releaseLease} calls for one lease,
+	 * so the expiry check and the takeover are one indivisible step: two contenders racing an expired
+	 * lease cannot both read it as expired and both acquire it. Keyed per lease name, so contenders
+	 * for different leases never take turns, and derived exactly like the append and schema keys —
+	 * from a scope no stream can produce, so lease traffic never contends with an append, and never
+	 * with an event query, which takes no lock at all.
+	 * <p>
+	 * Transaction-scoped ({@code pg_advisory_xact_lock}), held only for the few statements of one
+	 * lease request — and a transaction that has only taken an advisory lock holds no transaction id,
+	 * so a waiting contender does not pin {@code pg_snapshot_xmin} and cannot stall event visibility.
+	 */
+	private long leaseLockKey ( String leaseName ) {
+		return advisoryLockKey(LEASE_SCOPE + UNIT_SEPARATOR + leaseName);
 	}
 
 	/**
@@ -2294,6 +2364,242 @@ public class PostgresEventStorageImpl implements EventStorage {
 		} catch (SQLException e) {
 			throw new EventStorageException("Failed to close connection", e);
 		}
+	}
+
+	/*
+	 * One short transaction on the ordinary pool: advisory lock (per lease, holds no transaction id),
+	 * contender upsert, acquire-or-renew upsert, contender check, commit. Every temporal comparison is
+	 * now() on the database server — no contender clock ever enters the SQL — and nothing here touches
+	 * the events table or takes any lock an event query or append takes, so election traffic can
+	 * neither delay event reads nor be stalled by the pg_snapshot_xmin visibility barrier.
+	 */
+	@Override
+	public LeaseResponse requestLease ( LeaseRequest request ) {
+		checkNotClosed();
+		if ( request == null ) {
+			throw new IllegalArgumentException("lease request must not be null");
+		}
+
+		String registerContender = """
+			INSERT INTO %slease_contenders (lease_name, contender, priority, ttl_millis, heartbeat_at)
+			VALUES (?, ?, ?, ?, now())
+			ON CONFLICT (lease_name, contender)
+			DO UPDATE SET
+				priority = EXCLUDED.priority,
+				ttl_millis = EXCLUDED.ttl_millis,
+				heartbeat_at = now()
+		""".formatted(prefix);
+
+		// prune contender rows dead for many times their own ttl; opportunistic housekeeping only,
+		// liveness below never depends on it
+		String pruneContenders = """
+			DELETE FROM %slease_contenders
+			WHERE lease_name = ?
+			  AND heartbeat_at < now() - (ttl_millis * 10 * interval '1 millisecond')
+		""".formatted(prefix);
+
+		// the WHERE keeps the update away from a live lease of another owner: the row only changes for
+		// a renewal by the current owner or a takeover of an expired lease. The fencing token bumps on
+		// takeover and only then; acquired_at survives a renewal.
+		String acquireOrRenew = """
+			INSERT INTO %sleases AS l (lease_name, lease_owner, priority, fencing_token, ttl_millis, acquired_at, heartbeat_at)
+			VALUES (?, ?, ?, 1, ?, now(), now())
+			ON CONFLICT (lease_name)
+			DO UPDATE SET
+				lease_owner = EXCLUDED.lease_owner,
+				priority = EXCLUDED.priority,
+				fencing_token = CASE WHEN l.lease_owner = EXCLUDED.lease_owner THEN l.fencing_token ELSE l.fencing_token + 1 END,
+				ttl_millis = EXCLUDED.ttl_millis,
+				acquired_at = CASE WHEN l.lease_owner = EXCLUDED.lease_owner THEN l.acquired_at ELSE now() END,
+				heartbeat_at = now()
+			WHERE l.lease_owner = EXCLUDED.lease_owner
+			   OR l.heartbeat_at < now() - (l.ttl_millis * interval '1 millisecond')
+			RETURNING fencing_token
+		""".formatted(prefix);
+
+		String readHolder = """
+			SELECT lease_owner, fencing_token
+			FROM %sleases
+			WHERE lease_name = ?
+		""".formatted(prefix);
+
+		String liveHigherPriorityContender = """
+			SELECT EXISTS (
+				SELECT 1
+				FROM %slease_contenders
+				WHERE lease_name = ?
+				  AND contender <> ?
+				  AND priority > ?
+				  AND heartbeat_at >= now() - (ttl_millis * interval '1 millisecond')
+			) AS waiting
+		""".formatted(prefix);
+
+		try ( Connection connection = dataSource.getConnection() ) {
+			try {
+				connection.setAutoCommit(false);
+
+				try ( PreparedStatement lock = connection.prepareStatement(ACQUIRE_LEASE_LOCK) ) {
+					lock.setLong(1, leaseLockKey(request.leaseName()));
+					lock.execute();
+				}
+
+				try ( PreparedStatement stmt = connection.prepareStatement(registerContender) ) {
+					stmt.setString(1, request.leaseName());
+					stmt.setString(2, request.owner());
+					stmt.setLong(3, request.priority());
+					stmt.setLong(4, request.ttl().toMillis());
+					stmt.executeUpdate();
+				}
+
+				try ( PreparedStatement stmt = connection.prepareStatement(pruneContenders) ) {
+					stmt.setString(1, request.leaseName());
+					stmt.executeUpdate();
+				}
+
+				Long ownFencingToken = null;
+				try ( PreparedStatement stmt = connection.prepareStatement(acquireOrRenew) ) {
+					stmt.setString(1, request.leaseName());
+					stmt.setString(2, request.owner());
+					stmt.setLong(3, request.priority());
+					stmt.setLong(4, request.ttl().toMillis());
+					try ( ResultSet rs = stmt.executeQuery() ) {
+						if ( rs.next() ) {
+							ownFencingToken = rs.getLong("fencing_token");
+						}
+					}
+				}
+
+				LeaseResponse response;
+				if ( ownFencingToken == null ) {
+					// filtered out by the WHERE: another owner holds a live lease. Read it for the
+					// response — under the advisory lock nothing about this lease can change between
+					// the two statements
+					try ( PreparedStatement stmt = connection.prepareStatement(readHolder) ) {
+						stmt.setString(1, request.leaseName());
+						try ( ResultSet rs = stmt.executeQuery() ) {
+							if ( !rs.next() ) {
+								throw new EventStorageException("lease '%s' vanished between check and read; this cannot happen under the per-lease advisory lock".formatted(request.leaseName()));
+							}
+							response = new LeaseResponse(LeaseStatus.STANDBY, rs.getLong("fencing_token"), rs.getString("lease_owner"));
+						}
+					}
+				} else {
+					boolean stepDownRequested;
+					try ( PreparedStatement stmt = connection.prepareStatement(liveHigherPriorityContender) ) {
+						stmt.setString(1, request.leaseName());
+						stmt.setString(2, request.owner());
+						stmt.setLong(3, request.priority());
+						try ( ResultSet rs = stmt.executeQuery() ) {
+							rs.next();
+							stepDownRequested = rs.getBoolean("waiting");
+						}
+					}
+					LeaseStatus status = stepDownRequested ? LeaseStatus.LEADER_STEP_DOWN_REQUESTED : LeaseStatus.LEADER;
+					response = new LeaseResponse(status, ownFencingToken, request.owner());
+				}
+
+				connection.commit();
+				return response;
+
+			} catch (SQLException e) {
+				try {
+					connection.rollback();
+				} catch (SQLException rollbackEx) {
+					e.addSuppressed(rollbackEx);
+				}
+				throw new EventStorageException("Failed to request lease '%s' for owner '%s'".formatted(request.leaseName(), request.owner()), e);
+			}
+		} catch (SQLException e) {
+			throw new EventStorageException("Failed to close connection", e);
+		}
+	}
+
+	@Override
+	public void releaseLease ( String leaseName, String owner ) {
+		checkNotClosed();
+
+		// backdate rather than delete: the fencing token must survive a release, or the next owner
+		// would mint token 1 again and a superseded leader's stamp would look current
+		String release = """
+			UPDATE %sleases
+			SET heartbeat_at = to_timestamp(0)
+			WHERE lease_name = ? AND lease_owner = ?
+		""".formatted(prefix);
+
+		String withdrawContender = """
+			DELETE FROM %slease_contenders
+			WHERE lease_name = ? AND contender = ?
+		""".formatted(prefix);
+
+		try ( Connection connection = dataSource.getConnection() ) {
+			try {
+				connection.setAutoCommit(false);
+
+				try ( PreparedStatement lock = connection.prepareStatement(ACQUIRE_LEASE_LOCK) ) {
+					lock.setLong(1, leaseLockKey(leaseName));
+					lock.execute();
+				}
+
+				try ( PreparedStatement stmt = connection.prepareStatement(release) ) {
+					stmt.setString(1, leaseName);
+					stmt.setString(2, owner);
+					stmt.executeUpdate();
+				}
+
+				try ( PreparedStatement stmt = connection.prepareStatement(withdrawContender) ) {
+					stmt.setString(1, leaseName);
+					stmt.setString(2, owner);
+					stmt.executeUpdate();
+				}
+
+				connection.commit();
+
+			} catch (SQLException e) {
+				try {
+					connection.rollback();
+				} catch (SQLException rollbackEx) {
+					e.addSuppressed(rollbackEx);
+				}
+				throw new EventStorageException("Failed to release lease '%s' for owner '%s'".formatted(leaseName, owner), e);
+			}
+		} catch (SQLException e) {
+			throw new EventStorageException("Failed to close connection", e);
+		}
+	}
+
+	@Override
+	public List<Lease> getLeases ( ) {
+		checkNotClosed();
+		String sql = """
+			SELECT lease_name, lease_owner, priority, fencing_token, ttl_millis, acquired_at, heartbeat_at
+			FROM %sleases
+		""".formatted(prefix);
+
+		List<Lease> leases = new ArrayList<>();
+		try ( Connection readConnection = dataSource.getConnection() ) {
+			readConnection.setAutoCommit(true);
+			try ( PreparedStatement stmt = readConnection.prepareStatement(sql);
+			      ResultSet rs = stmt.executeQuery() ) {
+				while ( rs.next() ) {
+					Calendar utc = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+					Instant acquiredAt = rs.getTimestamp("acquired_at", utc).toInstant();
+					Instant heartbeatAt = rs.getTimestamp("heartbeat_at", utc).toInstant();
+					leases.add(new Lease(
+							rs.getString("lease_name"),
+							rs.getString("lease_owner"),
+							rs.getLong("priority"),
+							rs.getLong("fencing_token"),
+							acquiredAt,
+							heartbeatAt,
+							Duration.ofMillis(rs.getLong("ttl_millis"))));
+				}
+			} catch ( SQLException e ) {
+				throw new EventStorageException("Failed to list leases", e);
+			}
+		} catch ( SQLException e ) {
+			throw new EventStorageException("Failed to close connection", e);
+		}
+		return leases;
 	}
 
 	Limit effectiveLimit ( Limit softLimit ) {

--- a/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
@@ -302,3 +302,40 @@ DO $$ BEGIN
         EXECUTE FUNCTION notify_bookmark_placed();
   END IF;
 END $$;
+
+
+
+---- LEASES (leader election)
+
+-- Coordination state, deliberately outside the event log: lease reads and writes never touch the
+-- events table, take no lock any event query or append takes, and are not subject to the
+-- pg_snapshot_xmin visibility barrier — a stalled event reader must not look like an expired lease,
+-- and lease traffic must never delay an event read. Every timestamp in these tables is written and
+-- compared with the database server's clock only; no contender's clock ever enters a comparison.
+--
+-- An expired or released lease keeps its row (release just backdates heartbeat_at), because the
+-- fencing token must survive: it increments on every change of ownership and may never be handed
+-- out twice.
+
+CREATE TABLE IF NOT EXISTS leases (
+      lease_name TEXT PRIMARY KEY,
+      lease_owner TEXT NOT NULL,
+      priority BIGINT NOT NULL,
+      fencing_token BIGINT NOT NULL,
+      ttl_millis BIGINT NOT NULL,
+      acquired_at TIMESTAMP WITH TIME ZONE NOT NULL,
+      heartbeat_at TIMESTAMP WITH TIME ZONE NOT NULL
+  );
+
+-- One row per (lease, contender), refreshed on every requestLease call. A contender is live while
+-- its heartbeat is younger than its own ttl; a live contender with a strictly higher priority than
+-- the current owner turns the owner's renewals into step-down requests. Rows long dead are pruned
+-- opportunistically during requests.
+CREATE TABLE IF NOT EXISTS lease_contenders (
+      lease_name TEXT NOT NULL,
+      contender TEXT NOT NULL,
+      priority BIGINT NOT NULL,
+      ttl_millis BIGINT NOT NULL,
+      heartbeat_at TIMESTAMP WITH TIME ZONE NOT NULL,
+      PRIMARY KEY (lease_name, contender)
+  );

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/drop-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/drop-schema.sql
@@ -34,3 +34,6 @@ DROP TABLE IF EXISTS PREFIX_events CASCADE;
 -- wired straight back to it.
 DROP FUNCTION IF EXISTS PREFIX_notify_event_appended() CASCADE;
 DROP FUNCTION IF EXISTS PREFIX_notify_bookmark_placed() CASCADE;
+
+DROP TABLE IF EXISTS PREFIX_leases CASCADE;
+DROP TABLE IF EXISTS PREFIX_lease_contenders CASCADE;

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
@@ -302,3 +302,40 @@ DO $$ BEGIN
         EXECUTE FUNCTION PREFIX_notify_bookmark_placed();
   END IF;
 END $$;
+
+
+
+---- LEASES (leader election)
+
+-- Coordination state, deliberately outside the event log: lease reads and writes never touch the
+-- events table, take no lock any event query or append takes, and are not subject to the
+-- pg_snapshot_xmin visibility barrier — a stalled event reader must not look like an expired lease,
+-- and lease traffic must never delay an event read. Every timestamp in these tables is written and
+-- compared with the database server's clock only; no contender's clock ever enters a comparison.
+--
+-- An expired or released lease keeps its row (release just backdates heartbeat_at), because the
+-- fencing token must survive: it increments on every change of ownership and may never be handed
+-- out twice.
+
+CREATE TABLE IF NOT EXISTS PREFIX_leases (
+      lease_name TEXT PRIMARY KEY,
+      lease_owner TEXT NOT NULL,
+      priority BIGINT NOT NULL,
+      fencing_token BIGINT NOT NULL,
+      ttl_millis BIGINT NOT NULL,
+      acquired_at TIMESTAMP WITH TIME ZONE NOT NULL,
+      heartbeat_at TIMESTAMP WITH TIME ZONE NOT NULL
+  );
+
+-- One row per (lease, contender), refreshed on every requestLease call. A contender is live while
+-- its heartbeat is younger than its own ttl; a live contender with a strictly higher priority than
+-- the current owner turns the owner's renewals into step-down requests. Rows long dead are pruned
+-- opportunistically during requests.
+CREATE TABLE IF NOT EXISTS PREFIX_lease_contenders (
+      lease_name TEXT NOT NULL,
+      contender TEXT NOT NULL,
+      priority BIGINT NOT NULL,
+      ttl_millis BIGINT NOT NULL,
+      heartbeat_at TIMESTAMP WITH TIME ZONE NOT NULL,
+      PRIMARY KEY (lease_name, contender)
+  );

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/EventStoreBackend.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/EventStoreBackend.java
@@ -88,11 +88,18 @@ public interface EventStoreBackend {
 	 * unsupported capability are skipped rather than failed — see {@link ForEachBackend#requires()}.
 	 *
 	 * @param capability the capability in question
-	 * @return {@code true} if supported; the default supports everything except
-	 *         {@link Capability#RAW_STORAGE_ACCESS}
+	 * @return {@code true} if supported; see the default's switch for what is assumed by default
 	 */
 	default boolean supports ( Capability capability ) {
-		return capability != Capability.RAW_STORAGE_ACCESS;
+		// Exhaustive on purpose: a new capability added to the enum fails compilation here until a
+		// deliberate default is chosen for it. The old default returned true for anything unknown,
+		// which is the wrong direction for a capability whose SPI methods default to throwing —
+		// every backend written before the capability existed would have claimed support it does
+		// not have, and its TCK run would fail instead of skip.
+		return switch ( capability ) {
+			case IMPORT, TABLE_PREFIX, RESULT_LIMIT -> true;
+			case RAW_STORAGE_ACCESS, LEASE -> false;
+		};
 	}
 
 	/**
@@ -134,7 +141,17 @@ public interface EventStoreBackend {
 		 * {@link #dataSource(EventStorage)} returns a usable handle on the underlying database, so
 		 * a scenario can modify stored data out of band.
 		 */
-		RAW_STORAGE_ACCESS
+		RAW_STORAGE_ACCESS,
+
+		/**
+		 * The lease operations backing leader election —
+		 * {@link EventStorage#requestLease(EventStorage.LeaseRequest)},
+		 * {@link EventStorage#releaseLease(String, String)} and {@link EventStorage#getLeases()} —
+		 * are implemented. The SPI defaults throw {@code UnsupportedOperationException}, so this is
+		 * genuinely optional; the default here is {@code false} so a backend written before leases
+		 * existed skips the lease scenarios instead of failing them.
+		 */
+		LEASE
 
 	}
 

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/InMemoryBackend.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/InMemoryBackend.java
@@ -51,7 +51,11 @@ public class InMemoryBackend implements EventStoreBackend {
 
 	@Override
 	public boolean supports ( Capability capability ) {
-		return capability != Capability.RAW_STORAGE_ACCESS;
+		// exhaustive, so a new capability forces a deliberate decision here
+		return switch (capability) {
+			case IMPORT, TABLE_PREFIX, RESULT_LIMIT, LEASE -> true;
+			case RAW_STORAGE_ACCESS -> false;
+		};
 	}
 
 }

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/InMemoryFsBackend.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/backend/InMemoryFsBackend.java
@@ -81,7 +81,7 @@ public class InMemoryFsBackend implements EventStoreBackend {
 	public boolean supports ( Capability capability ) {
 		// one store per directory, so a table prefix has nothing to separate
 		return switch (capability) {
-			case IMPORT, RESULT_LIMIT -> true;
+			case IMPORT, RESULT_LIMIT, LEASE -> true;
 			case TABLE_PREFIX, RAW_STORAGE_ACCESS -> false;
 		};
 	}

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/spi/LeaseTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/spi/LeaseTest.java
@@ -1,0 +1,266 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.testing.tck.spi;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import org.sliceworkz.eventstore.events.Lease;
+import org.sliceworkz.eventstore.spi.EventStorage.LeaseRequest;
+import org.sliceworkz.eventstore.spi.EventStorage.LeaseResponse;
+import org.sliceworkz.eventstore.spi.EventStorage.LeaseStatus;
+import org.sliceworkz.eventstore.spi.EventStorageClosedException;
+import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
+import org.sliceworkz.eventstore.testing.EventStoreBackend.Capability;
+import org.sliceworkz.eventstore.testing.ForEachBackend;
+
+/**
+ * Shared compliance scenarios for the lease operations backing leader election —
+ * {@code requestLease}, {@code releaseLease} and {@code getLeases} — run against every backend
+ * claiming {@link Capability#LEASE}, so election behaves identically whatever the storage.
+ * <p>
+ * The load-bearing scenarios are the concurrent one (exactly one of N racing contenders may win an
+ * acquirable lease — the single-writer property everything above this rests on) and the fencing
+ * monotonicity one (a token, once superseded, must never be handed out again). The rest pin the
+ * state machine: renewal keeps the token, expiry and release make a lease acquirable, priorities
+ * request — but never force — a step-down.
+ * <p>
+ * Time-to-live scenarios use TTLs of a few hundred milliseconds and generous waits, since expiry is
+ * judged on the storage's clock (the database server's, for the Postgres backends) which this test
+ * deliberately does not read.
+ */
+public class LeaseTest extends AbstractEventStoreTest {
+
+	private static final String LEASE = "tck/lease/under-test";
+	private static final Duration LONG_TTL = Duration.ofSeconds(60);
+	private static final Duration SHORT_TTL = Duration.ofMillis(200);
+
+	private LeaseRequest request ( String owner, long priority, Duration ttl ) {
+		return new LeaseRequest(LEASE, owner, priority, ttl);
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testFirstRequestAcquiresTheLeaseWithTokenOne ( ) {
+		LeaseResponse response = eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+
+		assertEquals(LeaseStatus.LEADER, response.status());
+		assertEquals(1, response.fencingToken());
+		assertEquals("owner-a", response.currentOwner());
+
+		List<Lease> leases = eventStorage().getLeases();
+		assertEquals(1, leases.size());
+		Lease lease = leases.get(0);
+		assertEquals(LEASE, lease.leaseName());
+		assertEquals("owner-a", lease.owner());
+		assertEquals(1, lease.fencingToken());
+		assertEquals(LONG_TTL, lease.ttl());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testRenewalKeepsTheFencingTokenAndOwnership ( ) {
+		eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+		LeaseResponse renewal = eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+
+		assertEquals(LeaseStatus.LEADER, renewal.status());
+		assertEquals(1, renewal.fencingToken());
+		assertEquals("owner-a", renewal.currentOwner());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testSecondOwnerStandsByWhileTheLeaseIsLive ( ) {
+		eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+		LeaseResponse response = eventStorage().requestLease(request("owner-b", 0, LONG_TTL));
+
+		assertEquals(LeaseStatus.STANDBY, response.status());
+		assertEquals(1, response.fencingToken());
+		assertEquals("owner-a", response.currentOwner());
+
+		// standing by has not disturbed the holder
+		LeaseResponse renewal = eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+		assertEquals(LeaseStatus.LEADER, renewal.status());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testExpiredLeaseIsTakenOverWithAnIncrementedToken ( ) {
+		eventStorage().requestLease(request("owner-a", 0, SHORT_TTL));
+
+		// the takeover happens when the storage clock says the ttl has passed, so poll rather than
+		// assume this JVM's clock and the storage's agree on when that is
+		await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(100)).until(() ->
+				eventStorage().requestLease(request("owner-b", 0, LONG_TTL)).status() == LeaseStatus.LEADER);
+
+		List<Lease> leases = eventStorage().getLeases();
+		assertEquals(1, leases.size());
+		assertEquals("owner-b", leases.get(0).owner());
+		assertEquals(2, leases.get(0).fencingToken());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testReleaseLetsAContenderAcquireImmediately ( ) {
+		eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+		assertEquals(LeaseStatus.STANDBY, eventStorage().requestLease(request("owner-b", 0, LONG_TTL)).status());
+
+		eventStorage().releaseLease(LEASE, "owner-a");
+
+		LeaseResponse takeover = eventStorage().requestLease(request("owner-b", 0, LONG_TTL));
+		assertEquals(LeaseStatus.LEADER, takeover.status());
+		assertEquals(2, takeover.fencingToken());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testReleaseByANonOwnerLeavesTheLeaseUntouched ( ) {
+		eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+
+		assertDoesNotThrow(() -> eventStorage().releaseLease(LEASE, "owner-b"));
+		assertDoesNotThrow(() -> eventStorage().releaseLease("tck/lease/never-acquired", "owner-b"));
+
+		assertEquals(LeaseStatus.STANDBY, eventStorage().requestLease(request("owner-b", 0, LONG_TTL)).status());
+		assertEquals(LeaseStatus.LEADER, eventStorage().requestLease(request("owner-a", 0, LONG_TTL)).status());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testHigherPriorityContenderTriggersAStepDownRequest ( ) {
+		eventStorage().requestLease(request("owner-a", 1, LONG_TTL));
+		assertEquals(LeaseStatus.STANDBY, eventStorage().requestLease(request("owner-b", 2, LONG_TTL)).status());
+
+		LeaseResponse renewal = eventStorage().requestLease(request("owner-a", 1, LONG_TTL));
+
+		// still the leader — the storage requests the step-down, it never enforces it
+		assertEquals(LeaseStatus.LEADER_STEP_DOWN_REQUESTED, renewal.status());
+		assertEquals("owner-a", renewal.currentOwner());
+		assertEquals(1, renewal.fencingToken());
+		assertEquals("owner-a", eventStorage().getLeases().get(0).owner());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testEqualOrLowerPriorityContendersDoNotTriggerAStepDown ( ) {
+		eventStorage().requestLease(request("owner-a", 1, LONG_TTL));
+		eventStorage().requestLease(request("owner-equal", 1, LONG_TTL));
+		eventStorage().requestLease(request("owner-lower", 0, LONG_TTL));
+
+		assertEquals(LeaseStatus.LEADER, eventStorage().requestLease(request("owner-a", 1, LONG_TTL)).status());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testAStepDownRequestLapsesWithTheContender ( ) {
+		eventStorage().requestLease(request("owner-a", 1, LONG_TTL));
+		// the challenger registers with a short ttl and then goes away
+		eventStorage().requestLease(request("owner-b", 2, SHORT_TTL));
+		assertEquals(LeaseStatus.LEADER_STEP_DOWN_REQUESTED, eventStorage().requestLease(request("owner-a", 1, LONG_TTL)).status());
+
+		// once the challenger's own ttl has lapsed on the storage clock, it is no longer live and
+		// the step-down request disappears with it
+		await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(100)).until(() ->
+				eventStorage().requestLease(request("owner-a", 1, LONG_TTL)).status() == LeaseStatus.LEADER);
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testStepDownHandover ( ) {
+		// the full failback protocol: leader steps down on request, challenger takes over
+		eventStorage().requestLease(request("owner-standby", 1, LONG_TTL));
+		assertEquals(LeaseStatus.STANDBY, eventStorage().requestLease(request("owner-preferred", 2, LONG_TTL)).status());
+		assertEquals(LeaseStatus.LEADER_STEP_DOWN_REQUESTED, eventStorage().requestLease(request("owner-standby", 1, LONG_TTL)).status());
+
+		eventStorage().releaseLease(LEASE, "owner-standby");
+
+		LeaseResponse takeover = eventStorage().requestLease(request("owner-preferred", 2, LONG_TTL));
+		assertEquals(LeaseStatus.LEADER, takeover.status());
+		assertEquals(2, takeover.fencingToken());
+		// the demoted owner is a plain standby now
+		assertEquals(LeaseStatus.STANDBY, eventStorage().requestLease(request("owner-standby", 1, LONG_TTL)).status());
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testFencingTokensIncreaseStrictlyAcrossOwnershipChanges ( ) {
+		long first = eventStorage().requestLease(request("owner-a", 0, LONG_TTL)).fencingToken();
+		eventStorage().releaseLease(LEASE, "owner-a");
+		long second = eventStorage().requestLease(request("owner-b", 0, LONG_TTL)).fencingToken();
+		eventStorage().releaseLease(LEASE, "owner-b");
+		long third = eventStorage().requestLease(request("owner-a", 0, LONG_TTL)).fencingToken();
+
+		assertTrue(first < second, "token must increase on takeover: %d -> %d".formatted(first, second));
+		assertTrue(second < third, "token must increase on takeover: %d -> %d".formatted(second, third));
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testLeasesAreIndependentOfEachOther ( ) {
+		eventStorage().requestLease(new LeaseRequest("tck/lease/one", "owner-a", 0, LONG_TTL));
+		LeaseResponse other = eventStorage().requestLease(new LeaseRequest("tck/lease/two", "owner-b", 0, LONG_TTL));
+
+		assertEquals(LeaseStatus.LEADER, other.status());
+		assertEquals(2, eventStorage().getLeases().size());
+	}
+
+	/**
+	 * The single-writer property under concurrency, which every backend has to earn its own way (the
+	 * in-memory store by synchronizing, Postgres with its per-lease advisory lock): N contenders race
+	 * for one acquirable lease from a common start signal, and exactly one may be told LEADER.
+	 */
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testConcurrentFirstAcquireElectsExactlyOneLeader ( ) throws Exception {
+		int contenders = 8;
+		CountDownLatch start = new CountDownLatch(1);
+
+		try ( ExecutorService executor = Executors.newFixedThreadPool(contenders) ) {
+			List<Future<LeaseResponse>> futures = IntStream.range(0, contenders)
+					.mapToObj(i -> executor.submit(() -> {
+						start.await();
+						return eventStorage().requestLease(request("owner-" + i, 0, LONG_TTL));
+					}))
+					.toList();
+			start.countDown();
+
+			long leaders = 0;
+			long standbys = 0;
+			for ( Future<LeaseResponse> future : futures ) {
+				LeaseResponse response = future.get();
+				if ( response.status() == LeaseStatus.LEADER ) {
+					leaders++;
+					assertEquals(1, response.fencingToken());
+				} else {
+					assertEquals(LeaseStatus.STANDBY, response.status());
+					standbys++;
+				}
+			}
+			assertEquals(1, leaders, "exactly one contender may win the race");
+			assertEquals(contenders - 1, standbys);
+		}
+	}
+
+	@ForEachBackend(requires = Capability.LEASE)
+	public void testLeaseOperationsThrowOnAClosedStorage ( ) {
+		eventStorage().requestLease(request("owner-a", 0, LONG_TTL));
+		eventStorage().close();
+
+		assertThrows(EventStorageClosedException.class, () -> eventStorage().requestLease(request("owner-a", 0, LONG_TTL)));
+		assertThrows(EventStorageClosedException.class, () -> eventStorage().releaseLease(LEASE, "owner-a"));
+		assertThrows(EventStorageClosedException.class, () -> eventStorage().getLeases());
+	}
+
+}


### PR DESCRIPTION
## Summary

Implements distributed leader election via named leases across EventStore backends. This enables multiple instances of an application to coordinate which one should process events, with automatic failover when the leader expires or releases its lease.

## Key Changes

- **New Lease API** (`EventStorage` SPI):
  - `requestLease(LeaseRequest)`: Acquire, renew, or register as a contender for a named lease. Returns `LEADER`, `STANDBY`, or `LEADER_STEP_DOWN_REQUESTED` status.
  - `releaseLease(String, String)`: Release a held lease, making it immediately acquirable by others.
  - `getLeases()`: Snapshot list of all leases in the storage.

- **Lease Model** (`Lease` record):
  - Tracks owner, priority, fencing token (monotonically increasing per ownership change), acquisition time, heartbeat, and TTL.
  - Expiry judged on storage's clock only; contenders measure only their own durations.
  - Fencing tokens prevent zombie leaders from overlapping with successors.

- **PostgreSQL Implementation**:
  - Two new tables: `leases` (current lease state) and `lease_contenders` (live contenders per lease).
  - Per-lease advisory locks (`pg_advisory_xact_lock`) serialize acquisition/renewal/expiry checks atomically.
  - Lease operations never touch the events table or take locks that event queries take, preventing election traffic from stalling reads.
  - Release backdates heartbeat rather than deleting, preserving fencing token monotonicity.

- **In-Memory Implementation**:
  - Synchronized state management (expiry check and takeover are atomic).
  - Leases deliberately not persisted by the filesystem-backed decorator—a lease held by a dead process must expire, not resurrect.

- **TCK Test Suite** (`LeaseTest`):
  - 14 scenarios covering acquisition, renewal, expiry, release, priority-based step-down requests, fencing token monotonicity, independence of leases, and concurrent single-writer guarantees.
  - All scenarios run against every backend claiming `Capability.LEASE`.

- **Capability System**:
  - `Capability.LEASE` gates lease support; backends default to unsupported.
  - `EventStoreBackend.supports()` now exhaustive switch (compilation fails on new capabilities until a default is chosen), preventing false claims of support by older backends.

## Notable Implementation Details

- **Single-writer guarantee**: Between two successful `LEADER` renewals, no other owner holds the lease—provided the caller self-demotes if renewal fails or hangs (storage-clock expiry + caller-clock self-demotion prevents zombie overlap).
- **Priority semantics**: A live contender with *strictly higher* priority triggers a step-down request; equal or lower priority does not. Step-down is always the leader's own act; storage never revokes.
- **Clock independence**: Expiry is always judged on the storage's clock; contenders never compare instants across machines, only measure durations locally.
- **Fencing tokens**: Strictly monotonic per lease across releases (never reset), allowing superseded leaders' work to be recognized and rejected.
- **Opportunistic housekeeping**: Dead contender rows (heartbeat older than 10× their TTL) are pruned during requests; liveness never depends on this cleanup.

https://claude.ai/code/session_01XvVAU4k99Fpvm5j9u2Ah46