### PR TITLE
Reject bookmarks naming unstored events, enforce via FK and TCK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,37 @@ re-delivered the same target without pausing: ~700.000 deliveries a second on on
   null is given a defined meaning rather than left to whoever reads the contract more carefully.
 - `AppendListenerFailureTest.testListenerReportingNoProgressIsNotRedeliveredTo` pins it per backend.
 
+### Bookmarks: a cursor that must name a stored event, and a foreign key that never cascades
+
+- **`placeBookmark` rejects a reference this storage never stored** — `EventStorageException`, nothing
+  written, and a previously placed bookmark for that reader stays. The realistic mistake it catches is a
+  reference from a *different* store or prefix in a miswired multi-store setup, which would otherwise
+  poison the reader's cursor silently. Postgres enforces it with the `fk_bookmarks_event_id` foreign key
+  (recognised by the constraint name the server reports, like the idempotency index — never by message
+  text); the in-memory store checks its log under the same monitor that guards `append`. The contract is
+  documented on `EventStorage.bookmark`, and `BookmarksTest` in the TCK pins it per backend — before
+  this, the backends genuinely diverged: Postgres rejected, in-memory accepted anything, and no TCK
+  scenario said which was intended
+- **The check is on the event id alone, matching the foreign key.** The `(tx, position)` pair that
+  cursor comparisons actually order by is not cross-validated — a bookmark carrying a stored id with a
+  wrong position still passes. Keep that in mind before reading the constraint as "the bookmark is
+  valid": it says the event exists, not that the cursor is coherent
+- **The foreign key deliberately does not cascade.** An absent bookmark means "replay from the
+  beginning" — for a dispatcher in the eventmodeling framework, duplicate publishing to an external
+  system, the worst outcome it documents. `ON DELETE CASCADE` handed exactly that to the readers least
+  able to afford it: an event deletion (retention pruning, surgically removing a poison event) cascades
+  away the bookmarks of readers still pointing into the deleted range — the *lagging* ones — silently,
+  with no notification, since the bookmark trigger fires on INSERT/UPDATE only. A dangling cursor is
+  harmless by contrast: reads compare the stored `(event_tx, event_position)` and never join back to the
+  events row. With the default NO ACTION, deleting events out from under an outstanding bookmark fails
+  loudly, and whoever prunes decides explicitly what happens to the reader
+- **Migration for a database created while the cascade existed**: `ENSURE` only ever creates tables, so
+  an existing database keeps its constraint until migrated by hand —
+  `ALTER TABLE <prefix>bookmarks DROP CONSTRAINT fk_bookmarks_event_id; ALTER TABLE <prefix>bookmarks
+  ADD CONSTRAINT fk_bookmarks_event_id FOREIGN KEY (event_id) REFERENCES <prefix>events(event_id);` —
+  no data migration is needed. `checkDatabase()` validates the constraint by name only, not its delete
+  rule, so an un-migrated database still starts, with the old cascade behaviour
+
 ### Leases: electing one processor among several instances
 
 **The storage can hold named leases, which is what a framework builds leader election on** — one

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/spi/EventStorage.java
@@ -512,6 +512,11 @@ public interface EventStorage extends AutoCloseable {
 	 * After successfully storing a bookmark, implementations must notify all subscribed
 	 * listeners via {@link BookmarkPlacedNotification}.
 	 * <p>
+	 * Implementations must reject a reference that does not name an event stored in this storage,
+	 * throwing {@link EventStorageException} and leaving any previously stored bookmark for the
+	 * reader untouched. The check is on the event id alone — the position and transaction carried by
+	 * the reference are not cross-validated. The TCK's {@code BookmarksTest} pins this contract.
+	 * <p>
 	 * Typical Usage:
 	 * <pre>{@code
 	 * // Process events and bookmark progress

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/stream/EventSource.java
@@ -345,11 +345,20 @@ public interface EventSource<DOMAIN_EVENT_TYPE> extends AutoCloseable {
 	 * processing from where they left off. Each reader is identified by name and can
 	 * maintain only one bookmark per stream. Tags can be attached to bookmarks for
 	 * additional metadata (e.g., processing status, reader state).
+	 * <p>
+	 * The reference must name an event this storage has stored: a bookmark is a position in the
+	 * store's log, and a reference the store has never seen — typically one taken from a
+	 * <em>different</em> store or prefix — is a caller error, rejected with
+	 * {@link org.sliceworkz.eventstore.spi.EventStorageException} rather than stored as a cursor that
+	 * would poison the reader. A rejected update leaves any previously placed bookmark untouched.
 	 *
 	 * @param reader the unique name/identifier of the reader placing the bookmark; must not be null
-	 * @param reference the event reference to bookmark (the last processed event)
+	 * @param reference the event reference to bookmark (the last processed event); must reference an
+	 *        event stored in this storage
 	 * @param tags optional tags to attach to the bookmark for metadata
 	 * @throws NullPointerException if {@code reader} is null
+	 * @throws org.sliceworkz.eventstore.spi.EventStorageException if {@code reference} does not
+	 *         reference an event stored in this storage
 	 */
 	void placeBookmark ( String reader, EventReference reference, Tags tags );
 

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/InMemoryEventStorageImpl.java
@@ -514,6 +514,17 @@ public class InMemoryEventStorageImpl implements EventStorage {
 	@Override
 	public synchronized void bookmark(String reader, EventReference eventReference, Tags tags ) {
 		checkNotClosed();
+		// A bookmark is a position in this store's log, so a reference the store never stored --
+		// typically one from a different store -- is a caller error. The Postgres backend rejects it
+		// through the fk_bookmarks_event_id foreign key; checking here keeps the write-side contract
+		// identical across backends (BookmarksTest in the TCK pins both). Matching the foreign key,
+		// the check is on the event id alone, and a rejected bookmark leaves a previously placed one
+		// untouched.
+		if ( eventReference != null && !eventsById.containsKey(eventReference.id()) ) {
+			throw new EventStorageException(
+				"Cannot place bookmark for reader '%s': %s does not reference an event stored in this event storage"
+					.formatted(reader, eventReference));
+		}
 		Tags effectiveTags = tags == null ? Tags.none() : tags;
 		bookmarks.put(reader, new Bookmark(reader, eventReference, effectiveTags, Instant.now()));
 		BookmarkPlacedNotification notification = new BookmarkPlacedNotification(reader, eventReference);

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorageImpl.java
@@ -1757,6 +1757,15 @@ public class PostgresEventStorageImpl implements EventStorage {
 	/** SQLSTATE for {@code unique_violation}. */
 	private static final String UNIQUE_VIOLATION = "23505";
 
+	private static final String FOREIGN_KEY_VIOLATION = "23503";
+
+	/**
+	 * Name of the foreign key from the bookmarks table to the events table, as
+	 * {@code ensure-schema.sql} writes it. Constraint names are table-scoped in PostgreSQL, so the
+	 * name carries no table prefix and is shared by every store in a schema without colliding.
+	 */
+	private static final String BOOKMARKS_EVENT_FK = "fk_bookmarks_event_id";
+
 	/** Unprefixed name of the partial unique index that scopes idempotency keys to a stream. */
 	private static final String IDEMPOTENCY_INDEX = "idx_events_stream_idempotency";
 
@@ -1823,6 +1832,20 @@ public class PostgresEventStorageImpl implements EventStorage {
 	private boolean isIdempotencyKeyViolation ( SQLException e ) {
 		return UNIQUE_VIOLATION.equals(e.getSQLState())
 				&& idempotencyIndexName().equalsIgnoreCase(serverConstraintName(e));
+	}
+
+	/**
+	 * Whether a failed bookmark upsert was rejected because the reference names an event this store
+	 * never stored — the {@code fk_bookmarks_event_id} foreign key — as opposed to any other failure
+	 * the statement can produce. Routed by the constraint name the server reports, for the same
+	 * reasons as {@link #isIdempotencyKeyViolation}.
+	 *
+	 * @param e the failure to classify
+	 * @return {@code true} if the bookmarks-to-events foreign key rejected the row
+	 */
+	private static boolean isBookmarkEventFkViolation ( SQLException e ) {
+		return FOREIGN_KEY_VIOLATION.equals(e.getSQLState())
+				&& BOOKMARKS_EVENT_FK.equalsIgnoreCase(serverConstraintName(e));
 	}
 
 	/**
@@ -2326,6 +2349,14 @@ public class PostgresEventStorageImpl implements EventStorage {
 						writeConnection.rollback();
 					} catch (SQLException rollbackEx) {
 						e.addSuppressed(rollbackEx);
+					}
+					if ( isBookmarkEventFkViolation(e) ) {
+						// a bookmark is a position in this store's log, so a reference the store never
+						// stored -- typically one from a different store or prefix -- is a caller error,
+						// named as such rather than surfacing as an opaque SQL failure
+						throw new EventStorageException(
+							"Cannot place bookmark for reader '%s': %s does not reference an event stored in this event storage"
+								.formatted(reader, eventReference), e);
 					}
 					throw new EventStorageException("Failed to bookmark event for reader: " + reader, e);
 				}

--- a/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/quickstart/quickstart.ddl.sql
@@ -244,6 +244,19 @@ END $$;
 
 ---- BOOKMARKING
 
+-- The foreign key rejects a bookmark naming an event this store never stored -- the realistic
+-- mistake being a reference from a different store or prefix -- and the in-memory backend enforces
+-- the same rule, so the write-side contract is identical on every backend (BookmarksTest in the TCK
+-- pins it).
+--
+-- Deliberately NO "ON DELETE CASCADE". An absent bookmark means "replay from the beginning", which
+-- for a dispatcher is duplicate publishing to an external system -- and an event deletion (retention
+-- pruning, surgical removal of a poison event) reaches exactly the bookmarks of readers still
+-- pointing into the deleted range: the lagging ones, silently, with no notification (the bookmark
+-- trigger fires on INSERT/UPDATE only). A dangling cursor, by contrast, is harmless: reads compare
+-- the stored (event_tx, event_position) and never join back to the events row. So the default
+-- NO ACTION is the right policy -- deleting events out from under an outstanding bookmark fails
+-- loudly, and whoever prunes decides explicitly what to do with the reader.
 CREATE TABLE IF NOT EXISTS bookmarks (
       reader TEXT PRIMARY KEY,
       event_position BIGINT NOT NULL,
@@ -254,7 +267,6 @@ CREATE TABLE IF NOT EXISTS bookmarks (
       CONSTRAINT fk_bookmarks_event_id
           FOREIGN KEY (event_id)
           REFERENCES events(event_id)
-          ON DELETE CASCADE
   );
 
   CREATE INDEX IF NOT EXISTS idx_bookmarks_event_id ON bookmarks(event_id);

--- a/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
+++ b/sliceworkz-eventstore-infra-postgres/src/main/resources/ensure-schema.sql
@@ -244,6 +244,19 @@ END $$;
 
 ---- BOOKMARKING
 
+-- The foreign key rejects a bookmark naming an event this store never stored -- the realistic
+-- mistake being a reference from a different store or prefix -- and the in-memory backend enforces
+-- the same rule, so the write-side contract is identical on every backend (BookmarksTest in the TCK
+-- pins it).
+--
+-- Deliberately NO "ON DELETE CASCADE". An absent bookmark means "replay from the beginning", which
+-- for a dispatcher is duplicate publishing to an external system -- and an event deletion (retention
+-- pruning, surgical removal of a poison event) reaches exactly the bookmarks of readers still
+-- pointing into the deleted range: the lagging ones, silently, with no notification (the bookmark
+-- trigger fires on INSERT/UPDATE only). A dangling cursor, by contrast, is harmless: reads compare
+-- the stored (event_tx, event_position) and never join back to the events row. So the default
+-- NO ACTION is the right policy -- deleting events out from under an outstanding bookmark fails
+-- loudly, and whoever prunes decides explicitly what to do with the reader.
 CREATE TABLE IF NOT EXISTS PREFIX_bookmarks (
       reader TEXT PRIMARY KEY,
       event_position BIGINT NOT NULL,
@@ -254,7 +267,6 @@ CREATE TABLE IF NOT EXISTS PREFIX_bookmarks (
       CONSTRAINT fk_bookmarks_event_id
           FOREIGN KEY (event_id)
           REFERENCES PREFIX_events(event_id)
-          ON DELETE CASCADE
   );
 
   CREATE INDEX IF NOT EXISTS PREFIX_idx_bookmarks_event_id ON PREFIX_bookmarks(event_id);

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/BookmarksTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/BookmarksTest.java
@@ -20,6 +20,7 @@ package org.sliceworkz.eventstore.testing.tck.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -31,6 +32,7 @@ import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.EventReference;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.spi.EventStorageException;
 import org.sliceworkz.eventstore.testing.AbstractEventStoreTest;
 import org.sliceworkz.eventstore.testing.ForEachBackend;
 import org.sliceworkz.eventstore.testing.tck.mock.MockDomainEvent.FirstDomainEvent;
@@ -117,6 +119,47 @@ public class BookmarksTest extends AbstractEventStoreTest {
 		List<Bookmark> bookmarks = s.getBookmarks();
 		assertEquals(1, bookmarks.size());
 		assertEquals(Tags.parse("phase:second"), bookmarks.get(0).tags());
+	}
+
+	/**
+	 * A bookmark is a position in the store's log, so a reference the store never stored — typically
+	 * one taken from a <em>different</em> store or prefix in a miswired multi-store setup — is a
+	 * caller error, rejected loudly at write time rather than stored as a cursor that poisons the
+	 * reader. The Postgres backend enforces this through the {@code fk_bookmarks_event_id} foreign
+	 * key; the in-memory backends check the event id against their log. The check is on the event id
+	 * alone, matching the foreign key.
+	 */
+	@ForEachBackend
+	void bookmarkNamingNoStoredEventIsRejected ( ) {
+		EventReference real = appendOne();
+		EventStream<MockDomainEvent> s = stream();
+
+		// same position and tx as a stored event, but an id the store has never seen
+		EventReference fabricated = EventReference.create(real.position(), real.tx());
+		assertThrows(EventStorageException.class,
+				() -> s.placeBookmark("misdirected-reader", fabricated, Tags.none()),
+				"a bookmark must name an event this storage stored");
+		assertTrue(s.getBookmarks().isEmpty(), "the rejected bookmark must not have been stored");
+	}
+
+	/**
+	 * The rejection must not damage what was already there: a reader whose bookmark update is
+	 * rejected keeps its previous bookmark — reference and tags — rather than being reset.
+	 */
+	@ForEachBackend
+	void rejectedBookmarkLeavesThePreviousOneInPlace ( ) {
+		EventReference real = appendOne();
+		EventStream<MockDomainEvent> s = stream();
+		s.placeBookmark("guarded-reader", real, Tags.parse("phase:before"));
+
+		EventReference fabricated = EventReference.create(real.position(), real.tx());
+		assertThrows(EventStorageException.class,
+				() -> s.placeBookmark("guarded-reader", fabricated, Tags.parse("phase:after")));
+
+		List<Bookmark> bookmarks = s.getBookmarks();
+		assertEquals(1, bookmarks.size());
+		assertEquals(real, bookmarks.get(0).reference(), "the previous bookmark must survive the rejected update");
+		assertEquals(Tags.parse("phase:before"), bookmarks.get(0).tags());
 	}
 
 	@ForEachBackend


### PR DESCRIPTION
## Summary

Bookmarks are cursors into an event store's log. A bookmark referencing an event the store never stored — typically from a different store or prefix in a miswired multi-store setup — is a caller error that should be rejected loudly at write time rather than silently stored as a poisoned cursor. This change enforces that contract uniformly across all backends and documents it in the API.

## Key Changes

- **PostgreSQL backend**: Recognize `fk_bookmarks_event_id` foreign key violations (SQLSTATE 23503) and translate them to `EventStorageException` with a clear message. The foreign key constraint itself is unchanged (already present in schema); this adds the error classification logic.

- **In-memory backend**: Add validation in `bookmark()` to check that the event ID exists in the store's log before accepting the bookmark, matching the PostgreSQL foreign key behavior.

- **Schema changes**: Remove `ON DELETE CASCADE` from the `fk_bookmarks_event_id` foreign key in both `ensure-schema.sql` and `quickstart.ddl.sql`. The default `NO ACTION` policy ensures that deleting events fails loudly if outstanding bookmarks reference them, rather than silently cascading deletions to lagging readers. This is intentional: an absent bookmark means "replay from the beginning" (acceptable), but a cascade silently resets readers still pointing into the deleted range (unacceptable).

- **API documentation**: Update `EventSource.placeBookmark()` and `EventStorage.bookmark()` contracts to document the rejection behavior and the guarantee that a rejected update leaves any previously placed bookmark untouched.

- **TCK tests**: Add two new test scenarios in `BookmarksTest`:
  - `bookmarkNamingNoStoredEventIsRejected`: Verifies that a bookmark naming a fabricated event ID is rejected with `EventStorageException` and not stored.
  - `rejectedBookmarkLeavesThePreviousOneInPlace`: Verifies that a rejected bookmark update does not overwrite or clear a previously placed bookmark.

- **Documentation**: Expand `CLAUDE.md` with a detailed section on the bookmark foreign key contract, the rationale for `NO ACTION` instead of `CASCADE`, and migration guidance for databases created with the old cascade behavior.

## Implementation Details

- The check is on the **event ID alone**, matching the foreign key constraint. The `(tx, position)` pair is not cross-validated, so a bookmark with a stored ID but wrong position will pass. This is intentional and documented.

- Rejected bookmarks are detected by constraint name (`fk_bookmarks_event_id`), following the same pattern as idempotency key violations, to avoid false positives from other SQL failures.

- The in-memory backend check is guarded by the same monitor that protects `append()`, ensuring thread-safe validation.

- Migration for existing databases: `checkDatabase()` validates the constraint by name only, not its delete rule, so un-migrated databases still start but retain the old cascade behavior. Manual migration is provided in the documentation.

https://claude.ai/code/session_018ZsPxpTPtGd7tkmUiGFbra