### PR TITLE
Add withheld state for readers not entitled to personal data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1057,6 +1057,65 @@ than reporting stale data as readable.
 envelope as stored, which is what lets `EventStoreImporter` copy events with no keys and no domain
 classes.
 
+**Not every reader may read everything, and a reader that may not gets a third state: `Withheld`.**
+Access to a protected value is the ability to resolve its key, so who may read what is decided on the
+key seams and never in the read path. `Shreddable` is `Present`, `Shredded` or `Withheld`; a withheld
+value exists, may well still have its key, and this reader does not get it. It carries the subject and
+key id like `Shredded`, cannot be appended (this process never held the plaintext), and says nothing
+about erasure — a reader that may not decrypt a value cannot tell whether it was erased, and is not
+told; `ShreddingAudit` stays the account of erasures.
+
+- **Why a third state rather than either existing answer.** Reported as `Shredded`, a projection renders
+  "erased" for data that is not and writes that into its read model for good. Reported as a
+  `ShreddingException`, it means "retry later", so a `Projector` that is merely not entitled fails the
+  batch and never advances. Withheld is neither: the read completes, the projection decides how to
+  render the gap, and everything the reader *is* entitled to still gets projected. Adding a case to the
+  sealed interface breaks every exhaustive `switch` at compile time, which is the point — each renderer
+  has to decide what a withheld value looks like. `orElse("[erased]")` call sites are the ones to review,
+  since the fallback now covers both cases.
+- **The seams carry it as sealed results, not exceptions.** `ShreddingKeyStore.resolveKey` answers
+  `KeyResolution.Resolved | Erased | Denied`, and `ShreddingCodec.open` answers
+  `Unsealed.Plaintext | Erased | Withheld`; both have defaults deriving the first two answers from the
+  older two-answer methods, so a key store or codec written before them keeps working and never denies.
+  A sealed type rather than a `ShreddingException` subtype because the difference between "erased",
+  "denied" and "down" is the most important contract in this subsystem, and a `catch (ShreddingException)`
+  retry loop would swallow a refusal by accident. The two-answer methods on the shipped
+  implementations *throw* for a denial rather than report it as erased — nothing in the library calls
+  them any more.
+- **Three ways a reader is limited, from cheap to hard:**
+  ```java
+  // a reporting service: typed events, none of the personal data. Without a codec it could not open
+  // the stream at all -- registering a type that declares a Shreddable fails on a store with none
+  PostgresEventStorage.newBuilder().shredding(ShreddingCodec.withholdingAll()).buildStore();
+
+  // a service that reads names and never addresses: an in-process policy on the category
+  PostgresEventStorage.newBuilder().shredding(AesGcmShreddingCodec.over(keyStore).restrictedTo(Set.of("identity"))).buildStore();
+
+  // the hard boundary: a key store that refuses keys this role is not granted
+  KeyResolution resolveKey ( KeyId key ) { ... return new KeyResolution.Denied("vault: 403"); }
+  ```
+  `restrictedTo` decides on the category the envelope carries in the clear, before any key lookup, so a
+  denied category costs no key-store traffic. It is symmetric — the codec seals nothing outside its
+  categories either, and such an append fails as an `EventSerializationException` with nothing stored —
+  and it passes erasure and audit through whole, because an erasure that silently left another category
+  readable while reporting success is the worst outcome an erasure can have. It is a data-minimisation
+  boundary a deployment declares for itself, not a security boundary: the process still holds the codec.
+  The security boundary is the key store's refusal — a KMS policy per service role, or on Postgres a
+  role granted every column of `shredding_keys` *except* `key_material`, which `PostgresShreddingKeyStore`
+  recognises by SQLSTATE 42501 and reports as `Denied` (cached for the key ttl). Row-level security on
+  that table does **not** produce a denial: a hidden row reads as erased. The two compose.
+- **The unit of access is the unit of encryption: the `Shreddable` value, partitioned by `category`.**
+  "Name but not address" is two wrapped values under two categories, chosen when the event is written,
+  not one `Shreddable<ContactDetails>` holding both. Nothing inside one sealed value can be handed out on
+  its own — the alternative, decrypting and blanking fields, leaves the plaintext in the reader's memory
+  and needs the annotation-plus-split design already rejected above. A category is forward-only: a
+  value sealed under `default` cannot be re-categorised without re-sealing, which means rewriting the
+  event. Each category is one more key row per subject and one more `keyFor` query per append that
+  carries it, so a handful per subject is the intended scale, not one per field.
+- **A withheld reader still sees the pseudonymous subject id, the category, and the `dek:` tags.** That
+  is unchanged and by design, and it is why the rule that subject ids and tags must not themselves be
+  personal data is load-bearing for the PII-less reader.
+
 **A component that was a plain field when its events were written cannot be read as a `Shreddable`.**
 The stored value is bare, so nothing can say whose data it is, and the read fails with a message saying
 to migrate the events via `EventStoreImporter.transform` or to read the old shape through a
@@ -1065,8 +1124,13 @@ to migrate the events via `EventStoreImporter.transform` or to read the old shap
 `ShreddableEventDataTest` in the TCK pins all of this per backend, against *that backend's* key store:
 the two-subject erasure, the collection case, a record whose constructor rejects nulls surviving erasure,
 category independence, idempotent erasure and a fresh key afterwards, the `dek:` tags, the audit view
-(including, reflectively, that `KeyRecord` cannot carry key material), and — load-bearing — that an
-unreachable key store throws instead of reporting the data as erased.
+(including, reflectively, that `KeyRecord` cannot carry key material), that an unreachable key store
+throws instead of reporting the data as erased — and, for entitlement, that a withholding codec reads the
+typed events with every value withheld, that a restricted codec reads its categories and withholds the
+rest without a key lookup, seals nothing outside them and erases everything, that a withheld value says
+nothing about erasure, that a key store's `Denied` reads as withheld and a projector advances over it,
+and that a withheld value cannot be appended again. `ReaderEntitlementTest` in the api module pins the
+seams below the store.
 
 ## Testing
 

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/AesGcmShreddingCodec.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/AesGcmShreddingCodec.java
@@ -30,6 +30,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 
 import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.ActiveKey;
