### PR TITLE
Add meter for deduplicated events on idempotency key collision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,6 +611,12 @@ secondary identifier … (e.g. customer ID, order number)", and half the example
 - **`context` is deliberately not capped.** It names a bounded context and comes from the code, not from
   the traffic. A store whose *context* is per-entity has the same problem with none of the protection —
   don't do that.
+- **`sliceworkz.eventstore.append.deduplicated`** counts events an append submitted and storage silently
+  swallowed as idempotency-key duplicates (`submitted − stored`, incremented in `EventStreamImpl.append`).
+  It exists because the de-duplication is otherwise invisible in the meters: `append` counts calls,
+  `append.event` counts submitted events, and one call can carry several events, so no subtraction
+  recovers it. A clean run reads 0. Tagged like the other stream meters, and pinned per backend by
+  `EventStreamIdempotencyTest.aSwallowedDuplicateIsCountedOnTheDeduplicatedMeter`.
 - `MeterPurposeCardinalityTest` pins the cap, the pooling, the permanence of an admitted purpose, that
   the default applies to a store nobody configured, and that the cap holds exactly under concurrent first
   use of distinct purposes.

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/EventStoreImpl.java
@@ -479,6 +479,7 @@ public class EventStoreImpl implements EventStore {
 		private final EventPayloadSerializerDeserializer serde;
 
 		private Counter meterAppend;
+		private Counter meterAppendDeduplicated;
 		private Counter meterAppendOptimisticLock;
 		private Counter meterQuery;
 		private Counter meterGetEvent;
@@ -521,6 +522,7 @@ public class EventStoreImpl implements EventStore {
 
 			// prepare counters for metering
 			this.meterAppend = meterRegistry.counter("sliceworkz.eventstore.append", baseTags);
+			this.meterAppendDeduplicated = meterRegistry.counter("sliceworkz.eventstore.append.deduplicated", baseTags);
 			this.meterQuery = meterRegistry.counter("sliceworkz.eventstore.query", baseTags);
 			this.meterAppendOptimisticLock = meterRegistry.counter("sliceworkz.eventstore.append.optimisticlock", baseTags);
 			this.meterGetEvent = meterRegistry.counter("sliceworkz.eventstore.get.event", baseTags);
@@ -723,8 +725,22 @@ public class EventStoreImpl implements EventStore {
 			// append events to the eventstore (with optimistic locking)
 			List<Event<EVENT_TYPE>> appendedEvents;
 			try {
-				appendedEvents = timerAppend.record(()->eventStorage.append(appendCriteria, Optional.of(streamToAppendTo), reduce(events, streamToAppendTo)).stream().flatMap(se->enrich(se, QueryDirection.FORWARD)).toList());
+				List<EventToStore> eventsToStore = reduce(events, streamToAppendTo);
+				List<StoredEvent> storedEvents = timerAppend.record(()->eventStorage.append(appendCriteria, Optional.of(streamToAppendTo), eventsToStore));
+				appendedEvents = storedEvents.stream().flatMap(se->enrich(se, QueryDirection.FORWARD)).toList();
 				meterAppend.increment();
+
+				// A duplicate idempotency key is swallowed by storage -- the event is not written and the
+				// call reports success -- so submitted minus stored is the one place the de-duplication is
+				// observable: append counts calls and append.event counts submitted events, and one call
+				// can carry several, so no two meters can be subtracted to recover it. Counted on the
+				// stored events, not the enriched result, whose size upcasting can change. Splitting the
+				// storage call out of the pipeline also narrows timerAppend to the storage append alone,
+				// which is what timerQuery deliberately measures on the read side.
+				int deduplicatedEvents = events.size() - storedEvents.size();
+				if ( deduplicatedEvents > 0 ) {
+					meterAppendDeduplicated.increment(deduplicatedEvents);
+				}
 
 				// update highest event position gauge
 				appendedEvents.stream()

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventStreamIdempotencyTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/EventStreamIdempotencyTest.java
@@ -19,6 +19,7 @@ package org.sliceworkz.eventstore.testing.tck.stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.Connection;
@@ -28,6 +29,8 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.sliceworkz.eventstore.EventStore;
+import org.sliceworkz.eventstore.EventStoreFactory;
 import org.sliceworkz.eventstore.events.Event;
 import org.sliceworkz.eventstore.events.Tags;
 import org.sliceworkz.eventstore.query.EventQuery;
@@ -41,6 +44,9 @@ import org.sliceworkz.eventstore.testing.ForEachBackend;
 import org.sliceworkz.eventstore.testing.StorageOptions;
 import org.sliceworkz.eventstore.testing.tck.mockdomain.MockDomainEvent;
 import org.sliceworkz.eventstore.testing.tck.mockdomain.MockDomainEvent.FirstDomainEvent;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * What an idempotency key does, and — just as important — what it must not do.
@@ -113,6 +119,48 @@ public class EventStreamIdempotencyTest extends AbstractEventStoreTest {
 
 		assertEquals(1, stream.query(EventQuery.matchAll()).count());
 		assertEquals(1, otherStream.query(EventQuery.matchAll()).count());
+	}
+
+	/**
+	 * A swallowed duplicate is visible on {@code sliceworkz.eventstore.append.deduplicated}, and
+	 * nowhere else.
+	 * <p>
+	 * The de-duplication is otherwise silent by design: the call succeeds and returns an empty list.
+	 * The surrounding meters cannot recover it — {@code sliceworkz.eventstore.append} counts calls and
+	 * {@code append.event} counts submitted events, and one call can carry several events, so their
+	 * difference means nothing in general. A caller wanting to tell "n events ingested" from "n calls,
+	 * some de-duplicated" reads this counter; a clean run reads 0.
+	 */
+	@ForEachBackend
+	void aSwallowedDuplicateIsCountedOnTheDeduplicatedMeter ( ) {
+
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		try ( EventStore meteredStore = EventStoreFactory.get().eventStore(eventStorage(), registry) ) {
+			EventStream<MockDomainEvent> meteredStream = meteredStore
+					.getEventStream(EventStreamId.forContext("app").withPurpose("default"), MockDomainEvent.class);
+
+			// the counter exists from the moment the stream does, reading 0 -- a series that only
+			// appears once something is de-duplicated cannot be told apart from a broken scrape
+			Counter deduplicated = registry.find("sliceworkz.eventstore.append.deduplicated").counter();
+			assertNotNull(deduplicated, "no sliceworkz.eventstore.append.deduplicated counter was registered");
+			assertEquals(0.0, deduplicated.count());
+
+			meteredStream.append(AppendCriteria.none(),
+					Event.of(new FirstDomainEvent("1"), Tags.none()).withIdempotencyKey("order-4711"));
+			assertEquals(0.0, deduplicated.count(), "a clean append must not count as de-duplicated");
+
+			meteredStream.append(AppendCriteria.none(),
+					Event.of(new FirstDomainEvent("2"), Tags.none()).withIdempotencyKey("order-4711"));
+			assertEquals(1.0, deduplicated.count(), "a swallowed duplicate did not reach the deduplicated meter");
+
+			// an ordinary un-keyed append leaves the counter where it was
+			meteredStream.append(AppendCriteria.none(), Event.of(new FirstDomainEvent("3"), Tags.none()));
+			assertEquals(1.0, deduplicated.count());
+
+			// and the meter only reports, it does not change what the caller sees: one event was
+			// de-duplicated, two were stored
+			assertEquals(2, meteredStream.query(EventQuery.matchAll()).count());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Add observability for events silently swallowed due to idempotency key collisions by introducing a new `sliceworkz.eventstore.append.deduplicated` meter that counts the difference between submitted and stored events.

## Changes

- **New meter `sliceworkz.eventstore.append.deduplicated`**: Counts events submitted to `append()` that storage silently discarded as idempotency-key duplicates. This is the only place the de-duplication is observable in the meters, since `append` counts calls and `append.event` counts submitted events — their difference cannot be recovered when one call carries multiple events.

- **EventStreamImpl refactoring**: Split the storage append call out of the timer pipeline to separately track submitted vs. stored event counts. This also narrows `timerAppend` to measure only the storage append operation itself, aligning with how `timerQuery` is measured on the read side.

- **Test coverage**: Added `aSwallowedDuplicateIsCountedOnTheDeduplicatedMeter()` test that verifies:
  - The counter is registered and reads 0 on a clean run
  - Clean appends do not increment the counter
  - Duplicate idempotency keys increment the counter
  - Un-keyed appends do not affect the counter
  - The meter is informational only — it does not change what the caller observes (events are still stored/not stored as before)

- **Documentation**: Updated CLAUDE.md to document the new meter, its purpose, and its relationship to the other append meters.

## Implementation Details

The de-duplication counter is incremented only when `events.size() > storedEvents.size()`, capturing the silent swallowing that occurs in the storage layer. The counter is tagged like other stream meters and is pinned per backend by the TCK test.

https://claude.ai/code/session_015tj5GEugTny14SAkx2ivCj