### PR TITLE
Refactor db.properties lookup to follow framework conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,12 @@ EventStorage storage = PostgresEventStorage.newBuilder()
     .build();
 ```
 
-PostgreSQL requires a `db.properties` file with connection settings. The DataSourceFactory searches for this file in the current directory and up to 2 parent directories.
+Without a `DataSource`, the builder needs a `db.properties` file with connection settings. It takes
+`.configuration(Properties | Path)` first; otherwise `DataSourceFactory` reads the first of: the system
+property `eventstore.db.config`, the environment variable `EVENTSTORE_DB_CONFIG`, `./db.properties` in
+the working directory, `db.properties` on the classpath. It never walks into parent directories, and
+`build()` throws `EventStorageException` naming every location it tried when nothing is found. See
+"Finding `db.properties`" in `sliceworkz-eventstore-infra-postgres/CLAUDE.md` for the reasoning.
 
 ### Lifecycle: starting a store when the database is not there
 

--- a/sliceworkz-eventstore-benchmark/README.md
+++ b/sliceworkz-eventstore-benchmark/README.md
@@ -203,8 +203,8 @@ cluster stalls this store's reads outright, through `pg_snapshot_xmin`.
 machine and weak as a published number, because it is a container running stock defaults.
 
 `EXTERNAL` reaches a server configured outside the suite through `db.properties`, which the
-`DataSourceFactory` looks for in the working directory and up to two parents (or at
-`-Deventstore.db.config=<path>`). Published numbers come from there, because the settings that decide
+`DataSourceFactory` looks for in the working directory (the module directory, when launched as above)
+or at `-Deventstore.db.config=<path>`. Published numbers come from there, because the settings that decide
 them are then deliberate rather than inherited. The database needs the `btree_gin` extension, and
 creating it requires `CREATE` on the **database**, not on the schema — see the postgres module's
 README for the privilege table.

--- a/sliceworkz-eventstore-infra-postgres/CLAUDE.md
+++ b/sliceworkz-eventstore-infra-postgres/CLAUDE.md
@@ -366,3 +366,19 @@ locks, schema and trigger repair, migrations, diagnosis SQL, measured plan behav
   empty property name (a stray `db.pooled.=x` line) is rejected with that explanation rather than
   reaching `charAt(0)`. `HikariConfigurationUtilTest` asserts the value is absent from the whole
   exception chain, not just its top frame
+- **Finding `db.properties`.** Without a `DataSource`, the builder takes `.configuration(Properties | Path)`
+  first, and otherwise `DataSourceFactory.loadProperties()` reads the **first** of: the system property
+  `eventstore.db.config`, the environment variable `EVENTSTORE_DB_CONFIG`, `./db.properties` in the
+  working directory, `db.properties` at the root of the classpath. An explicitly configured path that
+  does not exist fails rather than falling through, and when nothing is found `build()` throws
+  `EventStorageException` naming every location tried. The order follows the convention frameworks
+  have settled on — an external file overrides a packaged one — so a jar can carry a default and a
+  deployment can replace it without rebuilding. The alternative — walking up from the working directory
+  into parent directories — loses because a library reading credentials from wherever the process was
+  started is not something anyone expects: it lets a store pick up another project's file two directories
+  up, or `/db.properties` in a container started from `/app`, with only an INFO line to say so. What that
+  walk would buy, a repo-root file found from a module directory, is a build concern: point
+  `-Deventstore.db.config` at it, or run from the directory that holds it. Several stores in one process
+  are configured per builder through `.configuration(...)`; two stores in one database under different
+  prefixes share one pool through `.dataSource(...)`. `DataSourceFactoryTest` pins the order, the
+  no-fall-through on a configured path, and the failure naming every location

--- a/sliceworkz-eventstore-infra-postgres/README.md
+++ b/sliceworkz-eventstore-infra-postgres/README.md
@@ -4,7 +4,41 @@
 Create a database schema with the DDL scripts found in 'ensure-schema.sql',
 removing "PREFIX_" or replacing it to manage different stores next to each other.
 Use 'drop-schema.sql' to drop existing schema objects before recreating.
- 
+
+## Connecting
+
+The builder needs two connections: a pooled one for reads and appends, and a direct one for the
+LISTEN/NOTIFY monitors, which do not work through a transaction pooler such as PgBouncer. Either build
+the pools yourself and pass them in, or describe them in a `db.properties` file
+(template: `src/main/quickstart/db.properties`):
+
+```properties
+db.pooled.url=jdbc:postgresql://host/db
+db.pooled.username=...
+db.pooled.password=...
+db.pooled.maximumPoolSize=25
+
+db.nonpooled.url=jdbc:postgresql://host/db
+db.nonpooled.username=...
+db.nonpooled.password=...
+db.nonpooled.maximumPoolSize=2
+```
+
+Keys inside a section are HikariCP properties; keys under `datasource.` (`db.pooled.datasource.sslmode`)
+go to the JDBC driver. The builder takes the first of these that is present:
+
+1. a `DataSource` passed to `.dataSource(...)` (and `.monitoringDataSource(...)`)
+2. `Properties` or a file passed to `.configuration(...)`
+3. the file named by the system property `eventstore.db.config`
+4. the file named by the environment variable `EVENTSTORE_DB_CONFIG`
+5. `./db.properties` in the working directory of the process
+6. `db.properties` at the root of the classpath (`src/main/resources` in a Maven project)
+
+The lookup never walks into parent directories. When nothing is found, `build()` throws an
+`EventStorageException` naming every location it tried. Several stores in one process are configured
+by giving each builder its own `.configuration(...)`, or by sharing one pool between them through
+`.dataSource(...)` when they live in one database under different prefixes.
+
 
 
 ## Database privileges

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/DataSourceFactory.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/DataSourceFactory.java
@@ -17,71 +17,119 @@
  */
 package org.sliceworkz.eventstore.infra.postgres;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sliceworkz.eventstore.spi.EventStorageException;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 /**
- * Utility class that can be used to create a HikariCP DataSource.
+ * Creates the HikariCP {@link javax.sql.DataSource DataSources} a {@link PostgresEventStorage} runs on, from a
+ * {@code db.properties} file.
  * <p>
- * This factory creates {@link HikariDataSource} instances instead of generic DataSource,
- * allowing for configuration of Micrometer metrics on the returned HikariDataSource instances.
- * Only useful when passing a DataSource to the PostgresEventStorage.Builder.
+ * The file holds one <em>named section</em> per DataSource — {@code db.pooled.*} for the ordinary pool and
+ * {@code db.nonpooled.*} for the LISTEN/NOTIFY monitor connections, which must not sit behind a transaction
+ * pooler. Keys inside a section are HikariCP configuration properties ({@code url}, {@code username},
+ * {@code password}, {@code maximumPoolSize}, ...); keys under {@code datasource.} go to the JDBC driver
+ * ({@code sslmode}, {@code cachePrepStmts}, ...). See {@link HikariConfigurationUtil}.
+ *
+ * <h2>Where the file is looked for</h2>
+ * {@link #loadProperties()} takes the <strong>first</strong> of these that is present, and never looks
+ * beyond a location that was explicitly configured:
+ * <ol>
+ *   <li>the path in the system property {@value #SYSTEM_PROPERTY}</li>
+ *   <li>the path in the environment variable {@value #ENVIRONMENT_VARIABLE}</li>
+ *   <li>{@code ./db.properties} in the working directory of the process</li>
+ *   <li>{@code db.properties} at the root of the classpath, so {@code src/main/resources/db.properties}
+ *       or {@code src/test/resources/db.properties} in a Maven project</li>
+ * </ol>
+ * A working-directory file wins over a packaged one, so a deployment can override what the jar carries
+ * without rebuilding it — the convention Spring Boot and most application frameworks follow. The lookup
+ * never walks into parent directories: a library reading credentials from wherever the process happens
+ * to have been started is not a convention anyone expects, and would let a store pick up another
+ * project's file, or in a container a file at {@code /}, with only a log line to say so.
+ * <p>
+ * Where none of that fits — configuration held by a framework, a secrets manager, several stores with
+ * different sections in one process — bypass the lookup: pass the {@link Properties} or the {@link Path}
+ * to {@link PostgresEventStorage.Builder#configuration(Properties)}, or build the pools yourself and pass
+ * them to {@link PostgresEventStorage.Builder#dataSource(javax.sql.DataSource)}.
+ * <p>
+ * This factory returns {@link HikariDataSource} rather than a generic DataSource so that the storage can
+ * register Micrometer metrics on the pool.
  */
 public class DataSourceFactory {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceFactory.class);
+
+	/** System property naming the properties file to use: {@code -Deventstore.db.config=/path/to/db.properties}. */
+	public static final String SYSTEM_PROPERTY = "eventstore.db.config";
+
+	/** Environment variable naming the properties file to use, consulted when the system property is absent. */
+	public static final String ENVIRONMENT_VARIABLE = "EVENTSTORE_DB_CONFIG";
+
+	/** The file name looked for in the working directory and on the classpath. */
+	public static final String FILE_NAME = "db.properties";
 
 	private DataSourceFactory ( ) {
 
 	}
 
 	/**
-	 * Creates a HikariDataSource using properties loaded from the default location.
+	 * Creates a HikariDataSource from the unnamed section ({@code db.*}) of the properties file found at
+	 * the default location.
 	 *
-	 * @return a configured HikariDataSource instance
+	 * @return a configured HikariDataSource instance, or null if the file holds no such section
+	 * @throws EventStorageException if no properties file is found or it cannot be read
+	 * @see #loadProperties()
 	 */
 	public static HikariDataSource fromConfiguration ( ) {
-		return fromConfiguration((Properties)null);
+		return fromConfiguration(loadProperties(), null);
 	}
 
 	/**
-	 * Creates a HikariDataSource using the provided properties.
+	 * Creates a HikariDataSource from the unnamed section ({@code db.*}) of the provided properties.
 	 *
 	 * @param properties the database connection properties
-	 * @return a configured HikariDataSource instance
+	 * @return a configured HikariDataSource instance, or null if the properties hold no such section
 	 */
 	public static HikariDataSource fromConfiguration ( Properties properties ) {
 		return fromConfiguration(properties, null);
 	}
 
 	/**
-	 * Creates a HikariDataSource using the specified named datasource configuration.
+	 * Creates a HikariDataSource from a named section of the properties file found at the default location.
 	 *
-	 * @param datasourceConfigurationName the name of the datasource configuration to use
-	 * @return a configured HikariDataSource instance
+	 * @param datasourceConfigurationName the name of the section to use, e.g. {@code pooled}
+	 * @return a configured HikariDataSource instance, or null if the file holds no such section
+	 * @throws EventStorageException if no properties file is found or it cannot be read
+	 * @see #loadProperties()
 	 */
 	public static HikariDataSource fromConfiguration ( String datasourceConfigurationName ) {
 		return fromConfiguration(loadProperties(), datasourceConfigurationName);
 	}
 
 	/**
-	 * Creates a HikariDataSource using the provided properties and named configuration.
+	 * Creates a HikariDataSource from a named section of the provided properties.
 	 *
 	 * @param dbProperties the database connection properties
-	 * @param datasourceConfigurationName the name of the datasource configuration to use
-	 * @return a configured HikariDataSource instance, or null if no configuration is found
+	 * @param datasourceConfigurationName the name of the section to use, e.g. {@code pooled}; null for the
+	 *        unnamed {@code db.*} section
+	 * @return a configured HikariDataSource instance, or null if the properties hold no such section
 	 */
 	public static HikariDataSource fromConfiguration ( Properties dbProperties, String datasourceConfigurationName ) {
+		Objects.requireNonNull(dbProperties, "dbProperties");
 		HikariConfig config = HikariConfigurationUtil.createConfig(datasourceConfigurationName, dbProperties);
 		if ( config != null ) {
 			return new HikariDataSource(config);
@@ -90,63 +138,107 @@ public class DataSourceFactory {
 		}
 	}
 
-	// looks for file in current working directory of process, and few levels up
+	/**
+	 * Loads the properties file from the default location — see the class documentation for the lookup
+	 * order.
+	 *
+	 * @return the loaded properties
+	 * @throws EventStorageException if no file is found at any of the locations, naming each one that was
+	 *         tried, or if the file found cannot be read
+	 */
 	public static Properties loadProperties ( ) {
+		return loadProperties(System::getProperty, System::getenv, Path.of("").toAbsolutePath(), contextClassLoader());
+	}
 
-		String configPath = System.getProperty("eventstore.db.config");
-		if ( configPath != null ) {
-			LOGGER.info("database configuration config path configured via System property 'eventstore.db.config' ({})", configPath);
-		} else {
-			LOGGER.debug("database configuration config path not found via System property 'eventstore.db.config'");
+	/**
+	 * Loads the properties file at the given path, consulting no other location.
+	 *
+	 * @param file the properties file
+	 * @return the loaded properties
+	 * @throws EventStorageException if the file does not exist or cannot be read
+	 */
+	public static Properties loadProperties ( Path file ) {
+		Objects.requireNonNull(file, "file");
+		if ( !Files.isRegularFile(file) ) {
+			throw new EventStorageException("database configuration file not found: " + file.toAbsolutePath());
 		}
-		
-		// 2. Environment variable: EVENTSTORE_DB_CONFIG
-		if (configPath == null) {
-			configPath = System.getenv("EVENTSTORE_DB_CONFIG");
-			if ( configPath != null ) {
-				LOGGER.info("searching database configuration in config path via environment variable EVENTSTORE_DB_CONFIG 'eventstore.db.config' ({})", configPath);
-			} else {
-				LOGGER.debug("database configuration config path not found via environment variable EVENTSTORE_DB_CONFIG 'eventstore.db.config'");
-			}
+		return read(file);
+	}
+
+	/**
+	 * The lookup with its environment made explicit, so that a test can drive every branch without
+	 * setting a system property, an environment variable or a file in the real working directory.
+	 */
+	static Properties loadProperties ( Function<String, String> systemProperties, Function<String, String> environment,
+			Path workingDirectory, ClassLoader classLoader ) {
+
+		String configured = systemProperties.apply(SYSTEM_PROPERTY);
+		if ( configured != null ) {
+			LOGGER.info("reading database configuration from system property {} ({})", SYSTEM_PROPERTY, configured);
+			return loadConfigured(Path.of(configured), "system property " + SYSTEM_PROPERTY);
 		}
 
-		// 3. Fall back to file search
-		if (configPath == null) {
-		    configPath = findPropertiesFile();
-			if ( configPath != null ) {
-				LOGGER.info("searching database configuration in db.properties in pwd or parent folder(s) ({})", configPath);
-			} else {
-				LOGGER.error("database configuration not found in db.properties in pwd or parent folder(s)");
-			}
+		configured = environment.apply(ENVIRONMENT_VARIABLE);
+		if ( configured != null ) {
+			LOGGER.info("reading database configuration from environment variable {} ({})", ENVIRONMENT_VARIABLE, configured);
+			return loadConfigured(Path.of(configured), "environment variable " + ENVIRONMENT_VARIABLE);
 		}
 
+		Path inWorkingDirectory = workingDirectory.resolve(FILE_NAME);
+		if ( Files.isRegularFile(inWorkingDirectory) ) {
+			LOGGER.info("reading database configuration from working directory ({})", inWorkingDirectory.toAbsolutePath());
+			return read(inWorkingDirectory);
+		}
+
+		URL onClasspath = classLoader == null ? null : classLoader.getResource(FILE_NAME);
+		if ( onClasspath != null ) {
+			LOGGER.info("reading database configuration from classpath ({})", onClasspath);
+			return read(onClasspath);
+		}
+
+		List<String> tried = new ArrayList<>();
+		tried.add("system property " + SYSTEM_PROPERTY + " (not set)");
+		tried.add("environment variable " + ENVIRONMENT_VARIABLE + " (not set)");
+		tried.add("working directory " + inWorkingDirectory.toAbsolutePath() + " (no such file)");
+		tried.add("classpath " + FILE_NAME + " (no such resource)");
+		throw new EventStorageException("no database configuration found; looked in: " + String.join(", ", tried)
+				+ ". Create a " + FILE_NAME + " at one of those locations, point " + SYSTEM_PROPERTY + " or "
+				+ ENVIRONMENT_VARIABLE + " at one, or pass the configuration or a DataSource to the builder");
+	}
+
+	private static Properties loadConfigured ( Path file, String configuredBy ) {
+		if ( !Files.isRegularFile(file) ) {
+			throw new EventStorageException("database configuration file " + file.toAbsolutePath() + " configured by "
+					+ configuredBy + " does not exist");
+		}
+		return read(file);
+	}
+
+	private static Properties read ( Path file ) {
+		try ( InputStream is = Files.newInputStream(file) ) {
+			return read(is);
+		} catch ( IOException e ) {
+			throw new EventStorageException("could not read database configuration file " + file.toAbsolutePath(), e);
+		}
+	}
+
+	private static Properties read ( URL resource ) {
+		try ( InputStream is = resource.openStream() ) {
+			return read(is);
+		} catch ( IOException e ) {
+			throw new EventStorageException("could not read database configuration resource " + resource, e);
+		}
+	}
+
+	private static Properties read ( InputStream is ) throws IOException {
 		Properties result = new Properties();
-		try {
-			try ( InputStream is = new FileInputStream(configPath)) {
-				result.load(is);
-			}
-		} catch (FileNotFoundException e) {
-			throw new RuntimeException(e);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
+		result.load(is);
 		return result;
 	}
-	
-	static String findPropertiesFile ( ) {
-		File file = null;
-		for ( int i = 0; i < 3; i++ ) {
-			file = new File("../".repeat(i) + "db.properties");
-			if ( file.exists() ) {
-				break;
-			}
-		}
-		if (!file.exists() ) {
-			throw new RuntimeException("db.properties file not found in current or parent directory up to 2 levels up");
-		} else {
-			LOGGER.info("read properties from '{}'", file);
-		}
-		return file.getPath();
+
+	private static ClassLoader contextClassLoader ( ) {
+		ClassLoader loader = Thread.currentThread().getContextClassLoader();
+		return loader != null ? loader : DataSourceFactory.class.getClassLoader();
 	}
 
 }

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/HikariConfigurationUtil.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/HikariConfigurationUtil.java
@@ -39,7 +39,7 @@ db.pooled.datasource.cachePrepStmts=true
 db.pooled.datasource.prepStmtCacheSize=250
 db.pooled.datasource.prepStmtCacheSqlLimit=2048
 
-db.pooled.url=jdbc:postgresql://hos.domain.com/db
+db.nonpooled.url=jdbc:postgresql://host.domain.com/db
 db.nonpooled.username=username
 db.nonpooled.password=password
 db.nonpooled.leakDetectionThreshold=60000

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/PostgresEventStorage.java
@@ -17,9 +17,11 @@
  */
 package org.sliceworkz.eventstore.infra.postgres;
 
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Properties;
 
 import javax.sql.DataSource;
@@ -61,17 +63,20 @@ import io.micrometer.core.instrument.Metrics;
  * </ul>
  * <p>
  * <strong>Database Configuration:</strong><br>
- * When no custom DataSource is provided, PostgresEventStorage automatically loads configuration from a
- * {@code db.properties} file. The {@link DataSourceFactory} searches for this file in:
+ * The builder takes its connections from, in order of precedence: a {@link Builder#dataSource(DataSource)
+ * DataSource} you built; a {@link Builder#configuration(Properties) Properties} or a
+ * {@link Builder#configuration(Path) file} you name; or, when neither is given, the {@code db.properties}
+ * file {@link DataSourceFactory} finds at the first of these locations:
  * <ol>
- *   <li>System property {@code eventstore.db.config}</li>
- *   <li>Environment variable {@code EVENTSTORE_DB_CONFIG}</li>
- *   <li>Current working directory and up to 2 parent directories</li>
+ *   <li>the path in the system property {@code eventstore.db.config}</li>
+ *   <li>the path in the environment variable {@code EVENTSTORE_DB_CONFIG}</li>
+ *   <li>{@code ./db.properties} in the working directory</li>
+ *   <li>{@code db.properties} at the root of the classpath</li>
  * </ol>
  * <p>
- * The properties file should contain connection settings prefixed with {@code db.pooled.} for the main
- * connection pool and {@code db.nonpooled.} for monitoring connections. See {@link DataSourceFactory}
- * for details on the expected format.
+ * The properties file holds connection settings prefixed with {@code db.pooled.} for the main
+ * connection pool and {@code db.nonpooled.} for the monitoring connections. See {@link DataSourceFactory}
+ * for the format and the lookup.
  * <p>
  * <strong>Table Prefixing:</strong><br>
  * Table prefixes enable multiple isolated event stores within the same database schema. The prefix must:
@@ -214,6 +219,7 @@ public interface PostgresEventStorage {
 		private String name = "psql";
 		private DataSource dataSource;
 		private DataSource monitoringDataSource;
+		private Properties configuration;
 		private DatabaseInitMode databaseInitMode = DatabaseInitMode.ENSURE;
 		private Duration notificationStartupTimeout = PostgresEventStorageImpl.DEFAULT_NOTIFICATION_STARTUP_TIMEOUT;
 		private Limit limit = Limit.none();
@@ -251,9 +257,9 @@ public interface PostgresEventStorage {
 		 * monitoring queries. The monitoring DataSource will also be set to this DataSource
 		 * unless explicitly overridden with {@link #monitoringDataSource(DataSource)}.
 		 * <p>
-		 * If no DataSource is provided, the builder will automatically create one using
-		 * {@link DataSourceFactory#fromConfiguration(String)} with configuration loaded
-		 * from a {@code db.properties} file.
+		 * If no DataSource is provided, the builder creates one — and a separate one for monitoring —
+		 * from the {@link #configuration(Properties) configuration} given to it, or from the
+		 * {@code db.properties} file {@link DataSourceFactory#loadProperties()} finds.
 		 * <p>
 		 * The DataSource should be configured with connection pooling (e.g., HikariCP) for
 		 * optimal performance.
@@ -282,8 +288,8 @@ public interface PostgresEventStorage {
 		 *   <li>Listening for bookmark update notifications</li>
 		 * </ul>
 		 * <p>
-		 * If not set explicitly, defaults to the main DataSource. When using automatic configuration
-		 * from {@code db.properties}, a separate non-pooled DataSource is created automatically.
+		 * If not set explicitly, defaults to the main DataSource. When the builder creates the DataSources
+		 * itself from {@code db.properties}, the {@code db.nonpooled.} section becomes this one.
 		 *
 		 * @param monitoringDataSource the JDBC DataSource for monitoring operations
 		 * @return this Builder for method chaining
@@ -292,6 +298,42 @@ public interface PostgresEventStorage {
 		public Builder monitoringDataSource ( DataSource monitoringDataSource ) {
 			this.monitoringDataSource = monitoringDataSource;
 			return this;
+		}
+
+		/**
+		 * Supplies the database configuration directly, in the {@code db.properties} format, instead of
+		 * having it looked up.
+		 * <p>
+		 * The builder creates its own pools from the {@code db.pooled.} and {@code db.nonpooled.} sections,
+		 * exactly as it does from a file it finds itself, and closes them with the storage. This is the
+		 * seam for configuration that lives somewhere other than a file — a framework's environment, a
+		 * secrets manager — and for a process running several stores, each handed its own properties.
+		 * Ignored when a {@link #dataSource(DataSource)} is set.
+		 *
+		 * @param configuration the connection properties, holding a {@code db.pooled.} section and a
+		 *        {@code db.nonpooled.} section
+		 * @return this Builder for method chaining
+		 * @see DataSourceFactory
+		 */
+		public Builder configuration ( Properties configuration ) {
+			this.configuration = Objects.requireNonNull(configuration, "configuration");
+			return this;
+		}
+
+		/**
+		 * Names the {@code db.properties} file to read, consulting none of the default locations.
+		 * <p>
+		 * Where {@code -Deventstore.db.config} points the whole JVM at one file, this points one
+		 * builder at one file, so two stores in one process can be configured from two files. Ignored
+		 * when a {@link #dataSource(DataSource)} is set.
+		 *
+		 * @param configurationFile the properties file
+		 * @return this Builder for method chaining
+		 * @throws EventStorageException if the file does not exist or cannot be read
+		 * @see DataSourceFactory#loadProperties(Path)
+		 */
+		public Builder configuration ( Path configurationFile ) {
+			return configuration(DataSourceFactory.loadProperties(configurationFile));
 		}
 
 		/**
@@ -517,8 +559,9 @@ public interface PostgresEventStorage {
 		 * Builds and returns the configured {@link EventStorage} implementation.
 		 * <p>
 		 * This method creates a {@link PostgresEventStorageImpl} instance with all configured
-		 * settings. If no custom DataSource was provided, it will be automatically created from
-		 * the {@code db.properties} file using {@link DataSourceFactory}.
+		 * settings. If no custom DataSource was provided, the pools are created from the
+		 * {@link #configuration(Properties) configuration} given, or else from the {@code db.properties}
+		 * file {@link DataSourceFactory#loadProperties()} finds.
 		 * <p>
 		 * The configured {@link DatabaseInitMode} determines how the database schema is handled:
 		 * <ul>
@@ -537,7 +580,7 @@ public interface PostgresEventStorage {
 		 * closing the storage is then the only thing that will ever close them.
 		 *
 		 * @return a configured EventStorage instance backed by PostgreSQL
-		 * @throws RuntimeException if database configuration cannot be loaded or schema operations fail
+		 * @throws EventStorageException if no database configuration can be found, or schema operations fail
 		 * @see #buildStore()
 		 * @see EventStoreFactory#eventStore(EventStorage)
 		 */
@@ -609,12 +652,13 @@ public interface PostgresEventStorage {
 			// one the caller passed in stays the caller's, and is never touched
 			boolean createdDataSources = false;
 			if ( dataSource == null ) {
-				Properties dbProperties = DataSourceFactory.loadProperties();
+				Properties dbProperties = configuration != null ? configuration : DataSourceFactory.loadProperties();
+				dataSource = DataSourceFactory.fromConfiguration(dbProperties, "pooled");
 				if ( dataSource == null ) {
-					dataSource = DataSourceFactory.fromConfiguration(dbProperties, "pooled");
-					monitoringDataSource = DataSourceFactory.fromConfiguration(dbProperties, "nonpooled");
-					createdDataSources = true;
+					throw new EventStorageException("database configuration holds no 'db.pooled.' section");
 				}
+				monitoringDataSource = DataSourceFactory.fromConfiguration(dbProperties, "nonpooled");
+				createdDataSources = true;
 				if ( monitoringDataSource == null ) {
 					monitoringDataSource = dataSource;
 				}

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/package-info.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/package-info.java
@@ -41,23 +41,26 @@
  *
  * <h2>Configuration:</h2>
  * <p>
- * Create a {@code db.properties} file in your project root or specify its location via:
+ * Put a {@code db.properties} file in the working directory of the process or on the classpath
+ * ({@code src/main/resources}), or name its location via:
  * <ul>
  *   <li>System property: {@code -Deventstore.db.config=/path/to/db.properties}</li>
  *   <li>Environment variable: {@code EVENTSTORE_DB_CONFIG=/path/to/db.properties}</li>
+ *   <li>The builder: {@code PostgresEventStorage.newBuilder().configuration(Path.of("/path/to/db.properties"))}</li>
  * </ul>
+ * A framework that already manages the connection pool passes it in with {@code .dataSource(...)} instead.
  *
  * <p>
  * Example {@code db.properties}:
  * <pre>
  * # Pooled connection (for queries and appends)
- * db.pooled.jdbcUrl=jdbc:postgresql://localhost:5432/eventstore
+ * db.pooled.url=jdbc:postgresql://localhost:5432/eventstore
  * db.pooled.username=eventstore_user
  * db.pooled.password=secret
  * db.pooled.maximumPoolSize=10
  *
  * # Non-pooled connection (for LISTEN/NOTIFY)
- * db.nonpooled.jdbcUrl=jdbc:postgresql://localhost:5432/eventstore
+ * db.nonpooled.url=jdbc:postgresql://localhost:5432/eventstore
  * db.nonpooled.username=eventstore_user
  * db.nonpooled.password=secret
  * </pre>

--- a/sliceworkz-eventstore-infra-postgres/src/main/quickstart/db.properties
+++ b/sliceworkz-eventstore-infra-postgres/src/main/quickstart/db.properties
@@ -19,10 +19,13 @@
 #
 # TEMPLATE 'db.properties' configuration file
 #
-# Copy and adapt to your needs.  Postgres Eventstore implementation searches this file:
-# 1. in the location specified by environment variable 'eventstore.db.config' [passed to VM with "-Deventstore.db.config=_path_to_file_"]
-# 2. in the location specified by system variable 'EVENTSTORE_DB_CONFIG' [System.getEnv("EVENTSTORE_DB_CONFIG")]
-# 3. in the current directory and up to two levels up [./db.properties, ./../db.properties, etc...]
+# Copy and adapt to your needs.  The Postgres Eventstore reads the first of these it finds:
+# 1. the file named by the system property 'eventstore.db.config' [passed to the JVM with "-Deventstore.db.config=_path_to_file_"]
+# 2. the file named by the environment variable 'EVENTSTORE_DB_CONFIG'
+# 3. ./db.properties in the working directory of the process
+# 4. db.properties at the root of the classpath [src/main/resources/db.properties in a Maven project]
+#
+# Or hand it to the builder directly: PostgresEventStorage.newBuilder().configuration(Path.of("...")) / .configuration(properties)
 #
 # There are actually two datasources: one pooled and one non-pooled (for monitoring connections)
 # You can use the same configuration for both if wanted.

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/DataSourceFactoryTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/DataSourceFactoryTest.java
@@ -1,0 +1,175 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sliceworkz.eventstore.spi.EventStorageException;
+
+/**
+ * Pins down where {@link DataSourceFactory} looks for {@code db.properties}, and in which order: an
+ * explicitly configured path, the working directory, the classpath — and never a parent directory.
+ * <p>
+ * Every branch is driven through the seam that takes the environment as arguments, so no test sets a
+ * real system property, needs a real environment variable, or writes into the real working directory.
+ */
+class DataSourceFactoryTest {
+
+	private static final Function<String, String> NOTHING = key -> null;
+
+	@TempDir
+	Path dir;
+
+	private Path write ( Path file, String origin ) throws IOException {
+		Files.createDirectories(file.getParent());
+		Files.writeString(file, "db.pooled.url=jdbc:postgresql://" + origin + "/db\n");
+		return file;
+	}
+
+	private static String originOf ( Properties properties ) {
+		return properties.getProperty("db.pooled.url").replace("jdbc:postgresql://", "").replace("/db", "");
+	}
+
+	private static ClassLoader classpathHolding ( Path root ) throws IOException {
+		return new URLClassLoader(new URL[] { root.toUri().toURL() }, null);
+	}
+
+	@Test
+	void testTheSystemPropertyWinsOverEverythingElse ( ) throws IOException {
+		Path work = dir.resolve("work");
+		Path classpath = dir.resolve("classpath");
+		Path configured = write(dir.resolve("elsewhere/db.properties"), "system-property");
+		Path viaEnvironment = write(dir.resolve("env/db.properties"), "environment");
+		write(work.resolve("db.properties"), "working-directory");
+		write(classpath.resolve("db.properties"), "classpath");
+
+		Properties loaded = DataSourceFactory.loadProperties(
+			Map.of(DataSourceFactory.SYSTEM_PROPERTY, configured.toString())::get,
+			Map.of(DataSourceFactory.ENVIRONMENT_VARIABLE, viaEnvironment.toString())::get,
+			work, classpathHolding(classpath));
+
+		assertEquals("system-property", originOf(loaded));
+	}
+
+	@Test
+	void testTheEnvironmentVariableIsNextWhenNoSystemPropertyIsSet ( ) throws IOException {
+		Path work = dir.resolve("work");
+		Path classpath = dir.resolve("classpath");
+		Path viaEnvironment = write(dir.resolve("env/db.properties"), "environment");
+		write(work.resolve("db.properties"), "working-directory");
+		write(classpath.resolve("db.properties"), "classpath");
+
+		Properties loaded = DataSourceFactory.loadProperties(NOTHING,
+			Map.of(DataSourceFactory.ENVIRONMENT_VARIABLE, viaEnvironment.toString())::get,
+			work, classpathHolding(classpath));
+
+		assertEquals("environment", originOf(loaded));
+	}
+
+	@Test
+	void testTheWorkingDirectoryWinsOverTheClasspath ( ) throws IOException {
+		Path work = dir.resolve("work");
+		Path classpath = dir.resolve("classpath");
+		write(work.resolve("db.properties"), "working-directory");
+		write(classpath.resolve("db.properties"), "classpath");
+
+		Properties loaded = DataSourceFactory.loadProperties(NOTHING, NOTHING, work, classpathHolding(classpath));
+
+		assertEquals("working-directory", originOf(loaded));
+	}
+
+	@Test
+	void testTheClasspathIsTheLastResort ( ) throws IOException {
+		Path work = dir.resolve("work");
+		Path classpath = dir.resolve("classpath");
+		Files.createDirectories(work);
+		write(classpath.resolve("db.properties"), "classpath");
+
+		Properties loaded = DataSourceFactory.loadProperties(NOTHING, NOTHING, work, classpathHolding(classpath));
+
+		assertEquals("classpath", originOf(loaded));
+	}
+
+	@Test
+	void testAParentDirectoryIsNeverConsulted ( ) throws IOException {
+		// a file one level up from the working directory, where the process might have been started from
+		// another project's tree: it must not be picked up
+		Path work = dir.resolve("project/module");
+		Files.createDirectories(work);
+		write(dir.resolve("project/db.properties"), "parent");
+		write(dir.resolve("db.properties"), "grandparent");
+
+		EventStorageException thrown = assertThrows(EventStorageException.class,
+			() -> DataSourceFactory.loadProperties(NOTHING, NOTHING, work, classpathHolding(dir.resolve("empty"))));
+
+		assertTrue(thrown.getMessage().contains(work.resolve("db.properties").toString()),
+			"the location tried must be the working directory itself: " + thrown.getMessage());
+	}
+
+	@Test
+	void testAConfiguredPathThatDoesNotExistFailsInsteadOfFallingThrough ( ) throws IOException {
+		Path work = dir.resolve("work");
+		write(work.resolve("db.properties"), "working-directory");
+		Path missing = dir.resolve("missing/db.properties");
+
+		EventStorageException thrown = assertThrows(EventStorageException.class,
+			() -> DataSourceFactory.loadProperties(Map.of(DataSourceFactory.SYSTEM_PROPERTY, missing.toString())::get,
+				NOTHING, work, classpathHolding(dir.resolve("empty"))));
+
+		assertTrue(thrown.getMessage().contains(missing.toString()), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains(DataSourceFactory.SYSTEM_PROPERTY),
+			"the message must say what configured the path: " + thrown.getMessage());
+	}
+
+	@Test
+	void testNothingFoundNamesEveryLocationTried ( ) throws IOException {
+		Path work = dir.resolve("work");
+		Files.createDirectories(work);
+
+		EventStorageException thrown = assertThrows(EventStorageException.class,
+			() -> DataSourceFactory.loadProperties(NOTHING, NOTHING, work, classpathHolding(dir.resolve("empty"))));
+
+		String message = thrown.getMessage();
+		assertTrue(message.contains(DataSourceFactory.SYSTEM_PROPERTY), message);
+		assertTrue(message.contains(DataSourceFactory.ENVIRONMENT_VARIABLE), message);
+		assertTrue(message.contains(work.resolve("db.properties").toString()), message);
+		assertTrue(message.contains("classpath"), message);
+	}
+
+	@Test
+	void testLoadingANamedFileConsultsNothingElse ( ) throws IOException {
+		Path named = write(dir.resolve("named/db.properties"), "named");
+
+		assertEquals("named", originOf(DataSourceFactory.loadProperties(named)));
+		assertThrows(EventStorageException.class, () -> DataSourceFactory.loadProperties(dir.resolve("absent.properties")));
+	}
+
+}

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/util/PostgresContainer.java
@@ -225,9 +225,12 @@ public class PostgresContainer {
 	 * writing a {@code db.properties} for it and setting {@code eventstore.db.config}.
 	 * <p>
 	 * Needed to exercise the path where the builder creates the connection pools itself — the path
-	 * where nobody but the storage has a handle on them.
+	 * where nobody but the storage has a handle on them. The file is returned as well, for a test that
+	 * would rather hand it to one builder's {@code configuration(Path)} than to the whole JVM.
+	 *
+	 * @return the file written
 	 */
-	public static void writeDbProperties ( String image ) {
+	public static Path writeDbProperties ( String image ) {
 		PostgreSQLContainer container = CONTAINERS.get(image);
 		if ( container == null ) {
 			throw new IllegalStateException("PostgresContainer.start(\"" + image + "\") was not called");
@@ -252,6 +255,7 @@ public class PostgresContainer {
 				db.nonpooled.datasource.ApplicationName=%2$s-nonpooled
 				""".formatted(url, SELF_BUILT_POOL_MARKER, container.getUsername(), container.getPassword()));
 			System.setProperty("eventstore.db.config", file.toString());
+			return file;
 		} catch ( IOException e ) {
 			throw new IllegalStateException("could not write a db.properties for " + image, e);
 		}


### PR DESCRIPTION
## Summary

Refactors `DataSourceFactory` to follow the configuration lookup convention established by Spring Boot and other frameworks: an explicitly configured path wins, then the working directory, then the classpath — never parent directories. This allows deployments to override packaged defaults without rebuilding, and prevents a library from accidentally reading another project's configuration file.

## Key Changes

- **Lookup order**: System property `eventstore.db.config` → environment variable `EVENTSTORE_DB_CONFIG` → `./db.properties` in working directory → `db.properties` on classpath. Removes the previous behavior of walking up to 2 parent directories.

- **Explicit configuration seams**: Adds `Builder.configuration(Properties)` and `Builder.configuration(Path)` to let callers supply configuration directly, enabling multi-store setups and frameworks that manage configuration externally.

- **Better error messages**: When no file is found, `EventStorageException` names every location tried. When an explicitly configured path doesn't exist, the error says which configuration source named it (system property, environment variable, or builder).

- **Testability**: Extracts the lookup logic into a static method that takes environment functions as arguments, allowing comprehensive test coverage of every branch without setting real system properties or environment variables.

- **Comprehensive test suite**: Adds `DataSourceFactoryTest` with 8 tests covering: system property precedence, environment variable fallback, working directory vs. classpath, parent directory rejection, missing configured paths, and the "nothing found" error message.

- **Documentation**: Updates class and method javadocs, README, and package-info to explain the lookup order and the new builder methods. Updates the quickstart template to reflect the new behavior.

## Implementation Details

- `loadProperties()` now delegates to `loadProperties(Function, Function, Path, ClassLoader)` with the real environment, making the lookup testable.
- Replaces `File` and `FileInputStream` with `java.nio.file` APIs for consistency and better error handling.
- Throws `EventStorageException` (from the SPI) instead of `RuntimeException` for configuration errors, making them part of the contract.
- The builder stores configuration as `Properties` and creates pools on demand in `build()`, closing them with the storage when it is closed.

https://claude.ai/code/session_01C876q9sW2bVXr8JEzEhqJs