+import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.KeyResolution;
 
 /**
  * The shipped {@link ShreddingCodec}: AES-256-GCM over a pluggable {@link ShreddingKeyStore}.
@@ -62,6 +63,12 @@ import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.ActiveKey;
  * failing outright. Tampering surfaces as a {@link ShreddingException}, never as a silently wrong value
  * and never as a spurious "erased".
  *
+ * <h2>A key store's refusal is passed on as withheld</h2>
+ * {@link #open} asks the key store through {@link ShreddingKeyStore#resolveKey}, and a
+ * {@link KeyResolution.Denied} becomes {@link Unsealed.Withheld} — the reader sees whose data it is not
+ * shown and carries on, rather than seeing an erasure that did not happen or an exception that would
+ * stop its projections. An in-process policy on categories is a decorator over this codec,
+ * {@link ShreddingCodec#restrictedTo(java.util.Set)}, and needs no support here.
  * <h2>Caching is the key store's business</h2>
  * This codec resolves a key per sealed value and holds nothing between calls, so erasure takes effect
  * here the instant the key store stops returning the key. Where resolving is expensive — a network call
@@ -160,6 +167,20 @@ public class AesGcmShreddingCodec implements ShreddingCodec {
 
 	@Override
 	public Optional<String> unseal ( Sealed sealed ) {
+		return switch ( open(sealed) ) {
+			case Unsealed.Plaintext plaintext -> Optional.of(plaintext.json());
+			case Unsealed.Erased erased -> Optional.empty();
+			// The two-answer method cannot say "withheld", and reporting it as erased is the one
+			// conflation this subsystem must never make. Nothing in the library calls this method; a
+			// caller that does is told through the exception rather than through a lie.
+			case Unsealed.Withheld withheld -> throw new ShreddingException(
+					"the value for subject %s under key %s is withheld (%s); read it through open(Sealed), which can say so"
+							.formatted(sealed.subject(), sealed.key(), withheld.reason()));
+		};
+	}
+
+	@Override
+	public Unsealed open ( Sealed sealed ) {
 		if ( sealed == null ) {
 			throw new IllegalArgumentException("sealed cannot be null");
 		}
@@ -172,22 +193,27 @@ public class AesGcmShreddingCodec implements ShreddingCodec {
 							.formatted(sealed.alg(), ALGORITHM));
 		}
 
-		Optional<SecretKey> key = keyStore.resolve(sealed.key());
-		if ( key.isEmpty() ) {
+		return switch ( keyStore.resolveKey(sealed.key()) ) {
 			// The key is gone, which is the mechanism working. Never conflate this with a key store that
 			// could not be reached -- that throws, from the key store itself.
-			return Optional.empty();
-		}
+			case KeyResolution.Erased erased -> Unsealed.Erased.INSTANCE;
+			// The key exists and this reader may not have it: the key store's own boundary, passed on as
+			// what it is rather than as an erasure or a retry.
+			case KeyResolution.Denied denied -> new Unsealed.Withheld(denied.reason());
+			case KeyResolution.Resolved resolved -> new Unsealed.Plaintext(decrypt(sealed, resolved.key()));
+		};
+	}
 
+	private static String decrypt ( Sealed sealed, SecretKey key ) {
 		try {
 			byte[] iv = decode(sealed.iv(), "iv", sealed);
 			byte[] ciphertext = decode(sealed.ciphertext(), "ct", sealed);
 
 			Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-			cipher.init(Cipher.DECRYPT_MODE, key.get(), new GCMParameterSpec(TAG_BITS, iv));
+			cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
 			cipher.updateAAD(additionalAuthenticatedData(sealed.key(), sealed.subject()));
 
-			return Optional.of(new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8));
+			return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
 
 		} catch (GeneralSecurityException e) {
 			// An authentication failure here means the ciphertext, the iv or the authenticated metadata

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/CategoryRestrictedShreddingCodec.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/CategoryRestrictedShreddingCodec.java
@@ -1,0 +1,174 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.shredding;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A {@link ShreddingCodec} over another, handling only the {@link DataSubject#category() categories} it
+ * was given.
+ * <p>
+ * Obtained through {@link ShreddingCodec#restrictedTo(Set)}. The decision is made on the category the
+ * envelope carries in the clear, so a withheld value costs no key lookup and no round trip to whatever
+ * holds the keys.
+ * <h2>What it is, and is not</h2>
+ * It is the declaration, in configuration, that this process handles some categories of personal data
+ * and not others — the data-minimisation boundary a service states about itself, honoured by the read
+ * path and the append path alike. It is not a security boundary: the process still holds the codec it
+ * wraps. The boundary that cannot be argued with from inside the JVM is the key store's own refusal,
+ * {@link ShreddingKeyStore.KeyResolution.Denied}, and the two compose — a restricted codec over a key
+ * store that also refuses gives the cheap answer for the categories it never asks about and the hard
+ * one for the rest.
+ * <h2>Symmetric, deliberately</h2>
+ * Sealing is restricted to the same categories as unsealing, so "the categories this process handles"
+ * is a single statement rather than two. A process that has the plaintext of a category it may not
+ * read is holding data it was configured not to handle, and an append that would seal it fails before
+ * anything is stored.
+ * <h2>Erasure and audit pass through</h2>
+ * Erasing a subject destroys every key the subject holds, in every category, exactly as on the wrapped
+ * codec. The alternative — erasing only the permitted categories — loses because an erasure that
+ * reports success while leaving data readable is the worst outcome an erasure can have; a process not
+ * entitled to erase should not be handed {@link org.sliceworkz.eventstore.EventStore#erase} at all.
+ *
+ * @see ShreddingCodec#restrictedTo(Set)
+ * @see Shreddable.Withheld
+ */
+public final class CategoryRestrictedShreddingCodec implements ShreddingCodec {
+
+	private final ShreddingCodec delegate;
+	private final Set<String> categories;
+
+	/**
+	 * @param delegate   the codec that does the sealing and unsealing for the permitted categories
+	 * @param categories the categories this codec handles
+	 * @throws IllegalArgumentException if the delegate is null, or the set is null, empty, or holds a null
+	 *                                  or blank category
+	 */
+	public CategoryRestrictedShreddingCodec ( ShreddingCodec delegate, Set<String> categories ) {
+		if ( delegate == null ) {
+			throw new IllegalArgumentException("delegate cannot be null");
+		}
+		if ( categories == null || categories.isEmpty() ) {
+			throw new IllegalArgumentException(
+					"categories cannot be null or empty; a codec handling no category is ShreddingCodec.withholdingAll()");
+		}
+		for ( String category : categories ) {
+			if ( category == null || category.isBlank() ) {
+				throw new IllegalArgumentException("a category cannot be null or blank");
+			}
+		}
+		this.delegate = delegate;
+		this.categories = Set.copyOf(categories);
+	}
+
+	/**
+	 * The codec this one restricts.
+	 *
+	 * @return the wrapped codec
+	 */
+	public ShreddingCodec delegate ( ) {
+		return delegate;
+	}
+
+	/**
+	 * The categories this codec seals and unseals.
+	 *
+	 * @return the permitted categories, never empty
+	 */
+	public Set<String> categories ( ) {
+		return categories;
+	}
+
+	/**
+	 * @param subject whose data
+	 * @return true if this codec handles the subject's category
+	 */
+	public boolean permits ( DataSubject subject ) {
+		return subject != null && categories.contains(subject.category());
+	}
+
+	@Override
+	public Sealed seal ( String plaintext, DataSubject subject ) {
+		if ( subject == null ) {
+			throw new IllegalArgumentException("subject cannot be null");
+		}
+		if ( !permits(subject) ) {
+			// Before the delegate sees the plaintext: a process configured not to handle a category must
+			// not seal it either, and the failure names the category rather than the value.
+			throw new ShreddingException(
+					"this codec handles categories %s only and cannot seal a value in category '%s' for subject %s"
+							.formatted(sortedCategories(), subject.category(), subject));
+		}
+		return delegate.seal(plaintext, subject);
+	}
+
+	@Override
+	public Optional<String> unseal ( Sealed sealed ) {
+		// The two-answer method cannot say "withheld", and pretending it is erased is the one thing this
+		// class exists to avoid. Nothing in the library calls it; a caller that does gets the answer
+		// through the exception rather than through a lie.
+		return switch ( open(sealed) ) {
+			case Unsealed.Plaintext plaintext -> Optional.of(plaintext.json());
+			case Unsealed.Erased erased -> Optional.empty();
+			case Unsealed.Withheld withheld -> throw new ShreddingException(
+					"the value is withheld (%s); read it through open(Sealed), which can say so".formatted(withheld.reason()));
+		};
+	}
+
+	@Override
+	public Unsealed open ( Sealed sealed ) {
+		if ( sealed == null ) {
+			throw new IllegalArgumentException("sealed cannot be null");
+		}
+		if ( !permits(sealed.subject()) ) {
+			return new Unsealed.Withheld(
+					"category '%s' is outside this codec's %s".formatted(sealed.subject().category(), sortedCategories()));
+		}
+		return delegate.open(sealed);
+	}
+
+	@Override
+	public ErasureReport shred ( DataSubject subject, ErasureReason reason ) {
+		return delegate.shred(subject, reason);
+	}
+
+	@Override
+	public Optional<ShreddingAudit> audit ( ) {
+		return delegate.audit();
+	}
+
+	/**
+	 * Closes the wrapped codec.
+	 */
+	@Override
+	public void close ( ) {
+		delegate.close();
+	}
+
+	private String sortedCategories ( ) {
+		return new TreeSet<>(categories).toString();
+	}
+
+	@Override
+	public String toString ( ) {
+		return "CategoryRestrictedShreddingCodec[%s over %s]".formatted(sortedCategories(), delegate);
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/DataSubject.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/DataSubject.java
@@ -33,14 +33,24 @@ package org.sliceworkz.eventstore.shredding;
  * This is the same discipline the library already asks for when tagging events: {@code Tag.of("customer",
  * customerId)} is safe to store and index precisely because {@code customerId} is pseudonymous.
  *
- * <h2>Category: what one erasure erases</h2>
+ * <h2>Category: the unit of erasure, and the unit of access</h2>
  * Keys are held per {@code (type, id, category)}, not per subject, so a subject's data can be erased
  * in parts. "Erase marketing data, retain financial records for the statutory period" is an ordinary
  * request, and a single key per subject makes it impossible to honour: shredding would take the
  * financial history with it.
  * <p>
+ * The same partition is what a reader can be given or refused. A category is written in the clear on
+ * every sealed envelope, so a codec can decide on it before looking up any key
+ * ({@link ShreddingCodec#restrictedTo(java.util.Set)}), and a key store that holds keys per category
+ * can refuse them per role ({@link ShreddingKeyStore.KeyResolution.Denied}). "This service reads names
+ * and never addresses" is therefore a modelling decision made when the event is written: the name and
+ * the address are two {@link Shreddable} values under two categories, not one value holding both.
+ * Nothing finer than a value is addressable — the value is what is encrypted — and a category chosen at
+ * write time cannot be changed afterwards without re-sealing, which would mean rewriting the event.
+ * <p>
  * Most events need only {@link #DEFAULT_CATEGORY}, which {@link #of(String, String)} applies. Reach for
- * a category when parts of a subject's data are governed by different retention rules:
+ * a category when parts of a subject's data are governed by different retention rules, or read by
+ * different systems:
  * <pre>{@code
  * DataSubject marketing = DataSubject.of("customer", "alice-42").withCategory("marketing");
  * DataSubject financial = DataSubject.of("customer", "alice-42").withCategory("financial");
@@ -48,6 +58,8 @@ package org.sliceworkz.eventstore.shredding;
  * // erases the marketing data only; the financial history keeps decrypting
  * eventStore.erase(marketing, ErasureReason.of("GDPR art.17 request #4711"));
  * }</pre>
+ * Each category a subject uses is one more key row and, on append, one more key lookup per event that
+ * carries it — a handful per subject is the intended scale, not one per field.
  *
  * <h2>Examples</h2>
  * <pre>{@code
@@ -66,6 +78,7 @@ package org.sliceworkz.eventstore.shredding;
  *
  * @see Shreddable
  * @see ShreddingKeyStore
+ * @see ShreddingCodec#restrictedTo(java.util.Set)
  * @see org.sliceworkz.eventstore.EventStore#erase(DataSubject, ErasureReason)
  */
 public record DataSubject ( String type, String id, String category ) {

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/Shreddable.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/Shreddable.java
@@ -112,7 +112,7 @@ import java.util.function.Supplier;
  * @see ShreddingCodec
  * @see org.sliceworkz.eventstore.EventStore#erase(DataSubject, ErasureReason)
  */
-public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shredded {
+public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shredded, Shreddable.Withheld {
 
 	/**
 	 * Whose data this is. Available whether or not the value is still readable — a shredded value still
@@ -129,21 +129,26 @@ public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shr
 	boolean isShredded ( );
 
 	/**
-	 * @return true if the value is still readable
+	 * @return true if this reader is not entitled to the value; whether it still exists is not known here
+	 */
+	boolean isWithheld ( );
+
+	/**
+	 * @return true if the value is readable by this reader — neither shredded nor withheld
 	 */
 	default boolean isPresent ( ) {
-		return !isShredded();
+		return !isShredded() && !isWithheld();
 	}
 
 	/**
-	 * The value if it is still readable, empty if it has been shredded.
+	 * The value if this reader can read it, empty if it has been shredded or withheld.
 	 *
 	 * @return the value as an {@link Optional}
 	 */
 	Optional<T> toOptional ( );
 
 	/**
-	 * Applies a function to the value if it is still readable, keeping the subject and key otherwise.
+	 * Applies a function to the value if this reader can read it, keeping the subject and key otherwise.
 	 * <p>
 	 * The usual way to read one field out of a protected value:
 	 * <pre>{@code
@@ -157,13 +162,13 @@ public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shr
 	<R> Shreddable<R> map ( Function<? super T, ? extends R> fn );
 
 	/**
-	 * @param fallback what to return when the value has been shredded; may be null
+	 * @param fallback what to return when the value has been shredded or withheld; may be null
 	 * @return the value, or the fallback
 	 */
 	T orElse ( T fallback );
 
 	/**
-	 * @param supplier produces the replacement when the value has been shredded
+	 * @param supplier produces the replacement when the value has been shredded or withheld
 	 * @return the value, or the supplied replacement
 	 */
 	T orElseGet ( Supplier<? extends T> supplier );
@@ -209,6 +214,11 @@ public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shr
 
 		@Override
 		public boolean isShredded ( ) {
+			return false;
+		}
+
+		@Override
+		public boolean isWithheld ( ) {
 			return false;
 		}
 
@@ -266,6 +276,11 @@ public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shr
 		}
 
 		@Override
+		public boolean isWithheld ( ) {
+			return false;
+		}
+
+		@Override
 		public Optional<T> toOptional ( ) {
 			return Optional.empty();
 		}
@@ -274,6 +289,69 @@ public sealed interface Shreddable<T> permits Shreddable.Present, Shreddable.Shr
 		@Override
 		public <R> Shreddable<R> map ( Function<? super T, ? extends R> fn ) {
 			// nothing to map -- a Shredded holds no value, so the same instance serves every element type
+			return (Shreddable<R>) this;
+		}
+
+		@Override
+		public T orElse ( T fallback ) {
+			return fallback;
+		}
+
+		@Override
+		public T orElseGet ( Supplier<? extends T> supplier ) {
+			return supplier.get();
+		}
+
+	}
+
+	/**
+	 * A value this reader is not entitled to. The ciphertext is in the event and the key may well still
+	 * exist; the codec or key store this reader goes through declined to unseal it.
+	 * <p>
+	 * The subject and key id are kept, as on {@link Shredded}, so a projection can still say whose data it
+	 * is not showing. Nothing here says whether the value has been erased: a reader that may not decrypt
+	 * it is not told, and the {@link ShreddingAudit} remains the account of erasures.
+	 * <p>
+	 * Cannot be appended, for the same reason a {@link Shredded} cannot: there is no plaintext to seal, and
+	 * a placeholder would be indistinguishable from real data on a later, entitled read.
+	 *
+	 * @param <T>     the type the value has
+	 * @param subject whose data it is
+	 * @param key     the key it is sealed under
+	 */
+	record Withheld<T> ( DataSubject subject, KeyId key ) implements Shreddable<T> {
+
+		/**
+		 * @throws IllegalArgumentException if the subject or the key is null
+		 */
+		public Withheld {
+			if ( subject == null ) {
+				throw new IllegalArgumentException("Shreddable subject must not be null");
+			}
+			if ( key == null ) {
+				throw new IllegalArgumentException("Withheld key must not be null");
+			}
+		}
+
+		@Override
+		public boolean isShredded ( ) {
+			return false;
+		}
+
+		@Override
+		public boolean isWithheld ( ) {
+			return true;
+		}
+
+		@Override
+		public Optional<T> toOptional ( ) {
+			return Optional.empty();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <R> Shreddable<R> map ( Function<? super T, ? extends R> fn ) {
+			// nothing to map -- a Withheld holds no value, so the same instance serves every element type
 			return (Shreddable<R>) this;
 		}
 

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/ShreddingCodec.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/ShreddingCodec.java
@@ -18,6 +18,7 @@
 package org.sliceworkz.eventstore.shredding;
 
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Turns a {@link Shreddable} value into a sealed envelope and back, and destroys the keys that make
@@ -33,6 +34,21 @@ import java.util.Optional;
  * key store that cannot be reached, an expired credential, a timeout, a corrupt envelope or an
  * unsupported algorithm must throw {@link ShreddingException}. See {@link ShreddingKeyStore} for why
  * conflating the two turns a transient outage into permanent, silent loss in every read model.
+ * <h2>Withheld is a third answer, for a reader that is not entitled</h2>
+ * Not every reader of a log may read everything in it. {@link #open} is {@link #unseal} with one more
+ * answer, {@link Unsealed.Withheld}: the value exists and this codec will not unseal it for this reader.
+ * The read path calls {@code open}, and turns that answer into {@link Shreddable.Withheld} — never into
+ * {@link Shreddable.Shredded}, which would render a projection's "erased" for data that is not, and
+ * never into an exception, which would stop a projector that is merely not entitled from advancing over
+ * what it is entitled to.
+ * <p>
+ * Two things produce it. {@link #restrictedTo(Set)} wraps any codec in an in-process policy on the
+ * {@link DataSubject#category() category} an envelope carries in the clear, deciding before any key is
+ * looked up: cheap, explicit in configuration, and the data-minimisation boundary most services need.
+ * It is not a security boundary — the process still holds the codec. That boundary is the key store's
+ * refusal, {@link ShreddingKeyStore.KeyResolution.Denied}, which the shipped codec also reports as
+ * withheld; the two compose. {@link #withholdingAll()} is the degenerate case: a codec with no keys at
+ * all, for a reader that must see the typed events and none of the personal data in them.
  *
  * <h2>Algorithm agility is a requirement, not a nicety</h2>
  * The algorithm is recorded on every envelope rather than assumed globally, so one store can hold
@@ -90,6 +106,77 @@ public interface ShreddingCodec extends AutoCloseable {
 	Optional<String> unseal ( Sealed sealed );
 
 	/**
+	 * Decrypts a sealed envelope, reports that its key is gone, or declines to unseal it for this reader.
+	 * <p>
+	 * The read path calls this rather than {@link #unseal}. The default derives {@link Unsealed.Plaintext}
+	 * and {@link Unsealed.Erased} from {@link #unseal} and never answers {@link Unsealed.Withheld}, so a
+	 * codec written before it existed keeps working. The shipped codec overrides it to pass on a key
+	 * store's {@link ShreddingKeyStore.KeyResolution.Denied}.
+	 *
+	 * @param sealed the envelope read from the event
+	 * @return the value's JSON form, or why it is not available: erased, or withheld from this reader
+	 * @throws ShreddingException if the key store cannot be reached, the algorithm is not supported, or
+	 *                            the envelope is malformed — never for a destroyed or withheld value
+	 */
+	default Unsealed open ( Sealed sealed ) {
+		return unseal(sealed).<Unsealed>map(Unsealed.Plaintext::new).orElse(Unsealed.Erased.INSTANCE);
+	}
+
+	/**
+	 * This codec, unsealing and sealing only the given {@link DataSubject#category() categories}.
+	 * <p>
+	 * A value in any other category reads as {@link Shreddable.Withheld}, decided on the category the
+	 * envelope carries in the clear and before any key is resolved — so a denied category costs no key
+	 * store traffic, and against a KMS no refused call per value. Sealing is restricted the same way, so
+	 * "the categories this process handles" is one statement: an append carrying a value outside them
+	 * fails with {@link ShreddingException}, which the append path reports as an
+	 * {@code EventSerializationException}, before anything is stored.
+	 * <pre>{@code
+	 * // a service entitled to names, never to addresses
+	 * PostgresEventStorage.newBuilder()
+	 *         .shredding(AesGcmShreddingCodec.over(keyStore).restrictedTo(Set.of("identity")))
+	 *         .buildStore();
+	 * }</pre>
+	 * The granularity is the {@link Shreddable} value: the writer decides what is one value under which
+	 * category, and that is what a reader can be given or refused. "Name but not address" means two
+	 * wrapped values under two categories, decided when the event is modelled.
+	 * <p>
+	 * Erasure and audit pass through unchanged. Erasing a subject is not a read, and a process entitled to
+	 * erase is entitled to erase every category — a restricted codec that silently erased only its own
+	 * categories would report success for an erasure it had not performed.
+	 *
+	 * @param categories the categories this codec seals and unseals; must not be null or empty
+	 * @return a codec over this one, withholding everything outside those categories
+	 * @throws IllegalArgumentException if the set is null, empty, or holds a null or blank category
+	 */
+	default ShreddingCodec restrictedTo ( Set<String> categories ) {
+		return new CategoryRestrictedShreddingCodec(this, categories);
+	}
+
+	/**
+	 * A codec that holds no keys and unseals nothing: every protected value reads as
+	 * {@link Shreddable.Withheld}, and nothing can be sealed.
+	 * <p>
+	 * For a reader that needs the typed events and none of the personal data in them — a reporting or
+	 * analytics service projecting amounts and pseudonymous ids. Without a codec such a reader cannot open
+	 * a typed stream at all, since registering an event type that declares a {@code Shreddable} fails on
+	 * a store with none; with this one it opens the same streams and gets withheld values. Raw mode reads
+	 * without keys too, but hands back JSON, without types or upcasting.
+	 * <pre>{@code
+	 * PostgresEventStorage.newBuilder().shredding(ShreddingCodec.withholdingAll()).buildStore();
+	 * }</pre>
+	 * It is an explicit opt-in, on purpose: a store with no codec keeps failing registration, so personal
+	 * data is never quietly unreadable through a missing configuration. Appending a value that needs
+	 * sealing fails with {@link ShreddingException}; erasure throws {@link UnsupportedOperationException},
+	 * since there are no keys here to destroy; the audit is empty.
+	 *
+	 * @return a codec that withholds every protected value
+	 */
+	static ShreddingCodec withholdingAll ( ) {
+		return WithholdingShreddingCodec.INSTANCE;
+	}
+
+	/**
 	 * Destroys every key held for a subject, making all values sealed under them permanently unreadable.
 	 * <p>
 	 * Idempotent: erasing a subject twice reports an empty second run rather than failing.
@@ -120,6 +207,63 @@ public interface ShreddingCodec extends AutoCloseable {
 	@Override
 	default void close ( ) {
 		// nothing to release by default
+	}
+
+	/**
+	 * The three answers {@link #open} can give.
+	 * <p>
+	 * A sealed type so that a caller handles all three, and an implementation names which it means. The
+	 * fourth outcome — the key store is down, the envelope is corrupt, the algorithm is unknown — is not an
+	 * answer but a {@link ShreddingException}.
+	 */
+	sealed interface Unsealed permits Unsealed.Plaintext, Unsealed.Erased, Unsealed.Withheld {
+
+		/**
+		 * The value, decrypted.
+		 *
+		 * @param json the value's JSON form
+		 */
+		record Plaintext ( String json ) implements Unsealed {
+
+			/**
+			 * @throws IllegalArgumentException if the json is null
+			 */
+			public Plaintext {
+				if ( json == null ) {
+					throw new IllegalArgumentException("Plaintext json must not be null; use Erased for a destroyed key");
+				}
+			}
+
+		}
+
+		/**
+		 * The key has been destroyed. The value is gone for everyone.
+		 */
+		record Erased ( ) implements Unsealed {
+
+			/**
+			 * The one instance; a record with no components has nothing to distinguish two.
+			 */
+			public static final Erased INSTANCE = new Erased();
+
+		}
+
+		/**
+		 * This reader is not entitled to the value. Whether it still exists is not said.
+		 *
+		 * @param reason what withheld it, for a log line; never key material, and never personal data
+		 */
+		record Withheld ( String reason ) implements Unsealed {
+
+			/**
+			 * Normalises a null reason to an empty string.
+			 */
+			public Withheld {
+				reason = reason == null ? "" : reason;
+			}
+
+		}
+
 	}
 
 	/**

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/ShreddingKeyStore.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/ShreddingKeyStore.java
@@ -38,6 +38,10 @@ import javax.crypto.SecretKey;
  *       appended after an erasure is readable again — the old ciphertext stays unreadable.</li>
  *   <li><b>{@link #resolve} answers empty only for a destroyed key.</b> See below; this is the one
  *       contract that must not be got wrong.</li>
+ *   <li><b>{@link #resolveKey} is the same lookup with a third answer</b>, {@link KeyResolution.Denied}:
+ *       the key exists and this caller may not have it. Its default derives the other two answers from
+ *       {@link #resolve}, so a store written before it existed keeps working; a store that can tell a
+ *       refusal from an outage overrides it, see below.</li>
  *   <li><b>{@link #shred} is idempotent</b> and returns what it actually destroyed, so a second erasure
  *       for the same subject reports an empty list rather than failing.</li>
  *   <li><b>Key material is never resurrected.</b> Destroying a key means the bytes are gone; keep the
@@ -57,6 +61,25 @@ import javax.crypto.SecretKey;
  * an exception, the read fails loudly, the bookmark does not move, and the projection recovers by
  * itself once the key store is back.
  *
+ * <h2>Denied is a third answer, and it is not an outage either</h2>
+ * A key store fronting a KMS or a database with per-role privileges will meet a caller that is not
+ * entitled to a key: a 403 from Vault, {@code insufficient_privilege} from PostgreSQL. That is neither an
+ * erasure nor a failure. Reported as empty, the value reads as {@link Shreddable.Shredded} and a
+ * projection renders "erased" for data that is not. Reported as a {@link ShreddingException}, it means
+ * "retry later", and a projector that is simply not entitled fails its batch and never advances. So
+ * {@link #resolveKey} has {@link KeyResolution.Denied} for it, which the read path turns into
+ * {@link Shreddable.Withheld}: the reader sees whose data it is not shown and carries on.
+ * <p>
+ * The three answers are a sealed type rather than an exception hierarchy so that an implementation has
+ * to name which one it means, and so that a {@code catch (ShreddingException)} retry loop cannot swallow
+ * a refusal by accident. {@link #resolve} keeps its two-answer contract and is what older codecs call;
+ * a store that overrides {@link #resolveKey} should make {@link #resolve} throw for a denial, since a
+ * caller of the old method cannot represent one.
+ * <p>
+ * This is where the <em>hard</em> boundary lives. A key store's refusal is enforced by whatever holds
+ * the keys — a KMS policy per service role, column privileges on the key table — and cannot be argued
+ * with from inside the JVM. The in-process alternative, {@link ShreddingCodec#restrictedTo(java.util.Set)},
+ * is a data-minimisation boundary a deployment declares for itself; the two compose.
  * <h2>Ordering, when the key store is not transactional with the events</h2>
  * The default key stores that ship with a SQL backend write keys on the same {@code DataSource} as the
  * events, so a key mint and the append that needs it commit together. An external key store cannot do
@@ -107,6 +130,23 @@ public interface ShreddingKeyStore extends AutoCloseable {
 	Optional<SecretKey> resolve ( KeyId key );
 
 	/**
+	 * The key material for a key id, or why this caller does not get it.
+	 * <p>
+	 * The read path calls this, not {@link #resolve}. The default answers {@link KeyResolution.Resolved}
+	 * or {@link KeyResolution.Erased} from {@link #resolve} and never {@link KeyResolution.Denied}, so a
+	 * store that has no notion of entitlement need not override it. One that has — a KMS, a database role
+	 * without the privilege — overrides this to return {@code Denied} for a refusal, and keeps throwing
+	 * {@link ShreddingException} for everything that a retry might fix.
+	 *
+	 * @param key the key id taken from a sealed envelope
+	 * @return the key, or why it is not available: destroyed, or not for this caller
+	 * @throws ShreddingException if the key store cannot be reached — never for a destroyed or denied key
+	 */
+	default KeyResolution resolveKey ( KeyId key ) {
+		return resolve(key).<KeyResolution>map(KeyResolution.Resolved::new).orElse(KeyResolution.Erased.INSTANCE);
+	}
+
+	/**
 	 * Destroys every key held for a subject, recording why.
 	 *
 	 * @param subject whose keys to destroy
@@ -138,6 +178,67 @@ public interface ShreddingKeyStore extends AutoCloseable {
 	@Override
 	default void close ( ) {
 		// nothing to release by default
+	}
+
+	/**
+	 * The three answers a key lookup can have.
+	 * <p>
+	 * A sealed type rather than an {@code Optional} plus an exception, so that an implementation names
+	 * which one it means and a caller has to handle all three. The difference between them is the most
+	 * important contract in this subsystem: {@link Erased} is the mechanism working, {@link Denied} is a
+	 * reader that is not entitled, and an outage is neither — that one throws.
+	 *
+	 * @see ShreddingKeyStore#resolveKey(KeyId)
+	 */
+	sealed interface KeyResolution permits KeyResolution.Resolved, KeyResolution.Erased, KeyResolution.Denied {
+
+		/**
+		 * The key exists and this caller may use it.
+		 *
+		 * @param key the key material
+		 */
+		record Resolved ( SecretKey key ) implements KeyResolution {
+
+			/**
+			 * @throws IllegalArgumentException if the key is null
+			 */
+			public Resolved {
+				if ( key == null ) {
+					throw new IllegalArgumentException("Resolved key must not be null; use Erased for a destroyed key");
+				}
+			}
+
+		}
+
+		/**
+		 * The key has been destroyed, or never existed. The value sealed under it is gone for everyone.
+		 */
+		record Erased ( ) implements KeyResolution {
+
+			/**
+			 * The one instance; a record with no components has nothing to distinguish two.
+			 */
+			public static final Erased INSTANCE = new Erased();
+
+		}
+
+		/**
+		 * The key exists, and this caller is not entitled to it. The value reads as
+		 * {@link Shreddable.Withheld}.
+		 *
+		 * @param reason what refused it, for a log line; never key material, and never personal data
+		 */
+		record Denied ( String reason ) implements KeyResolution {
+
+			/**
+			 * Normalises a null reason to an empty string.
+			 */
+			public Denied {
+				reason = reason == null ? "" : reason;
+			}
+
+		}
+
 	}
 
 	/**

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/WithholdingShreddingCodec.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/WithholdingShreddingCodec.java
@@ -1,0 +1,79 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.shredding;
+
+import java.util.Optional;
+
+/**
+ * The codec behind {@link ShreddingCodec#withholdingAll()}: no keys, no key store, every protected
+ * value withheld.
+ * <p>
+ * It exists so that a reader with no entitlement to personal data can still open typed streams over
+ * events that carry it. Registering an event type that declares a {@link Shreddable} fails on a store
+ * with no codec, and that is right for a writer; a reader that only wants the non-personal payload
+ * needs a codec that answers, and this one answers {@link Unsealed.Withheld} for everything.
+ * <p>
+ * A singleton, since it holds nothing.
+ */
+final class WithholdingShreddingCodec implements ShreddingCodec {
+
+	static final WithholdingShreddingCodec INSTANCE = new WithholdingShreddingCodec();
+
+	private static final String REASON = "this store's codec withholds every protected value (ShreddingCodec.withholdingAll())";
+
+	private WithholdingShreddingCodec ( ) {
+		// nothing to hold
+	}
+
+	@Override
+	public Sealed seal ( String plaintext, DataSubject subject ) {
+		if ( subject == null ) {
+			throw new IllegalArgumentException("subject cannot be null");
+		}
+		throw new ShreddingException(
+				"cannot seal a value for subject %s: this store's codec holds no keys (ShreddingCodec.withholdingAll()) and is for reading only"
+						.formatted(subject));
+	}
+
+	@Override
+	public Optional<String> unseal ( Sealed sealed ) {
+		// Cannot say "withheld", and must not say "erased".
+		throw new ShreddingException(REASON + "; read it through open(Sealed), which can say so");
+	}
+
+	@Override
+	public Unsealed open ( Sealed sealed ) {
+		if ( sealed == null ) {
+			throw new IllegalArgumentException("sealed cannot be null");
+		}
+		return new Unsealed.Withheld(REASON);
+	}
+
+	@Override
+	public ErasureReport shred ( DataSubject subject, ErasureReason reason ) {
+		throw new UnsupportedOperationException(
+				"this store's codec holds no keys (ShreddingCodec.withholdingAll()), so it cannot erase subject %s; erase through a store whose codec holds the keys"
+						.formatted(subject));
+	}
+
+	@Override
+	public String toString ( ) {
+		return "WithholdingShreddingCodec";
+	}
+
+}

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/package-info.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/package-info.java
@@ -66,7 +66,31 @@
  *   <li>{@link org.sliceworkz.eventstore.shredding.ErasureReason} and
  *       {@link org.sliceworkz.eventstore.shredding.ErasureReport} — the audit trail, since the events
  *       themselves record nothing about the erasure</li>
+ *   <li>{@link org.sliceworkz.eventstore.shredding.CategoryRestrictedShreddingCodec} and
+ *       {@link org.sliceworkz.eventstore.shredding.ShreddingCodec#withholdingAll()} — a reader entitled
+ *       to some categories of personal data, or to none</li>
  * </ul>
+ * <h2>Not every reader may read everything</h2>
+ * Access to a protected value is the ability to resolve its key, so who may read what is decided on the
+ * key seams and never in the event store's read path. A reader that is not entitled to a value gets
+ * {@link org.sliceworkz.eventstore.shredding.Shreddable.Withheld}, a third state beside present and
+ * shredded: the value exists, and this reader does not get it. It is neither an erasure — a projection
+ * would render "erased" for data that is not — nor an exception, which would stop a reader that is
+ * merely not entitled from projecting what it is entitled to.
+ * <pre>{@code
+ * // a service that reads names and never addresses: an in-process policy on the category
+ * AesGcmShreddingCodec.over(keyStore).restrictedTo(Set.of("identity"))
+ *
+ * // a reporting service that reads the typed events and none of the personal data in them
+ * ShreddingCodec.withholdingAll()
+ *
+ * // the hard boundary: a key store that refuses keys this role is not granted
+ * KeyResolution resolveKey(KeyId key) { ... return new KeyResolution.Denied("vault: 403"); }
+ * }</pre>
+ * The unit of access is the unit of encryption, the {@code Shreddable} value, partitioned by the
+ * {@link org.sliceworkz.eventstore.shredding.DataSubject#category() category} chosen when the event is
+ * written. "Name but not address" is two wrapped values under two categories, decided at modelling
+ * time; nothing inside one sealed value can be given out on its own.
  *
  * <h2>Two rules that are easy to break</h2>
  * <ul>

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/shredding/ReaderEntitlementTest.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/shredding/ReaderEntitlementTest.java
@@ -1,0 +1,321 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.shredding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec.Sealed;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec.Unsealed;
+import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.KeyResolution;
+
+/**
+ * The two codec seams' third answer, below the event store: a restricted codec, the withholding codec,
+ * a key store's denial, and the {@link Shreddable.Withheld} state itself. The read path through a store
+ * is pinned per backend by the TCK's {@code ShreddableEventDataTest}.
+ */
+public class ReaderEntitlementTest {
+
+	private static final DataSubject IDENTITY = DataSubject.of("customer", "alice-42").withCategory("identity");
+	private static final DataSubject ADDRESS = DataSubject.of("customer", "alice-42").withCategory("address");
+
+	@Test
+	void aRestrictedCodecUnsealsItsCategoriesAndWithholdsTheRestWithoutAskingTheKeyStore ( ) {
+		MapKeyStore keyStore = new MapKeyStore();
+		AesGcmShreddingCodec full = AesGcmShreddingCodec.over(keyStore);
+		Sealed name = full.seal("\"Alice\"", IDENTITY);
+		Sealed street = full.seal("\"Rue Haute 1\"", ADDRESS);
+
+		ShreddingCodec namesOnly = full.restrictedTo(Set.of("identity"));
+		keyStore.resolved.clear();
+
+		assertEquals(new Unsealed.Plaintext("\"Alice\""), namesOnly.open(name));
+		Unsealed.Withheld withheld = assertInstanceOf(Unsealed.Withheld.class, namesOnly.open(street));
+		assertTrue(withheld.reason().contains("address"), withheld.reason());
+		assertEquals(List.of(name.key()), keyStore.resolved, "the withheld category must not reach the key store");
+
+		// the two-answer method cannot say withheld, and must not say erased
+		assertEquals(Optional.of("\"Alice\""), namesOnly.unseal(name));
+		assertThrows(ShreddingException.class, () -> namesOnly.unseal(street));
+	}
+
+	@Test
+	void aRestrictedCodecSealsOnlyItsCategories ( ) {
+		ShreddingCodec namesOnly = AesGcmShreddingCodec.over(new MapKeyStore()).restrictedTo(Set.of("identity"));
+		assertEquals(IDENTITY, namesOnly.seal("\"Alice\"", IDENTITY).subject());
+		ShreddingException thrown = assertThrows(ShreddingException.class, () -> namesOnly.seal("\"Rue Haute 1\"", ADDRESS));
+		assertTrue(thrown.getMessage().contains("address"), thrown.getMessage());
+	}
+
+	@Test
+	void aRestrictedCodecErasesAndAuditsThroughTheWholeDelegate ( ) {
+		MapKeyStore keyStore = new MapKeyStore();
+		AesGcmShreddingCodec full = AesGcmShreddingCodec.over(keyStore);
+		Sealed street = full.seal("\"Rue Haute 1\"", ADDRESS);
+
+		ShreddingCodec namesOnly = full.restrictedTo(Set.of("identity"));
+		assertEquals(List.of(street.key()), namesOnly.shred(ADDRESS, ErasureReason.of("art.17")).shreddedKeys(),
+				"erasure is not a read and must not be narrowed to the reader's categories");
+		assertEquals(Unsealed.Erased.INSTANCE, full.open(street));
+		assertSame(full.audit().isPresent(), namesOnly.audit().isPresent());
+	}
+
+	@Test
+	void aRestrictedCodecRejectsAnEmptyOrBlankCategorySet ( ) {
+		ShreddingCodec codec = AesGcmShreddingCodec.over(new MapKeyStore());
+		assertThrows(IllegalArgumentException.class, () -> codec.restrictedTo(Set.of()));
+		assertThrows(IllegalArgumentException.class, () -> codec.restrictedTo(null));
+		assertThrows(IllegalArgumentException.class, () -> codec.restrictedTo(Set.of(" ")));
+		assertThrows(IllegalArgumentException.class, () -> new CategoryRestrictedShreddingCodec(null, Set.of("identity")));
+	}
+
+	@Test
+	void theWithholdingCodecHoldsNoKeysAndWithholdsEverything ( ) {
+		Sealed name = AesGcmShreddingCodec.over(new MapKeyStore()).seal("\"Alice\"", IDENTITY);
+		ShreddingCodec none = ShreddingCodec.withholdingAll();
+
+		assertInstanceOf(Unsealed.Withheld.class, none.open(name));
+		assertThrows(ShreddingException.class, () -> none.unseal(name), "must not report withheld as erased");
+		assertThrows(ShreddingException.class, () -> none.seal("\"Alice\"", IDENTITY));
+		assertThrows(UnsupportedOperationException.class, () -> none.shred(IDENTITY, ErasureReason.of("art.17")));
+		assertEquals(Optional.empty(), none.audit());
+		assertSame(none, ShreddingCodec.withholdingAll(), "holds nothing, so one instance serves everyone");
+	}
+
+	@Test
+	void aKeyStoreDenialIsPassedOnAsWithheldByTheShippedCodec ( ) {
+		MapKeyStore keyStore = new MapKeyStore();
+		AesGcmShreddingCodec codec = AesGcmShreddingCodec.over(keyStore);
+		Sealed name = codec.seal("\"Alice\"", IDENTITY);
+
+		keyStore.denying = true;
+		Unsealed.Withheld withheld = assertInstanceOf(Unsealed.Withheld.class, codec.open(name));
+		assertEquals("simulated 403", withheld.reason());
+		assertThrows(ShreddingException.class, () -> codec.unseal(name), "the two-answer method cannot say withheld");
+
+		keyStore.denying = false;
+		assertEquals(new Unsealed.Plaintext("\"Alice\""), codec.open(name));
+	}
+
+	@Test
+	void theDefaultResolveKeyDerivesResolvedAndErasedFromResolveAndNeverDenied ( ) {
+		MapKeyStore keyStore = new MapKeyStore();
+		KeyId key = keyStore.keyFor(IDENTITY).id();
+
+		KeyResolution.Resolved resolved = assertInstanceOf(KeyResolution.Resolved.class, new TwoAnswerKeyStore(keyStore).resolveKey(key));
+		assertEquals(keyStore.resolve(key).orElseThrow(), resolved.key());
+
+		keyStore.shred(IDENTITY, ErasureReason.of("art.17"));
+		assertEquals(KeyResolution.Erased.INSTANCE, new TwoAnswerKeyStore(keyStore).resolveKey(key));
+	}
+
+	@Test
+	void theDefaultOpenDerivesPlaintextAndErasedFromUnsealAndNeverWithheld ( ) {
+		MapKeyStore keyStore = new MapKeyStore();
+		AesGcmShreddingCodec codec = AesGcmShreddingCodec.over(keyStore);
+		Sealed name = codec.seal("\"Alice\"", IDENTITY);
+
+		ShreddingCodec twoAnswers = new TwoAnswerCodec(codec);
+		assertEquals(new Unsealed.Plaintext("\"Alice\""), twoAnswers.open(name));
+		keyStore.shred(IDENTITY, ErasureReason.of("art.17"));
+		assertEquals(Unsealed.Erased.INSTANCE, twoAnswers.open(name));
+	}
+
+	@Test
+	void withheldIsNeitherPresentNorShreddedAndMapsToItself ( ) {
+		KeyId key = KeyId.of("k-1");
+		Shreddable<String> withheld = new Shreddable.Withheld<>(IDENTITY, key);
+
+		assertTrue(withheld.isWithheld());
+		assertFalse(withheld.isShredded());
+		assertFalse(withheld.isPresent());
+		assertEquals(Optional.empty(), withheld.toOptional());
+		assertEquals("fallback", withheld.orElse("fallback"));
+		assertEquals("supplied", withheld.orElseGet(() -> "supplied"));
+		assertSame(withheld, withheld.map(String::length));
+		assertEquals(IDENTITY, withheld.subject());
+
+		assertThrows(IllegalArgumentException.class, () -> new Shreddable.Withheld<>(null, key));
+		assertThrows(IllegalArgumentException.class, () -> new Shreddable.Withheld<>(IDENTITY, null));
+
+		// the other two keep their meaning
+		assertFalse(Shreddable.of("Alice", IDENTITY).isWithheld());
+		assertTrue(Shreddable.of("Alice", IDENTITY).isPresent());
+		assertFalse(new Shreddable.Shredded<>(IDENTITY, key).isWithheld());
+		assertFalse(new Shreddable.Shredded<>(IDENTITY, key).isPresent());
+	}
+
+	@Test
+	void theResultTypesRejectWhatTheyCannotMean ( ) {
+		assertThrows(IllegalArgumentException.class, () -> new KeyResolution.Resolved(null));
+		assertThrows(IllegalArgumentException.class, () -> new Unsealed.Plaintext(null));
+		assertEquals("", new KeyResolution.Denied(null).reason());
+		assertEquals("", new Unsealed.Withheld(null).reason());
+	}
+
+	/**
+	 * A key store written against the two-answer contract only, to check the defaults derive the
+	 * three-answer one from it.
+	 */
+	private static final class TwoAnswerKeyStore implements ShreddingKeyStore {
+
+		private final ShreddingKeyStore delegate;
+
+		private TwoAnswerKeyStore ( ShreddingKeyStore delegate ) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ActiveKey keyFor ( DataSubject subject ) {
+			return delegate.keyFor(subject);
+		}
+
+		@Override
+		public Optional<SecretKey> resolve ( KeyId key ) {
+			return delegate.resolve(key);
+		}
+
+		@Override
+		public List<KeyId> shred ( DataSubject subject, ErasureReason reason ) {
+			return delegate.shred(subject, reason);
+		}
+
+	}
+
+	/**
+	 * A codec written against the two-answer contract only.
+	 */
+	private static final class TwoAnswerCodec implements ShreddingCodec {
+
+		private final ShreddingCodec delegate;
+
+		private TwoAnswerCodec ( ShreddingCodec delegate ) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Sealed seal ( String plaintext, DataSubject subject ) {
+			return delegate.seal(plaintext, subject);
+		}
+
+		@Override
+		public Optional<String> unseal ( Sealed sealed ) {
+			return delegate.unseal(sealed);
+		}
+
+		@Override
+		public ErasureReport shred ( DataSubject subject, ErasureReason reason ) {
+			return delegate.shred(subject, reason);
+		}
+
+	}
+
+	/**
+	 * The smallest key store that can mint, resolve, shred, deny and be watched.
+	 */
+	private static final class MapKeyStore implements ShreddingKeyStore {
+
+		private final Map<DataSubject, KeyId> active = new HashMap<>();
+		private final Map<KeyId, SecretKey> material = new HashMap<>();
+		private final Map<KeyId, DataSubject> subjects = new HashMap<>();
+		private final List<KeyId> resolved = new ArrayList<>();
+		private boolean denying;
+
+		@Override
+		public ActiveKey keyFor ( DataSubject subject ) {
+			KeyId id = active.computeIfAbsent(subject, s -> {
+				KeyId fresh = KeyId.of("k-" + UUID.randomUUID());
+				material.put(fresh, generate());
+				subjects.put(fresh, s);
+				return fresh;
+			});
+			return new ActiveKey(id, material.get(id));
+		}
+
+		@Override
+		public Optional<SecretKey> resolve ( KeyId key ) {
+			resolved.add(key);
+			return Optional.ofNullable(material.get(key));
+		}
+
+		@Override
+		public KeyResolution resolveKey ( KeyId key ) {
+			if ( denying ) {
+				return new KeyResolution.Denied("simulated 403");
+			}
+			return ShreddingKeyStore.super.resolveKey(key);
+		}
+
+		@Override
+		public List<KeyId> shred ( DataSubject subject, ErasureReason reason ) {
+			List<KeyId> shredded = new ArrayList<>();
+			subjects.forEach((id, s) -> {
+				if ( s.equals(subject) && material.get(id) != null ) {
+					material.put(id, null);
+					shredded.add(id);
+				}
+			});
+			active.remove(subject);
+			return shredded;
+		}
+
+		@Override
+		public Optional<ShreddingAudit> audit ( ) {
+			return Optional.of(new ShreddingAudit() {
+				@Override
+				public List<KeyRecord> keys ( KeyAuditQuery query ) {
+					return List.of();
+				}
+
+				@Override
+				public ShreddingTotals totals ( ) {
+					return new ShreddingTotals(0, 0, 0);
+				}
+			});
+		}
+
+		private static SecretKey generate ( ) {
+			try {
+				KeyGenerator generator = KeyGenerator.getInstance("AES");
+				generator.init(256);
+				return generator.generateKey();
+			} catch (NoSuchAlgorithmException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+
+	}
+
+}

--- a/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/ShreddableModule.java
+++ b/sliceworkz-eventstore-impl/src/main/java/org/sliceworkz/eventstore/impl/serde/ShreddableModule.java
@@ -18,7 +18,6 @@
 package org.sliceworkz.eventstore.impl.serde;
 
 import java.util.LinkedHashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import org.sliceworkz.eventstore.shredding.DataSubject;
@@ -26,6 +25,7 @@ import org.sliceworkz.eventstore.shredding.KeyId;
 import org.sliceworkz.eventstore.shredding.Shreddable;
 import org.sliceworkz.eventstore.shredding.ShreddingCodec;
 import org.sliceworkz.eventstore.shredding.ShreddingCodec.Sealed;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec.Unsealed;
 import org.sliceworkz.eventstore.shredding.ShreddingException;
 
 import tools.jackson.core.JsonGenerator;
@@ -52,8 +52,11 @@ import tools.jackson.databind.module.SimpleModule;
  *           "iv":  "yQ3mR1…",
  *           "ct":  "8Kd2vRhT…" }
  * }</pre>
- * Reading reverses it, and a key that no longer resolves yields {@link Shreddable.Shredded} rather than
- * a failure.
+ * Reading reverses it. A key that no longer resolves yields {@link Shreddable.Shredded} rather than a
+ * failure, and a value the codec declines to unseal for this reader — a category outside a
+ * {@link ShreddingCodec#restrictedTo(java.util.Set) restricted} codec's, a key the key store refuses this
+ * role — yields {@link Shreddable.Withheld}. Neither is an error: the read completes and the projection
+ * decides how to render the gap.
  * <p>
  * Because this is an ordinary Jackson serializer keyed on the {@code Shreddable} type, it applies
  * wherever one appears — a top-level record component, several levels down a nested record, inside a
@@ -175,19 +178,23 @@ public final class ShreddableModule extends SimpleModule {
 	 * A {@link Shreddable.Shredded} cannot be written: there is no plaintext left to seal, and inventing
 	 * one would replace erased personal data with a placeholder that later reads could not tell from the
 	 * real thing. Re-appending an event whose personal data has been erased is a programming error, and
-	 * it fails here rather than quietly writing a hole.
+	 * it fails here rather than quietly writing a hole. A {@link Shreddable.Withheld} cannot be written
+	 * for the same reason: this reader never had the plaintext, and a placeholder would read as real
+	 * data on a later, entitled read.
 	 */
 	private final class ShreddableSerializer extends ValueSerializer<Shreddable<?>> {
 
 		@Override
 		public void serialize ( Shreddable<?> value, JsonGenerator generator, SerializationContext context ) {
-			if ( value instanceof Shreddable.Shredded<?> shredded ) {
-				throw new IllegalArgumentException(
+			Shreddable.Present<?> present = switch ( value ) {
+				case Shreddable.Present<?> p -> p;
+				case Shreddable.Shredded<?> shredded -> throw new IllegalArgumentException(
 						"cannot append a value whose personal data has already been erased (subject %s, key %s). Reading an event, erasing its subject and appending it again would store a placeholder indistinguishable from real data; build the new event from data you still hold."
 								.formatted(shredded.subject(), shredded.key()));
-			}
-
-			Shreddable.Present<?> present = (Shreddable.Present<?>) value;
+				case Shreddable.Withheld<?> withheld -> throw new IllegalArgumentException(
+						"cannot append a value that was withheld from this reader (subject %s, key %s). This process never held the plaintext, and storing a placeholder would read as real data to a reader that is entitled to it; build the new event from data you hold."
+								.formatted(withheld.subject(), withheld.key()));
+			};
 			String plaintext = mapper().writeValueAsString(present.value());
 			Sealed sealed = codec.seal(plaintext, present.subject());
 			recordSealedKey(sealed.key());
@@ -275,16 +282,17 @@ public final class ShreddableModule extends SimpleModule {
 					node.get(FIELD_IV).asString(),
 					node.get(FIELD_CIPHERTEXT).asString());
 
-			Optional<String> plaintext = codec.unseal(sealed);
-			if ( plaintext.isEmpty() ) {
-				return new Shreddable.Shredded<>(sealed.subject(), sealed.key());
-			}
-
-			if ( valueType == null ) {
-				throw new IllegalStateException(
-						"cannot read a raw Shreddable: declare the component as Shreddable<YourType> so the decrypted value can be parsed");
-			}
-			return new Shreddable.Present<>(mapper().readValue(plaintext.get(), valueType), sealed.subject());
+			return switch ( codec.open(sealed) ) {
+				case Unsealed.Erased erased -> new Shreddable.Shredded<>(sealed.subject(), sealed.key());
+				case Unsealed.Withheld withheld -> new Shreddable.Withheld<>(sealed.subject(), sealed.key());
+				case Unsealed.Plaintext plaintext -> {
+					if ( valueType == null ) {
+						throw new IllegalStateException(
+								"cannot read a raw Shreddable: declare the component as Shreddable<YourType> so the decrypted value can be parsed");
+					}
+					yield new Shreddable.Present<>(mapper().readValue(plaintext.json(), valueType), sealed.subject());
+				}
+			};
 		}
 
 		private DataSubject subjectOf ( JsonNode node ) {

--- a/sliceworkz-eventstore-infra-postgres/README.md
+++ b/sliceworkz-eventstore-infra-postgres/README.md
@@ -75,6 +75,23 @@ what leaves the erasure an audit trail — the events themselves record nothing 
 lets a key id keep resolving to "erased" rather than to "unknown". Granting `DELETE` here would let
 an erasure be made untraceable.
 
+A role that must read the events but never the personal data in them is granted every column of the
+key table *except* `key_material`:
+
+```sql
+GRANT SELECT (key_id, subject_type, subject_id, subject_category, created_at, shredded_at, shredded_reason)
+    ON <prefix>shredding_keys TO <reporting_role>;
+```
+
+Resolving a key under that role fails with `insufficient_privilege`, which the key store reports as a
+denial rather than an outage: every protected value reads as `Shreddable.Withheld`, projections
+advance, and the audit still works since it never selects `key_material`. This is the database-enforced
+boundary, and it is all-or-nothing per role. Per-category entitlement — a service that reads names
+and never addresses — is declared on the codec with `ShreddingCodec.restrictedTo(...)`, which decides
+on the category in the envelope and never reaches the table for a denied one. Row-level security on
+the key table does *not* produce a denial: a hidden row is indistinguishable from an absent one and
+reads as erased.
+
 ### Migrating a database created before shredding existed
 
 `ENSURE` only ever creates tables, so it adds this one on the next start of an existing database and

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/shredding/PostgresShreddingKeyStore.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/shredding/PostgresShreddingKeyStore.java
@@ -44,6 +44,7 @@ import org.sliceworkz.eventstore.shredding.KeyId;
 import org.sliceworkz.eventstore.shredding.ShreddingAudit;
 import org.sliceworkz.eventstore.shredding.ShreddingException;
 import org.sliceworkz.eventstore.shredding.ShreddingKeyStore;
+import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.KeyResolution;
 
 /**
  * A {@link ShreddingKeyStore} keeping data encryption keys in a SQL table beside the events.
@@ -89,6 +90,24 @@ import org.sliceworkz.eventstore.shredding.ShreddingKeyStore;
  * <h2>Privileges</h2>
  * Needs {@code SELECT}, {@code INSERT} and {@code UPDATE} on the table. It does not need {@code DELETE}:
  * erasure updates a row rather than removing it.
+ * <h2>A role without the privilege reads withheld, not erased</h2>
+ * A reader that must never decrypt anything can be given a role with {@code SELECT} on every column of
+ * the key table except {@code key_material}. Resolving a key then fails with
+ * {@code insufficient_privilege} (SQLSTATE 42501), which {@link #resolveKey} reports as
+ * {@link KeyResolution.Denied}, so the reader sees {@link org.sliceworkz.eventstore.shredding.Shreddable.Withheld}
+ * and its projections advance — rather than an outage to retry forever, which is what any other
+ * {@code SQLException} is. The audit statements never touch that column, so the same role can still
+ * report on erasures. This is the hard boundary the database enforces; it is all-or-nothing per role,
+ * because column privileges are. Per-category entitlement is the codec's
+ * {@link org.sliceworkz.eventstore.shredding.ShreddingCodec#restrictedTo(java.util.Set)}, which
+ * decides on the category in the envelope and never reaches this store for a denied one.
+ * <p>
+ * Row-level security on the key table does <em>not</em> give a denial: a row the policy hides is
+ * indistinguishable from a row that never existed, and reads as erased. Use column privileges for the
+ * hard boundary and the codec restriction for the per-category one.
+ * <p>
+ * A denial is cached for the same ttl as a key, since a role's privileges do not change per value; a
+ * grant made while a process runs is seen once the entry lapses.
  *
  * <h2>Ownership</h2>
  * The {@code DataSource} is never closed by this key store — it belongs to the storage, which closes
@@ -133,11 +152,17 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 	 * The expiry is what bounds an erasure performed by <em>another</em> instance: this one keeps
 	 * decrypting with a key it cached until the entry lapses and the next read finds the row shredded.
 	 */
-	private record CachedKey ( SecretKey key, Instant expiresAt ) {
+	private record CachedKey ( KeyResolution resolution, Instant expiresAt ) {
 		private boolean isLive ( Instant now ) {
 			return now.isBefore(expiresAt);
 		}
 	}
+
+	/**
+	 * PostgreSQL's SQLSTATE for {@code insufficient_privilege}: the one failure that is a reader's
+	 * entitlement rather than an outage.
+	 */
+	private static final String SQLSTATE_INSUFFICIENT_PRIVILEGE = "42501";
 
 	/**
 	 * @param dataSource the storage's data source; never closed by this key store
@@ -245,6 +270,20 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 
 	@Override
 	public Optional<SecretKey> resolve ( KeyId key ) {
+		return switch ( resolveKey(key) ) {
+			case KeyResolution.Resolved resolved -> Optional.of(resolved.key());
+			case KeyResolution.Erased erased -> Optional.empty();
+			// The two-answer method cannot say "denied", and reporting it as erased is the one thing this
+			// subsystem must never do. Nothing in the library calls this method; a caller that does is
+			// told through the exception.
+			case KeyResolution.Denied denied -> throw new ShreddingException(
+					"this role is not entitled to key %s in %s (%s); resolve it through resolveKey, which can say so"
+							.formatted(key, tableName, denied.reason()));
+		};
+	}
+
+	@Override
+	public KeyResolution resolveKey ( KeyId key ) {
 		if ( key == null ) {
 			throw new IllegalArgumentException("key cannot be null");
 		}
@@ -252,7 +291,7 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 		CachedKey cached = cache.get(key);
 		if ( cached != null ) {
 			if ( cached.isLive(Instant.now()) ) {
-				return Optional.of(cached.key());
+				return cached.resolution();
 			}
 			// lapsed rather than wrong: drop it and ask the database, which is where an erasure by
 			// another instance will have been recorded
@@ -270,23 +309,32 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 					// No such key. Reported as "erased" rather than thrown: a key id this store has never
 					// held cannot be produced by a retry either, and the only readings that reach here are
 					// an erasure whose row was pruned, or an envelope from another store.
-					return Optional.empty();
+					return KeyResolution.Erased.INSTANCE;
 				}
 				byte[] material = resultSet.getBytes("key_material");
 				if ( material == null ) {
 					// Shredded. This is the mechanism working, and must never be confused with the
 					// database being unreachable -- which throws, from the catch below.
-					return Optional.empty();
+					return KeyResolution.Erased.INSTANCE;
 				}
-				SecretKey secretKey = new SecretKeySpec(material, KEY_ALGORITHM);
-				cacheKey(key, secretKey);
-				return Optional.of(secretKey);
+				KeyResolution resolved = new KeyResolution.Resolved(new SecretKeySpec(material, KEY_ALGORITHM));
+				cacheResolution(key, resolved);
+				return resolved;
 			}
 
 		} catch (SQLException e) {
-			// Loudly, and never as an empty Optional: reported as erased, a database blip would make
-			// every protected value read as destroyed, and bookmarked projections would write those gaps
-			// into read models and never revisit them.
+			if ( SQLSTATE_INSUFFICIENT_PRIVILEGE.equals(e.getSQLState()) ) {
+				// This role may not read key_material: the database's own entitlement boundary, passed on
+				// as what it is. Recognised by SQLSTATE, never by message text, like every other
+				// server-reported condition in this backend.
+				KeyResolution denied = new KeyResolution.Denied(
+						"role is not granted SELECT on %s.key_material (SQLSTATE %s)".formatted(tableName, e.getSQLState()));
+				cacheResolution(key, denied);
+				return denied;
+			}
+			// Loudly, and never as erased: reported as erased, a database blip would make every
+			// protected value read as destroyed, and bookmarked projections would write those gaps into
+			// read models and never revisit them.
 			throw new ShreddingException("failed to resolve shredding key %s from %s".formatted(key, tableName), e);
 		}
 	}
@@ -455,10 +503,14 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 	}
 
 	private void cacheKey ( KeyId keyId, SecretKey material ) {
+		cacheResolution(keyId, new KeyResolution.Resolved(material));
+	}
+
+	private void cacheResolution ( KeyId keyId, KeyResolution resolution ) {
 		if ( cacheTtl.isZero() ) {
 			return;
 		}
-		cache.put(keyId, new CachedKey(material, Instant.now().plus(cacheTtl)));
+		cache.put(keyId, new CachedKey(resolution, Instant.now().plus(cacheTtl)));
 	}
 
 	private Optional<ActiveKey> selectActiveKey ( Connection connection, DataSubject subject ) throws SQLException {

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/AbstractEventStoreTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/AbstractEventStoreTest.java
@@ -31,6 +31,7 @@ import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.EventStoreFactory;
 import org.sliceworkz.eventstore.MeterOptions;
 import org.sliceworkz.eventstore.shredding.AesGcmShreddingCodec;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec;
 import org.sliceworkz.eventstore.shredding.ShreddingKeyStore;
 import org.sliceworkz.eventstore.spi.EventStorage;
 
@@ -175,8 +176,20 @@ public abstract class AbstractEventStoreTest {
 	 * @return a store with shredding configured, over {@link #eventStorage()}
 	 */
 	protected EventStore eventStoreWithShredding ( ShreddingKeyStore shreddingKeyStore ) {
-		return EventStoreFactory.get().eventStore(eventStorage(), new SimpleMeterRegistry(), MeterOptions.defaults(),
-				AesGcmShreddingCodec.over(shreddingKeyStore));
+		return eventStoreWithShredding(AesGcmShreddingCodec.over(shreddingKeyStore));
+	}
+
+	/**
+	 * An event store over the same storage, with a codec of your choosing.
+	 * <p>
+	 * For scenarios about what a reader is entitled to: a codec restricted to some categories, or one
+	 * that withholds every protected value.
+	 *
+	 * @param shreddingCodec seals and unseals protected values
+	 * @return a store with shredding configured, over {@link #eventStorage()}
+	 */
+	protected EventStore eventStoreWithShredding ( ShreddingCodec shreddingCodec ) {
+		return EventStoreFactory.get().eventStore(eventStorage(), new SimpleMeterRegistry(), MeterOptions.defaults(), shreddingCodec);
 	}
 
 	/**

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/ShreddableEventDataTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/ShreddableEventDataTest.java
@@ -26,14 +26,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.crypto.SecretKey;
 
 import org.sliceworkz.eventstore.EventStore;
 import org.sliceworkz.eventstore.events.Event;
+import org.sliceworkz.eventstore.events.EventSerializationException;
 import org.sliceworkz.eventstore.events.Tag;
 import org.sliceworkz.eventstore.events.Tags;
+import org.sliceworkz.eventstore.projection.Projection;
+import org.sliceworkz.eventstore.projection.Projector;
+import org.sliceworkz.eventstore.projection.Projector.ProjectorMetrics;
 import org.sliceworkz.eventstore.query.EventQuery;
+import org.sliceworkz.eventstore.shredding.AesGcmShreddingCodec;
 import org.sliceworkz.eventstore.shredding.DataSubject;
 import org.sliceworkz.eventstore.shredding.ErasureReason;
 import org.sliceworkz.eventstore.shredding.ErasureReport;
@@ -41,8 +47,10 @@ import org.sliceworkz.eventstore.shredding.KeyAuditQuery;
 import org.sliceworkz.eventstore.shredding.KeyId;
 import org.sliceworkz.eventstore.shredding.Shreddable;
 import org.sliceworkz.eventstore.shredding.ShreddingAudit;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec;
 import org.sliceworkz.eventstore.shredding.ShreddingException;
 import org.sliceworkz.eventstore.shredding.ShreddingKeyStore;
+import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.KeyResolution;
 import org.sliceworkz.eventstore.stream.AppendCriteria;
 import org.sliceworkz.eventstore.stream.EventStream;
 import org.sliceworkz.eventstore.stream.EventStreamId;
@@ -357,6 +365,192 @@ public class ShreddableEventDataTest extends AbstractEventStoreTest {
 		assertEquals(2, audit(store).keys(KeyAuditQuery.all().withLimit(2)).size());
 	}
 
+	// ---- who may read what: withheld is a third state, decided on the key seams -------------------------
+
+	/**
+	 * A reader with no keys at all still gets the typed events. Without a codec it could not open the
+	 * stream, since registering a type that declares a Shreddable fails; with the withholding codec it
+	 * reads everything that is not personal data and is told, per value, that the rest is withheld.
+	 */
+	@ForEachBackend
+	void aReaderWithNoKeysReadsTheTypedEventsAndEveryProtectedValueIsWithheld ( ) {
+		eventStoreWithShredding().getEventStream(STREAM, PaymentEvent.class)
+				.append(AppendCriteria.none(), Event.of(transfer(), Tags.of("transfer", "t-9001")));
+
+		EventStore reader = eventStoreWithShredding(ShreddingCodec.withholdingAll());
+		EventStream<PaymentEvent> payments = reader.getEventStream(STREAM, PaymentEvent.class);
+
+		Event<PaymentEvent> read = payments.query(EventQuery.matchAll()).findFirst().orElseThrow();
+		TransferMade transfer = (TransferMade) read.data();
+
+		// the non-personal payload is all there
+		assertEquals("t-9001", transfer.transferId());
+		assertEquals(25000, transfer.cents());
+		assertEquals("alice-42", transfer.fromCustomerId());
+		assertTrue(read.tags().tags().contains(Tag.of("transfer", "t-9001")));
+
+		// and the personal data is withheld: not erased, not an error, and still says whose it is
+		Shreddable.Withheld<PartyDetails> from = assertInstanceOf(Shreddable.Withheld.class, transfer.from());
+		assertEquals(ALICE, from.subject());
+		assertNotNull(from.key());
+		assertTrue(transfer.from().isWithheld());
+		assertFalse(transfer.from().isShredded(), "withheld must never read as erased");
+		assertFalse(transfer.from().isPresent());
+		assertEquals(Optional.empty(), transfer.from().toOptional());
+		assertEquals("[withheld]", transfer.from().map(PartyDetails::name).orElse("[withheld]"));
+		assertTrue(transfer.to().isWithheld());
+
+		// it holds no keys, so it can neither seal nor erase, and has nothing to audit
+		assertThrows(EventSerializationException.class,
+				() -> payments.append(AppendCriteria.none(), Event.of(transfer(), Tags.none())));
+		assertThrows(UnsupportedOperationException.class, () -> reader.erase(ALICE, ErasureReason.of("art.17")));
+		assertEquals(Optional.empty(), reader.shreddingAudit());
+	}
+
+	/**
+	 * "Names but not addresses": two categories, and a reader restricted to one of them. The unit of
+	 * access is the Shreddable value, partitioned by the category chosen when the event was written.
+	 */
+	@ForEachBackend
+	void aReaderRestrictedToACategoryReadsThatCategoryAndIsWithheldTheRest ( ) {
+		DataSubject identity = ALICE.withCategory("identity");
+		DataSubject address = ALICE.withCategory("address");
+
+		// one key store, shared by the writer and the restricted reader, as in a deployment
+		CountingKeyStore keyStore = new CountingKeyStore(backend().shreddingKeyStore(eventStorage()));
+		eventStoreWithShredding(keyStore).getEventStream(STREAM, PaymentEvent.class).append(AppendCriteria.none(),
+				Event.of(new ContactRecorded("c-1", Shreddable.of("Alice Martin", identity), Shreddable.of("Rue Haute 1", address)), Tags.none()));
+		keyStore.resolutions.clear();
+
+		EventStream<PaymentEvent> namesOnly = eventStoreWithShredding(AesGcmShreddingCodec.over(keyStore).restrictedTo(Set.of("identity")))
+				.getEventStream(STREAM, PaymentEvent.class);
+
+		ContactRecorded read = (ContactRecorded) namesOnly.query(EventQuery.matchAll()).findFirst().orElseThrow().data();
+		assertEquals("Alice Martin", read.name().orElse(null));
+		Shreddable.Withheld<String> withheld = assertInstanceOf(Shreddable.Withheld.class, read.address());
+		assertEquals(address, withheld.subject());
+
+		// the denied category is decided on the envelope, before any key is looked up
+		assertEquals(Set.of(withheld.key()), keyStore.notAskedFor(), "a withheld category must not cost a key lookup");
+		assertEquals(1, keyStore.resolutions.size(), "exactly the permitted value's key was resolved");
+	}
+
+	/**
+	 * Withheld says nothing about erasure. A reader that may not decrypt a value cannot tell whether
+	 * it has been erased and is not told; a reader that may sees the erasure as before.
+	 */
+	@ForEachBackend
+	void aWithheldValueSaysNothingAboutErasureAndAPermittedOneStillReportsIt ( ) {
+		DataSubject identity = ALICE.withCategory("identity");
+		DataSubject address = ALICE.withCategory("address");
+
+		ShreddingKeyStore keyStore = backend().shreddingKeyStore(eventStorage());
+		EventStore full = eventStoreWithShredding(keyStore);
+		full.getEventStream(STREAM, PaymentEvent.class).append(AppendCriteria.none(),
+				Event.of(new ContactRecorded("c-1", Shreddable.of("Alice Martin", identity), Shreddable.of("Rue Haute 1", address)), Tags.none()));
+
+		full.erase(address, ErasureReason.of("address no longer needed"));
+		full.erase(identity, ErasureReason.of("art.17"));
+
+		ShreddingCodec restricted = AesGcmShreddingCodec.over(keyStore).restrictedTo(Set.of("identity"));
+		ContactRecorded read = (ContactRecorded) eventStoreWithShredding(restricted).getEventStream(STREAM, PaymentEvent.class)
+				.query(EventQuery.matchAll()).findFirst().orElseThrow().data();
+
+		assertTrue(read.address().isWithheld(), "an erased value outside the reader's categories is withheld, not reported erased");
+		assertTrue(read.name().isShredded(), "an erased value inside the reader's categories is reported erased");
+
+		ContactRecorded seenByFull = (ContactRecorded) full.getEventStream(STREAM, PaymentEvent.class)
+				.query(EventQuery.matchAll()).findFirst().orElseThrow().data();
+		assertTrue(seenByFull.address().isShredded());
+	}
+
+	/**
+	 * The restriction is symmetric: a process configured not to handle a category cannot seal it either,
+	 * and the append fails before anything is stored.
+	 */
+	@ForEachBackend
+	void aRestrictedCodecDoesNotSealOutsideItsCategoriesAndStoresNothing ( ) {
+		DataSubject identity = ALICE.withCategory("identity");
+		DataSubject address = ALICE.withCategory("address");
+
+		ShreddingCodec restricted = AesGcmShreddingCodec.over(backend().shreddingKeyStore(eventStorage())).restrictedTo(Set.of("identity"));
+		EventStream<PaymentEvent> namesOnly = eventStoreWithShredding(restricted).getEventStream(STREAM, PaymentEvent.class);
+
+		namesOnly.append(AppendCriteria.none(), Event.of(new StrictlyValidated("ok", Shreddable.of("Alice Martin", identity)), Tags.none()));
+
+		EventSerializationException thrown = assertThrows(EventSerializationException.class, () -> namesOnly.append(AppendCriteria.none(),
+				Event.of(new ContactRecorded("c-1", Shreddable.of("Alice Martin", identity), Shreddable.of("Rue Haute 1", address)), Tags.none())));
+		assertTrue(thrown.getMessage().contains("address"), thrown.getMessage());
+
+		assertEquals(1, namesOnly.query(EventQuery.matchAll()).count(), "a refused append must store nothing");
+	}
+
+	/**
+	 * Erasure is not a read. A restricted codec passes it through whole, because an erasure that
+	 * silently left another category readable while reporting success is the worst outcome an erasure
+	 * can have.
+	 */
+	@ForEachBackend
+	void erasingThroughARestrictedCodecErasesEveryCategory ( ) {
+		DataSubject address = ALICE.withCategory("address");
+		ShreddingKeyStore keyStore = backend().shreddingKeyStore(eventStorage());
+		eventStoreWithShredding(keyStore).getEventStream(STREAM, PaymentEvent.class).append(AppendCriteria.none(),
+				Event.of(new StrictlyValidated("a-1", Shreddable.of("Rue Haute 1", address)), Tags.none()));
+
+		EventStore namesOnly = eventStoreWithShredding(AesGcmShreddingCodec.over(keyStore).restrictedTo(Set.of("identity")));
+		assertEquals(1, namesOnly.erase(address, ErasureReason.of("art.17")).keysShredded());
+
+		StrictlyValidated read = (StrictlyValidated) eventStoreWithShredding(keyStore).getEventStream(STREAM, PaymentEvent.class)
+				.query(EventQuery.matchAll()).findFirst().orElseThrow().data();
+		assertTrue(read.email().isShredded());
+		assertEquals(1, namesOnly.shreddingAudit().orElseThrow().keys(KeyAuditQuery.all().onlyShredded()).size(), "the audit passes through too");
+	}
+
+	/**
+	 * The hard boundary: a key store that refuses a key this caller is not granted. The refusal is
+	 * neither an erasure nor an outage, and a projector that is merely not entitled keeps advancing.
+	 */
+	@ForEachBackend
+	void aKeyStoreThatDeniesAKeyReadsAsWithheldAndAProjectorAdvancesOverIt ( ) {
+		ShreddingKeyStore working = backend().shreddingKeyStore(eventStorage());
+		DenyingKeyStore denying = new DenyingKeyStore(working);
+
+		EventStream<PaymentEvent> writing = eventStoreWithShredding(denying).getEventStream(STREAM, PaymentEvent.class);
+		writing.append(AppendCriteria.none(), List.of(
+				Event.of(transfer(), Tags.none()),
+				Event.of(new StrictlyValidated("v-1", Shreddable.of("alice@example.org", ALICE)), Tags.none())));
+
+		denying.denying = true;
+
+		EventStream<PaymentEvent> reading = eventStoreWithShredding(denying).getEventStream(STREAM, PaymentEvent.class);
+		TransferMade transfer = (TransferMade) reading.query(EventQuery.matchAll()).findFirst().orElseThrow().data();
+		Shreddable.Withheld<PartyDetails> from = assertInstanceOf(Shreddable.Withheld.class, transfer.from());
+		assertEquals(ALICE, from.subject());
+		assertFalse(transfer.from().isShredded());
+
+		CountingProjection projection = new CountingProjection();
+		ProjectorMetrics metrics = Projector.from(reading).towards(projection).build().run();
+		assertEquals(2, projection.handled, "a reader that is not entitled must still project what it is entitled to");
+		assertEquals(2, metrics.eventsHandled());
+		assertEquals(3, projection.withheld, "every protected value came through as withheld");
+	}
+
+	@ForEachBackend
+	void aWithheldValueCannotBeAppendedAgain ( ) {
+		EventStore full = eventStoreWithShredding();
+		full.getEventStream(STREAM, PaymentEvent.class).append(AppendCriteria.none(),
+				Event.of(new StrictlyValidated("v-1", Shreddable.of("alice@example.org", ALICE)), Tags.none()));
+
+		StrictlyValidated withheld = (StrictlyValidated) eventStoreWithShredding(ShreddingCodec.withholdingAll())
+				.getEventStream(STREAM, PaymentEvent.class).query(EventQuery.matchAll()).findFirst().orElseThrow().data();
+		assertTrue(withheld.email().isWithheld(), "fixture");
+
+		// this reader never had the plaintext; a placeholder would read as real data to one that is entitled
+		EventStream<PaymentEvent> entitled = full.getEventStream(STREAM, PaymentEvent.class);
+		assertThrows(EventSerializationException.class, () -> entitled.append(AppendCriteria.none(), Event.of(withheld, Tags.none())));
+		assertEquals(1, entitled.query(EventQuery.matchAll()).count());
+	}
+
 	private ShreddingAudit audit ( EventStore store ) {
 		return store.shreddingAudit().orElseThrow();
 	}
@@ -399,6 +593,121 @@ public class ShreddableEventDataTest extends AbstractEventStoreTest {
 		}
 
 	}
+
+	/**
+	 * Records which keys were asked for, so a scenario can assert that a withheld category never reached
+	 * the key store.
+	 */
+	private static final class CountingKeyStore implements ShreddingKeyStore {
+
+		private final ShreddingKeyStore delegate;
+		private final java.util.Set<KeyId> resolutions = new java.util.LinkedHashSet<>();
+		private final java.util.Set<KeyId> minted = new java.util.LinkedHashSet<>();
+
+		private CountingKeyStore ( ShreddingKeyStore delegate ) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ActiveKey keyFor ( DataSubject subject ) {
+			ActiveKey key = delegate.keyFor(subject);
+			minted.add(key.id());
+			return key;
+		}
+
+		@Override
+		public Optional<SecretKey> resolve ( KeyId key ) {
+			resolutions.add(key);
+			return delegate.resolve(key);
+		}
+
+		@Override
+		public KeyResolution resolveKey ( KeyId key ) {
+			resolutions.add(key);
+			return delegate.resolveKey(key);
+		}
+
+		@Override
+		public List<KeyId> shred ( DataSubject subject, ErasureReason reason ) {
+			return delegate.shred(subject, reason);
+		}
+
+		/**
+		 * The keys this store knows about that were never resolved through it.
+		 */
+		private java.util.Set<KeyId> notAskedFor ( ) {
+			return delegate.audit().orElseThrow().keys(KeyAuditQuery.all()).stream()
+					.map(ShreddingAudit.KeyRecord::id)
+					.filter(id -> !resolutions.contains(id))
+					.collect(java.util.stream.Collectors.toSet());
+		}
+
+	}
+
+	/**
+	 * Stands in for a key store fronting a KMS or a database role that refuses this caller every key.
+	 */
+	private static final class DenyingKeyStore implements ShreddingKeyStore {
+
+		private final ShreddingKeyStore delegate;
+		private boolean denying;
+
+		private DenyingKeyStore ( ShreddingKeyStore delegate ) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ActiveKey keyFor ( DataSubject subject ) {
+			return delegate.keyFor(subject);
+		}
+
+		@Override
+		public Optional<SecretKey> resolve ( KeyId key ) {
+			if ( denying ) {
+				throw new ShreddingException("a caller of the two-answer method cannot be told about a denial");
+			}
+			return delegate.resolve(key);
+		}
+
+		@Override
+		public KeyResolution resolveKey ( KeyId key ) {
+			if ( denying ) {
+				return new KeyResolution.Denied("simulated: this role is not granted key " + key);
+			}
+			return delegate.resolveKey(key);
+		}
+
+		@Override
+		public List<KeyId> shred ( DataSubject subject, ErasureReason reason ) {
+			return delegate.shred(subject, reason);
+		}
+
+	}
+
+	private static final class CountingProjection implements Projection<PaymentEvent> {
+
+		private int handled;
+		private int withheld;
+
+		@Override
+		public EventQuery eventQuery ( ) {
+			return EventQuery.matchAll();
+		}
+
+		@Override
+		public void when ( Event<PaymentEvent> event ) {
+			handled++;
+			switch ( event.data() ) {
+				case TransferMade t -> withheld += (t.from().isWithheld() ? 1 : 0) + (t.to().isWithheld() ? 1 : 0);
+				case StrictlyValidated v -> withheld += v.email().isWithheld() ? 1 : 0;
+				default -> { }
+			}
+		}
+
+	}
+
+	/** A name and an address under two categories, so a reader can be entitled to one and not the other. */
+	public record ContactRecorded ( String contactId, Shreddable<String> name, Shreddable<String> address ) implements PaymentEvent { }
 
 	/** A party to a transfer. Personal data, protected as a whole. */
 	public record PartyDetails ( String name, String iban ) { }


### PR DESCRIPTION
## Summary

Implements a third state in the shredding subsystem: `Withheld`. This allows readers without entitlement to decrypt personal data to read typed events and see which values they cannot access, rather than either failing with an exception or silently treating withheld data as erased.

## Key Changes

- **New `Shreddable.Withheld<T>` state**: A sealed subtype of `Shreddable` representing a value this reader is not entitled to. It carries the subject and key ID (like `Shredded`) but is neither present nor erased, and cannot be appended.

- **Three-answer seams on codec and key store**:
  - `ShreddingCodec.open(Sealed)`: Returns `Unsealed.Plaintext | Erased | Withheld` (default derives the first two from `unseal()` for backward compatibility)
  - `ShreddingKeyStore.resolveKey(KeyId)`: Returns `KeyResolution.Resolved | Erased | Denied` (default derives the first two from `resolve()`)

- **Category-restricted codec** (`CategoryRestrictedShreddingCodec`): Wraps any codec to handle only specified `DataSubject` categories. Withheld values are decided on the category in the clear envelope before any key lookup, so denied categories cost no key store traffic. Sealing is restricted symmetrically—a process configured not to handle a category cannot seal it either. Erasure and audit pass through unchanged.

- **Withholding codec** (`WithholdingShreddingCodec`): A singleton codec with no keys that withholds every protected value, allowing readers with no entitlement to personal data to still open typed event streams.

- **`ShreddingCodec.withholdingAll()`**: Factory method returning the singleton withholding codec.

- **`ShreddingCodec.restrictedTo(Set<String>)`**: Factory method wrapping the codec in a category restriction.

- **PostgreSQL key store enhancement**: `resolveKey()` override detects `insufficient_privilege` (SQLSTATE 42501) from column-level security and reports it as `Denied` rather than throwing, allowing readers with restricted database roles to see withheld values instead of projection failures.

- **Serialization support**: `ShreddableModule` updated to deserialize withheld values from sealed envelopes when the codec declines to unseal them.

- **Comprehensive TCK tests**: New test cases in `ShreddableEventDataTest` covering:
  - Reading with no keys (all values withheld)
  - Category-restricted readers (permitted categories readable, others withheld)
  - Withheld vs. erased distinction (withheld says nothing about erasure)
  - Symmetric restriction on sealing (append fails before storage)
  - Erasure through restricted codec (passes through unchanged)
  - Key store denial (hard boundary enforced by database role privileges)

## Implementation Details

- **Backward compatible**: Codecs and key stores written before this change keep working—the new three-answer methods have defaults deriving the older two-answer results, so they never deny.

- **Sealed types, not exceptions**: The distinction between erased, denied, and down is the most important contract in the shredding subsystem. Using sealed result types rather than exception subtypes forces callers to name which outcome they mean and prevents accidental swallowing of denials in retry loops.

- **Symmetric design**: A process configured not to handle a category cannot seal it either, making "the categories this process handles" a single configuration statement rather than two separate policies.

- **Erasure is not a read**: A restricted codec passes erasure through whole to the delegate, because an erasure that silently left another category readable while reporting success is the worst outcome an erasure can have.

- **Two composition points**: In-process category restriction (cheap, explicit in configuration) and key store refusal (hard boundary enforced by whatever holds the keys) compose—a restricted codec over a key store that also refuses gives the cheap answer for denied categories and the hard one for the rest.

https://claude.ai/code/session_01GDdQTwiNrjNfwVZ1W3aNTq