### PR TITLE
Increase event position padding from 5 to 6 digits

### DIFF
--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorage.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorage.java
@@ -62,8 +62,8 @@ import io.micrometer.core.instrument.Metrics;
  * <pre>
  * eventstore-data/
  *   events/
- *     0000000001-00001-0-2026-04-02-10-30-00-0000.json
- *     0000000002-00002-0-2026-04-02-10-30-01-0000.json
+ *     0000000001-000001-0-2026-04-02-10-30-00-0000.json
+ *     0000000002-000002-0-2026-04-02-10-30-01-0000.json
  *     ...
  *   bookmarks/
  *     my-projection.json

--- a/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/main/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImpl.java
@@ -201,7 +201,7 @@ class InMemoryFsEventStorageImpl implements EventStorage {
 
 	private void persistEvent ( StoredEvent event ) {
 		try {
-			String fileName = "%010d-%05d-%d-%s.json".formatted(event.reference().tx(), event.reference().position(), event.reference().index(), TIMESTAMP_FORMAT.format(event.timestamp()));
+			String fileName = "%010d-%06d-%d-%s.json".formatted(event.reference().tx(), event.reference().position(), event.reference().index(), TIMESTAMP_FORMAT.format(event.timestamp()));
 			Path filePath = eventsDir.resolve(fileName);
 			Files.writeString(filePath, eventCodec.write(event));
 		} catch ( IOException e ) {

--- a/sliceworkz-eventstore-infra-inmem-fs/src/test/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImplTest.java
+++ b/sliceworkz-eventstore-infra-inmem-fs/src/test/java/org/sliceworkz/eventstore/infra/inmem/fs/InMemoryFsEventStorageImplTest.java
@@ -88,8 +88,8 @@ public class InMemoryFsEventStorageImplTest {
 
 		// Verify JSON files exist on disk (filenames include dynamic timestamps)
 		Path eventsDir = tempDir.resolve("events");
-		assertTrue(eventFileExists(eventsDir, "0000000001-00001-0-"));
-		assertTrue(eventFileExists(eventsDir, "0000000001-00002-0-"));
+		assertTrue(eventFileExists(eventsDir, "0000000001-000001-0-"));
+		assertTrue(eventFileExists(eventsDir, "0000000001-000002-0-"));
 
 		// Second instance: reload from disk
 		{
@@ -106,6 +106,40 @@ public class InMemoryFsEventStorageImplTest {
 			assertEquals("CustomerNameChanged", events.get(1).type().name());
 			assertTrue(events.get(0).tags().containsAll(Tags.of("customer", "123")));
 		}
+	}
+
+	@Test
+	void testEventFileWithLegacyPositionPaddingStillLoads ( @TempDir Path tempDir ) throws IOException {
+		EventStreamId streamId = EventStreamId.forContext("customer").withPurpose("123");
+
+		// First instance: append an event, then rename its file to the pre-%06d five-digit padding
+		{
+			EventStore store = InMemoryFsEventStorage.newBuilder()
+					.directory(tempDir)
+					.name("legacy-padding-test")
+					.buildStore();
+
+			EventStream<TestEvent> stream = store.getEventStream(streamId, TestEvent.class);
+			stream.append(AppendCriteria.none(), List.of(
+					Event.of(new TestEvent.CustomerRegistered("John"), Tags.none())
+			));
+		}
+		Path eventsDir = tempDir.resolve("events");
+		Path current = findEventFile(eventsDir, "0000000001-000001-0-");
+		Path legacy = eventsDir.resolve(current.getFileName().toString().replace("-000001-", "-00001-"));
+		Files.move(current, legacy);
+
+		// Second instance: the loader orders by the reference inside the JSON, never by filename,
+		// so a directory written before the padding change reloads unchanged
+		EventStore store2 = InMemoryFsEventStorage.newBuilder()
+				.directory(tempDir)
+				.name("legacy-padding-test-2")
+				.buildStore();
+
+		EventStream<TestEvent> stream2 = store2.getEventStream(streamId, TestEvent.class);
+		List<Event<TestEvent>> events = stream2.query(EventQuery.matchAll()).toList();
+		assertEquals(1, events.size());
+		assertEquals("CustomerRegistered", events.get(0).type().name());
 	}
 
 	@Test
@@ -227,7 +261,7 @@ public class InMemoryFsEventStorageImplTest {
 		));
 
 		// Verify JSON file is human-readable
-		String json = Files.readString(findEventFile(tempDir.resolve("events"), "0000000001-00001-0-"));
+		String json = Files.readString(findEventFile(tempDir.resolve("events"), "0000000001-000001-0-"));
 		assertTrue(json.contains("\"context\" : \"ctx\""));
 		assertTrue(json.contains("\"purpose\" : \"p\""));
 		assertTrue(json.contains("\"type\" : \"CustomerRegistered\""));


### PR DESCRIPTION
## Summary
Updates the event filename format to use 6-digit zero-padded position numbers instead of 5 digits, increasing the maximum event position per transaction from 99,999 to 999,999. Includes backward compatibility support for loading events stored with the legacy 5-digit padding format.

## Changes
- **Filename format update**: Changed position padding in `persistEvent()` from `%05d` to `%06d` in `InMemoryFsEventStorageImpl.java`
  - Example: `0000000001-00001-0-...json` → `0000000001-000001-0-...json`
  - Updated documentation examples to reflect new format

- **Backward compatibility**: Added `testEventFileWithLegacyPositionPaddingStillLoads()` test demonstrating that:
  - Events stored with the old 5-digit padding format can still be loaded
  - The loader orders events by the reference stored inside the JSON, not by filename
  - Directories written before this change reload unchanged

- **Test updates**: Updated existing test assertions to expect the new 6-digit padding format in `testEventRoundTrip()` and `testEventDataPreserved()`

## Implementation Details
The change is safe because event ordering is determined by the `reference` field stored within each event's JSON content, not by filename parsing. This allows the in-memory filesystem storage to transparently handle events written with either padding format, making the migration seamless for existing deployments.

https://claude.ai/code/session_014ad1SSMTtMoCX9V8nnBLLB