### PR TITLE
Add key-by-id lookup and category inventory to shredding audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1027,16 +1027,44 @@ ShreddingAudit audit = eventStore.shreddingAudit().orElseThrow();
 audit.totals();                                          // subjects with live keys, live keys, shredded keys
 audit.keys(KeyAuditQuery.forSubject("customer", "alice-42"));   // one person, every category
 audit.keys(KeyAuditQuery.all().onlyShredded());                 // the erasure log: what, when, on whose authority
+audit.categories();                                             // which categories exist, and how much under each
+audit.keys(KeyAuditQuery.forKeys(keysOnAnEvent));               // are the keys this event carries still live?
 ```
 
 - **`KeyRecord` carries no key material, and no method here returns any.** That separation is the whole
   reason this is a second interface rather than another method on the key store: a dashboard credential
   granted it can see *that* data is protected and *when* it was erased, and never *what* it was. The
   Postgres implementation does not merely refrain from reading `key_material` — the column is absent
-  from every statement it issues, so key bytes cannot reach a log or a heap dump through this path.
+  from every statement the audit issues, predicates included, so key bytes cannot reach a log or a heap
+  dump through this path. That absence is also what keeps the audit working for the reporting role the
+  postgres README recommends, which is granted every column *but* that one: PostgreSQL checks `SELECT`
+  privilege on every column a statement references, a `WHERE` or `FILTER` clause as much as the select
+  list, so "shredded" is judged by `shredded_at` — stamped by the same statement that nulls the material
+  — never by `key_material IS NULL`. `PostgresShreddingReportingRoleTest` pins every audit statement
+  under that role. The same privilege rule hides the column from `information_schema`, so such a role
+  starts its store with `DatabaseInitMode.NONE`; `VALIDATE` would report `key_material` as missing.
 - **Bounded, with no cursor.** `KeyAuditQuery` always carries a limit (default 500). A store running for
   years holds one row per subject per category and never prunes the shredded ones, and unlike an event
   query there is nothing to resume from — so an accidental full enumeration is not offered.
+- **`categories()` is the inventory: which categories of personal data the store holds, and how much
+  under each** (`CategoryTotals`: live subjects, live keys, shredded keys per category, most live
+  subjects first). A category is the unit of erasure *and* of access, and only the key store knows
+  which exist — writers choose them, and events carry them only inside sealed envelopes — so this is
+  what an operator reads before deciding which categories a service is `restrictedTo`. Deriving it
+  from `keys()` is wrong on any store holding more keys than the query's limit, which is why it is a
+  method rather than a recipe. An erased category stays listed with zero live keys and its erasures
+  counted. The default throws `UnsupportedOperationException`, like the optional SPI methods on
+  `EventStorage`, so an audit written before it compiles and a caller is told rather than shown an empty
+  inventory; the three shipped key stores all answer it.
+- **`KeyAuditQuery.forKeys(Set<KeyId>)` is the join back from an event.** An event carries its keys as
+  `dek:` tags and in each envelope, and nothing else; whether those keys still exist is the key store's
+  to say. A reader holding an event — a dashboard rendering it, a support tool — asks for exactly those
+  keys and can tell "protected" from "erased on … because …" without holding a key of its own. A
+  primary-key lookup on Postgres, however many keys a page of events carries; the limit defaults to the
+  number of keys asked for. It narrows the other parts rather than replacing them, an empty set is
+  refused (it could only mean "nothing"), and a key the store never held answers nothing rather than
+  failing — an envelope from another store is a miswiring the caller can see from the gap. The
+  five-argument constructor stays, meaning "any key".
 - **Which *events* hold data under a key is not answered here** — the key store has never seen an event.
   That is an ordinary tag query, since each event carries its keys as `dek:` tags:
   `EventQuery.forEvents(EventTypesFilter.any(), Tags.of(KeyId.TAG_KEY, record.id().value()))`.

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/KeyAuditQuery.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/KeyAuditQuery.java
@@ -17,6 +17,8 @@
  */
 package org.sliceworkz.eventstore.shredding;
 
+import java.util.Set;
+
 /**
  * Which keys a {@link ShreddingAudit} should report on.
  * <p>
@@ -27,7 +29,16 @@ package org.sliceworkz.eventstore.shredding;
  * KeyAuditQuery.all().onlyShredded()                     // the erasure log
  * KeyAuditQuery.forSubject("customer", "alice-42")       // one person, every category
  * KeyAuditQuery.all().withCategory("marketing")          // one retention category across subjects
+ * KeyAuditQuery.forKeys(keysOnAnEvent)                   // the keys an event carries as dek: tags
  * }</pre>
+ *
+ * <h2>By key id: the join back from an event</h2>
+ * An event says which keys its payload was sealed under — its {@code dek:} tags, and the envelope of
+ * each protected value — and nothing else. Whether those keys still exist is the key store's to say, so
+ * a reader that has an event in hand and wants to render "erased on …" rather than "protected" asks
+ * {@link #forKeys(Set)}. On a SQL key store that is a primary-key lookup. A key filter narrows the
+ * other parts rather than replacing them: under a subject filter it reports only the keys that satisfy
+ * both, and a key the store never held answers nothing rather than failing.
  *
  * <h2>Always bounded</h2>
  * The limit is not optional. A key store holds one row per subject per category and never prunes the
@@ -37,12 +48,13 @@ package org.sliceworkz.eventstore.shredding;
  * @param subjectType which kind of subject, or null for any
  * @param subjectId   which subject, or null for any; only meaningful together with a type
  * @param category    which retention category, or null for any
+ * @param keys        which keys, by id, or null for any; never empty
  * @param shreddedOnly report only keys whose material has been destroyed
  * @param limit       how many records at most
  *
  * @see ShreddingAudit#keys(KeyAuditQuery)
  */
-public record KeyAuditQuery ( String subjectType, String subjectId, String category, boolean shreddedOnly, int limit ) {
+public record KeyAuditQuery ( String subjectType, String subjectId, String category, Set<KeyId> keys, boolean shreddedOnly, int limit ) {
 
 	/**
 	 * How many records a query reports when it does not say.
@@ -50,7 +62,8 @@ public record KeyAuditQuery ( String subjectType, String subjectId, String categ
 	public static final int DEFAULT_LIMIT = 500;
 
 	/**
-	 * @throws IllegalArgumentException if the limit is not positive, or an id is given without a type
+	 * @throws IllegalArgumentException if the limit is not positive, an id is given without a type, or
+	 *                                  the key set is empty or holds a null
 	 */
 	public KeyAuditQuery {
 		if ( limit <= 0 ) {
@@ -59,13 +72,39 @@ public record KeyAuditQuery ( String subjectType, String subjectId, String categ
 		if ( subjectId != null && subjectType == null ) {
 			throw new IllegalArgumentException("a subjectId without a subjectType matches subjects of every type, which is never what is meant");
 		}
+		if ( keys != null ) {
+			if ( keys.isEmpty() ) {
+				throw new IllegalArgumentException("an empty key set matches nothing, which is never what is meant; use null for any key");
+			}
+			// a loop rather than contains(null): an immutable Set.of(...) throws on that call
+			for ( KeyId key : keys ) {
+				if ( key == null ) {
+					throw new IllegalArgumentException("KeyAuditQuery keys cannot contain null");
+				}
+			}
+			keys = Set.copyOf(keys);
+		}
+	}
+
+	/**
+	 * A query over every key, the shape every query had before keys could be named. Kept so a caller
+	 * building one from its parts need not know about the key filter.
+	 *
+	 * @param subjectType  which kind of subject, or null for any
+	 * @param subjectId    which subject, or null for any; only meaningful together with a type
+	 * @param category     which retention category, or null for any
+	 * @param shreddedOnly report only keys whose material has been destroyed
+	 * @param limit        how many records at most
+	 */
+	public KeyAuditQuery ( String subjectType, String subjectId, String category, boolean shreddedOnly, int limit ) {
+		this(subjectType, subjectId, category, null, shreddedOnly, limit);
 	}
 
 	/**
 	 * @return every key, newest first, up to {@link #DEFAULT_LIMIT}
 	 */
 	public static KeyAuditQuery all ( ) {
-		return new KeyAuditQuery(null, null, null, false, DEFAULT_LIMIT);
+		return new KeyAuditQuery(null, null, null, null, false, DEFAULT_LIMIT);
 	}
 
 	/**
@@ -74,7 +113,7 @@ public record KeyAuditQuery ( String subjectType, String subjectId, String categ
 	 * @return every key held for one data subject, in every category
 	 */
 	public static KeyAuditQuery forSubject ( String subjectType, String subjectId ) {
-		return new KeyAuditQuery(subjectType, subjectId, null, false, DEFAULT_LIMIT);
+		return new KeyAuditQuery(subjectType, subjectId, null, null, false, DEFAULT_LIMIT);
 	}
 
 	/**
@@ -82,7 +121,36 @@ public record KeyAuditQuery ( String subjectType, String subjectId, String categ
 	 * @return every key held for exactly that subject and category
 	 */
 	public static KeyAuditQuery forSubject ( DataSubject subject ) {
-		return new KeyAuditQuery(subject.type(), subject.id(), subject.category(), false, DEFAULT_LIMIT);
+		return new KeyAuditQuery(subject.type(), subject.id(), subject.category(), null, false, DEFAULT_LIMIT);
+	}
+
+	/**
+	 * The keys with these ids — typically the {@code dek:} tags of one event, or of a page of them.
+	 * <p>
+	 * The limit defaults to the number of keys asked for, since a key id names at most one record: a
+	 * caller asking about the keys on a page of events gets an answer for every one of them.
+	 *
+	 * @param keys which keys; must not be null or empty
+	 * @return every record for those keys, live or shredded
+	 * @throws IllegalArgumentException if the set is null or empty, or holds a null
+	 */
+	public static KeyAuditQuery forKeys ( Set<KeyId> keys ) {
+		if ( keys == null ) {
+			throw new IllegalArgumentException("KeyAuditQuery keys cannot be null; use all() for every key");
+		}
+		return new KeyAuditQuery(null, null, null, keys, false, Math.max(keys.size(), 1));
+	}
+
+	/**
+	 * @param key which key
+	 * @return the record for that key, live or shredded, as a one-element query
+	 * @throws IllegalArgumentException if the key is null
+	 */
+	public static KeyAuditQuery forKey ( KeyId key ) {
+		if ( key == null ) {
+			throw new IllegalArgumentException("KeyAuditQuery key cannot be null");
+		}
+		return forKeys(Set.of(key));
 	}
 
 	/**
@@ -90,14 +158,26 @@ public record KeyAuditQuery ( String subjectType, String subjectId, String categ
 	 * @return the same query narrowed to one category
 	 */
 	public KeyAuditQuery withCategory ( String category ) {
-		return new KeyAuditQuery(subjectType, subjectId, category, shreddedOnly, limit);
+		return new KeyAuditQuery(subjectType, subjectId, category, keys, shreddedOnly, limit);
+	}
+
+	/**
+	 * @param keys which keys, by id; must not be null or empty
+	 * @return the same query narrowed to those keys
+	 * @throws IllegalArgumentException if the set is null or empty, or holds a null
+	 */
+	public KeyAuditQuery withKeys ( Set<KeyId> keys ) {
+		if ( keys == null ) {
+			throw new IllegalArgumentException("KeyAuditQuery keys cannot be null; a query without a key filter is the same query");
+		}
+		return new KeyAuditQuery(subjectType, subjectId, category, keys, shreddedOnly, limit);
 	}
 
 	/**
 	 * @return the same query narrowed to destroyed keys — the erasure log
 	 */
 	public KeyAuditQuery onlyShredded ( ) {
-		return new KeyAuditQuery(subjectType, subjectId, category, true, limit);
+		return new KeyAuditQuery(subjectType, subjectId, category, keys, true, limit);
 	}
 
 	/**
@@ -105,7 +185,7 @@ public record KeyAuditQuery ( String subjectType, String subjectId, String categ
 	 * @return the same query with a different bound
 	 */
 	public KeyAuditQuery withLimit ( int limit ) {
-		return new KeyAuditQuery(subjectType, subjectId, category, shreddedOnly, limit);
+		return new KeyAuditQuery(subjectType, subjectId, category, keys, shreddedOnly, limit);
 	}
 
 }

--- a/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/ShreddingAudit.java
+++ b/sliceworkz-eventstore-api/src/main/java/org/sliceworkz/eventstore/shredding/ShreddingAudit.java
@@ -52,6 +52,10 @@ import java.util.Optional;
  * }
  * }</pre>
  *
+ * The other direction is answered here: an event carries its keys, and {@link KeyAuditQuery#forKeys}
+ * says whether those keys still exist, so a reader holding an event can tell "protected" from "erased"
+ * without a key of its own.
+ *
  * @see ShreddingKeyStore#audit()
  * @see KeyId#TAG_KEY
  */
@@ -77,6 +81,36 @@ public interface ShreddingAudit {
 	 * @throws ShreddingException if the key store cannot be reached
 	 */
 	ShreddingTotals totals ( );
+
+	/**
+	 * The same totals, broken down by {@link DataSubject#category() category}: which categories of
+	 * personal data this store holds at all, and how much sits under each.
+	 * <p>
+	 * A category is the unit of erasure and the unit of access — what {@code EventStore.erase} takes
+	 * and what a reader is granted through {@code ShreddingCodec.restrictedTo} — and nothing but the
+	 * key store knows which categories exist: they are chosen by whoever writes an event, and the
+	 * events carry them only inside sealed envelopes. So this is the inventory an operator reads before
+	 * deciding which categories each service may open, and the only way to learn a category name
+	 * without already knowing it. Computing it from {@link #keys} instead is wrong on any store that
+	 * holds more keys than the query's limit.
+	 * <p>
+	 * A category with no keys left at all cannot appear: erasure keeps the row, so a category every
+	 * key of which has been destroyed is reported with zero live keys rather than dropped.
+	 *
+	 * <p>
+	 * The shipped key stores all answer it. The default throws, as the optional SPI methods on
+	 * {@code EventStorage} do, so an audit written before it existed keeps compiling and a caller
+	 * learns that it cannot answer rather than reading an empty inventory as "no personal data here".
+	 *
+	 * @return one entry per category that holds or has held a key, most live subjects first, then by
+	 *         category name; never null
+	 * @throws ShreddingException if the key store cannot be reached
+	 * @throws UnsupportedOperationException if this audit cannot break its totals down by category
+	 */
+	default List<CategoryTotals> categories ( ) {
+		throw new UnsupportedOperationException(
+				"this ShreddingAudit (%s) does not report totals per category".formatted(getClass().getName()));
+	}
 
 	/**
 	 * One key, as far as anything that must not decrypt is allowed to see it.
@@ -137,5 +171,36 @@ public interface ShreddingAudit {
 	 * @param shreddedKeys         keys whose material has been destroyed
 	 */
 	record ShreddingTotals ( long subjectsWithLiveKeys, long liveKeys, long shreddedKeys ) { }
+
+	/**
+	 * The {@link ShreddingTotals} of one category.
+	 * <p>
+	 * Subjects are counted per {@code (type, id)} within the category, so a subject holding data in two
+	 * categories counts once in each — which is what "how many people's marketing data do we hold" asks.
+	 *
+	 * @param category             the {@link DataSubject#category() category}
+	 * @param subjectsWithLiveKeys distinct data subjects holding at least one key that still exists in it
+	 * @param liveKeys             keys in it that still exist
+	 * @param shreddedKeys         keys in it whose material has been destroyed
+	 */
+	record CategoryTotals ( String category, long subjectsWithLiveKeys, long liveKeys, long shreddedKeys ) {
+
+		/**
+		 * @throws IllegalArgumentException if the category is null or blank
+		 */
+		public CategoryTotals {
+			if ( category == null || category.isBlank() ) {
+				throw new IllegalArgumentException("CategoryTotals category must not be null or blank");
+			}
+		}
+
+		/**
+		 * @return the totals without the category, for a caller summing or comparing them
+		 */
+		public ShreddingTotals totals ( ) {
+			return new ShreddingTotals(subjectsWithLiveKeys, liveKeys, shreddedKeys);
+		}
+
+	}
 
 }

--- a/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/shredding/KeyAuditQueryTest.java
+++ b/sliceworkz-eventstore-api/src/test/java/org/sliceworkz/eventstore/shredding/KeyAuditQueryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.shredding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The shape of a key audit query: what narrows it, what it refuses, and that a query built the way
+ * queries were built before keys could be named still means the same thing.
+ */
+class KeyAuditQueryTest {
+
+	private static final KeyId K1 = KeyId.of("k-1");
+	private static final KeyId K2 = KeyId.of("k-2");
+
+	@Test
+	void forKeysNamesTheKeysAndBoundsTheAnswerAtTheirCount ( ) {
+		KeyAuditQuery query = KeyAuditQuery.forKeys(Set.of(K1, K2));
+
+		assertEquals(Set.of(K1, K2), query.keys());
+		assertNull(query.subjectType());
+		assertNull(query.subjectId());
+		assertNull(query.category());
+		assertTrue(!query.shreddedOnly());
+		// a key id names at most one record, so asking about n keys wants n answers, not the default 500
+		assertEquals(2, query.limit());
+
+		assertEquals(query, KeyAuditQuery.forKey(K1).withKeys(Set.of(K1, K2)).withLimit(2));
+	}
+
+	@Test
+	void theKeyFilterNarrowsTheOtherPartsInsteadOfReplacingThem ( ) {
+		KeyAuditQuery query = KeyAuditQuery.forSubject("customer", "alice-42").withCategory("marketing").onlyShredded().withKeys(Set.of(K1));
+
+		assertEquals("customer", query.subjectType());
+		assertEquals("alice-42", query.subjectId());
+		assertEquals("marketing", query.category());
+		assertTrue(query.shreddedOnly());
+		assertEquals(Set.of(K1), query.keys());
+		assertEquals(KeyAuditQuery.DEFAULT_LIMIT, query.limit());
+
+		// and every other narrowing keeps the key filter
+		assertEquals(Set.of(K1), query.withCategory("default").keys());
+		assertEquals(Set.of(K1), query.withLimit(7).keys());
+		assertEquals(Set.of(K1), query.onlyShredded().keys());
+	}
+
+	@Test
+	void anEmptyOrNullBearingKeySetIsRefusedRatherThanMatchingNothing ( ) {
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.forKeys(Set.of()));
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.forKeys(null));
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.forKey(null));
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.all().withKeys(Set.of()));
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.all().withKeys(null));
+
+		Set<KeyId> withNull = new HashSet<>();
+		withNull.add(K1);
+		withNull.add(null);
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.forKeys(withNull));
+	}
+
+	@Test
+	void theKeySetIsCopiedSoALaterChangeToTheCallersSetDoesNotReachTheQuery ( ) {
+		Set<KeyId> keys = new HashSet<>(Set.of(K1));
+		KeyAuditQuery query = KeyAuditQuery.forKeys(keys);
+		keys.add(K2);
+
+		assertEquals(Set.of(K1), query.keys());
+		assertThrows(UnsupportedOperationException.class, () -> query.keys().add(K2));
+	}
+
+	@Test
+	void aQueryBuiltWithoutAKeyFilterMeansEveryKey ( ) {
+		KeyAuditQuery fiveParts = new KeyAuditQuery("customer", "alice-42", "marketing", true, 10);
+
+		assertNull(fiveParts.keys());
+		assertEquals(new KeyAuditQuery("customer", "alice-42", "marketing", null, true, 10), fiveParts);
+		assertNull(KeyAuditQuery.all().keys());
+		assertNull(KeyAuditQuery.forSubject(DataSubject.of("customer", "alice-42")).keys());
+	}
+
+	@Test
+	void theOlderRefusalsStillHold ( ) {
+		assertThrows(IllegalArgumentException.class, () -> KeyAuditQuery.all().withLimit(0));
+		assertThrows(IllegalArgumentException.class, () -> new KeyAuditQuery(null, "alice-42", null, null, false, 1));
+	}
+
+}

--- a/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/shredding/InMemoryShreddingKeyStore.java
+++ b/sliceworkz-eventstore-infra-inmem/src/main/java/org/sliceworkz/eventstore/infra/inmem/shredding/InMemoryShreddingKeyStore.java
@@ -196,8 +196,42 @@ public class InMemoryShreddingKeyStore implements ShreddingKeyStore {
 			}
 		}
 
+		@Override
+		public List<CategoryTotals> categories ( ) {
+			synchronized ( InMemoryShreddingKeyStore.this ) {
+				// insertion order of first sight, then re-sorted as the contract says: most live
+				// subjects first, category name as the tie-breaker
+				Map<String, long[]> counts = new LinkedHashMap<>();
+				Map<String, java.util.Set<String>> liveSubjects = new java.util.HashMap<>();
+				for ( StoredKey stored : keys.values() ) {
+					String category = stored.subject().category();
+					long[] count = counts.computeIfAbsent(category, c -> new long[2]);
+					if ( stored.isShredded() ) {
+						count[1]++;
+					} else {
+						count[0]++;
+						liveSubjects.computeIfAbsent(category, c -> new java.util.HashSet<>())
+								.add(stored.subject().type() + "/" + stored.subject().id());
+					}
+				}
+				List<CategoryTotals> categories = new ArrayList<>();
+				counts.forEach(( category, count ) -> categories.add(new CategoryTotals(
+						category,
+						liveSubjects.getOrDefault(category, java.util.Set.of()).size(),
+						count[0],
+						count[1])));
+				categories.sort(java.util.Comparator
+						.comparingLong(CategoryTotals::subjectsWithLiveKeys).reversed()
+						.thenComparing(CategoryTotals::category));
+				return List.copyOf(categories);
+			}
+		}
+
 		private boolean matches ( StoredKey stored, KeyAuditQuery query ) {
 			if ( query.shreddedOnly() && !stored.isShredded() ) {
+				return false;
+			}
+			if ( query.keys() != null && !query.keys().contains(stored.id()) ) {
 				return false;
 			}
 			DataSubject subject = stored.subject();

--- a/sliceworkz-eventstore-infra-postgres/README.md
+++ b/sliceworkz-eventstore-infra-postgres/README.md
@@ -85,7 +85,16 @@ GRANT SELECT (key_id, subject_type, subject_id, subject_category, created_at, sh
 
 Resolving a key under that role fails with `insufficient_privilege`, which the key store reports as a
 denial rather than an outage: every protected value reads as `Shreddable.Withheld`, projections
-advance, and the audit still works since it never selects `key_material`. This is the database-enforced
+advance, and the audit still works. That last part rests on a detail of PostgreSQL worth knowing when
+writing anything else against this table: `SELECT` privilege is checked on *every* column a statement
+references, in a `WHERE` or `FILTER` clause as much as in the select list. The audit therefore never
+mentions `key_material` at all and judges "shredded" by `shredded_at`, which an erasure stamps in the
+same statement; a predicate on `key_material IS NULL` would fail the whole audit for exactly this role.
+`PostgresShreddingReportingRoleTest` pins both halves — every key denied, every audit statement
+answered — per supported version. One consequence for how such a role *starts* its store: the
+`information_schema` shows a role only the columns it has a privilege on, so schema validation would
+report `key_material` as missing. A store opened by the reporting role therefore uses
+`DatabaseInitMode.NONE`, which is the production recommendation anyway. This is the database-enforced
 boundary, and it is all-or-nothing per role. Per-category entitlement — a service that reads names
 and never addresses — is declared on the codec with `ShreddingCodec.restrictedTo(...)`, which decides
 on the category in the envelope and never reaches the table for a denied one. Row-level security on

--- a/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/shredding/PostgresShreddingKeyStore.java
+++ b/sliceworkz-eventstore-infra-postgres/src/main/java/org/sliceworkz/eventstore/infra/postgres/shredding/PostgresShreddingKeyStore.java
@@ -413,9 +413,14 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 					 WHERE 1 = 1
 					""".formatted(tableName));
 
+			// Every predicate here is on a column the reporting role is granted. "Shredded" is judged on
+			// shredded_at, never on key_material IS NULL: PostgreSQL checks SELECT privilege on every
+			// column a statement references, a WHERE or FILTER clause included, so a predicate on
+			// key_material would fail the whole audit for the role the README recommends -- the one
+			// granted every column but that one. The two are always stamped together by shred().
 			List<String> parameters = new ArrayList<>();
 			if ( query.shreddedOnly() ) {
-				sql.append(" AND key_material IS NULL");
+				sql.append(" AND shredded_at IS NOT NULL");
 			}
 			if ( query.subjectType() != null ) {
 				sql.append(" AND subject_type = ?");
@@ -429,6 +434,10 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 				sql.append(" AND subject_category = ?");
 				parameters.add(query.category());
 			}
+			if ( query.keys() != null ) {
+				// a primary-key lookup, however many keys a page of events carries
+				sql.append(" AND key_id = ANY(?)");
+			}
 			// key_id breaks the tie so that paging is stable when several keys share a creation instant,
 			// which two subjects minted inside one append genuinely do.
 			sql.append(" ORDER BY created_at DESC, key_id DESC LIMIT ?");
@@ -439,6 +448,10 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 				int index = 1;
 				for ( String parameter : parameters ) {
 					statement.setString(index++, parameter);
+				}
+				if ( query.keys() != null ) {
+					String[] keyIds = query.keys().stream().map(KeyId::value).toArray(String[]::new);
+					statement.setArray(index++, connection.createArrayOf("text", keyIds));
 				}
 				statement.setInt(index, query.limit());
 
@@ -460,11 +473,13 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 			// One pass over the table rather than three: the counts are always reported together, and the
 			// live-subject count has to see the same snapshot as the key counts or the summary contradicts
 			// itself while an erasure is running.
+			// Live is judged on shredded_at, not on key_material: see keys() for why the audit must not
+			// reference that column at all.
 			String sql = """
-					SELECT count(*) FILTER (WHERE key_material IS NOT NULL) AS live_keys,
-					       count(*) FILTER (WHERE key_material IS NULL) AS shredded_keys,
+					SELECT count(*) FILTER (WHERE shredded_at IS NULL) AS live_keys,
+					       count(*) FILTER (WHERE shredded_at IS NOT NULL) AS shredded_keys,
 					       count(DISTINCT (subject_type, subject_id, subject_category))
-					           FILTER (WHERE key_material IS NOT NULL) AS live_subjects
+					           FILTER (WHERE shredded_at IS NULL) AS live_subjects
 					  FROM %s
 					""".formatted(tableName);
 
@@ -482,6 +497,40 @@ public class PostgresShreddingKeyStore implements ShreddingKeyStore {
 
 			} catch (SQLException e) {
 				throw new ShreddingException("failed to summarise the shredding keys in %s".formatted(tableName), e);
+			}
+		}
+
+		@Override
+		public List<CategoryTotals> categories ( ) {
+			// The same pass as totals(), grouped. One row per subject per category makes this a scan of
+			// the key table, which totals() already is; a store for which that is too slow has more
+			// categories than anyone can read off a screen anyway.
+			String sql = """
+					SELECT subject_category,
+					       count(*) FILTER (WHERE shredded_at IS NULL) AS live_keys,
+					       count(*) FILTER (WHERE shredded_at IS NOT NULL) AS shredded_keys,
+					       count(DISTINCT (subject_type, subject_id)) FILTER (WHERE shredded_at IS NULL) AS live_subjects
+					  FROM %s
+					 GROUP BY subject_category
+					 ORDER BY live_subjects DESC, subject_category ASC
+					""".formatted(tableName);
+
+			try ( Connection connection = dataSource.getConnection();
+					PreparedStatement statement = connection.prepareStatement(sql);
+					ResultSet resultSet = statement.executeQuery() ) {
+
+				List<CategoryTotals> categories = new ArrayList<>();
+				while ( resultSet.next() ) {
+					categories.add(new CategoryTotals(
+							resultSet.getString("subject_category"),
+							resultSet.getLong("live_subjects"),
+							resultSet.getLong("live_keys"),
+							resultSet.getLong("shredded_keys")));
+				}
+				return List.copyOf(categories);
+
+			} catch (SQLException e) {
+				throw new ShreddingException("failed to summarise the shredding keys in %s by category".formatted(tableName), e);
 			}
 		}
 

--- a/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/shredding/PostgresShreddingReportingRoleTest.java
+++ b/sliceworkz-eventstore-infra-postgres/src/test/java/org/sliceworkz/eventstore/infra/postgres/shredding/PostgresShreddingReportingRoleTest.java
@@ -1,0 +1,200 @@
+/*
+ * Sliceworkz Eventstore - a Java/Postgres DCB Eventstore implementation
+ * Copyright © 2025-2026 Sliceworkz / XTi (info@sliceworkz.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.sliceworkz.eventstore.infra.postgres.shredding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sliceworkz.eventstore.infra.postgres.PostgresEventStorage;
+import org.sliceworkz.eventstore.infra.postgres.util.PostgresContainer;
+import org.sliceworkz.eventstore.shredding.AesGcmShreddingCodec;
+import org.sliceworkz.eventstore.shredding.DataSubject;
+import org.sliceworkz.eventstore.shredding.ErasureReason;
+import org.sliceworkz.eventstore.shredding.KeyAuditQuery;
+import org.sliceworkz.eventstore.shredding.KeyId;
+import org.sliceworkz.eventstore.shredding.ShreddingAudit;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec.Sealed;
+import org.sliceworkz.eventstore.shredding.ShreddingCodec.Unsealed;
+import org.sliceworkz.eventstore.shredding.ShreddingException;
+import org.sliceworkz.eventstore.shredding.ShreddingKeyStore;
+import org.sliceworkz.eventstore.shredding.ShreddingKeyStore.KeyResolution;
+import org.sliceworkz.eventstore.spi.EventStorage;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * The reporting role the module README recommends — granted every column of the key table except
+ * {@code key_material} — really does get what the README promises: a denial for every key, and a
+ * working audit.
+ * <p>
+ * The audit half is the one worth a test of its own, because it is easy to break without noticing.
+ * PostgreSQL checks {@code SELECT} privilege on <em>every</em> column a statement references, a
+ * {@code WHERE} or {@code FILTER} clause included, not only the columns it returns. So an audit
+ * statement that judged "shredded" by {@code key_material IS NULL} would fail for exactly this role
+ * with the same {@code insufficient_privilege} the key lookup gets — and since the audit reports that
+ * as a {@link ShreddingException}, an operations screen would render "the key store cannot be
+ * reached" for a store that is perfectly healthy. The audit therefore judges on {@code shredded_at},
+ * which {@code shred()} stamps in the same statement, and this pins it for every statement it issues.
+ * <p>
+ * Runs in the shared database under its own table prefix; the role is cluster-wide and named for
+ * this test.
+ */
+public class PostgresShreddingReportingRoleTest {
+
+	private static final String PASSWORD = "pwd";
+	private static final String PREFIX = "reprole_";
+	private static final String ROLE = "shredding_reporting_role";
+
+	private static final DataSubject ALICE = DataSubject.of("customer", "alice-42");
+	private static final DataSubject BOB_MARKETING = DataSubject.of("customer", "bob-77").withCategory("marketing");
+
+	abstract static class Tests {
+
+		final String image;
+
+		Tests ( String image ) {
+			this.image = image;
+		}
+
+		@Test
+		public void testTheReportingRoleIsDeniedEveryKeyAndCanStillAudit ( ) throws Exception {
+			DataSource application = PostgresContainer.dataSource(image);
+
+			// the application role: creates the schema, mints two keys, erases one
+			KeyId alicesKey;
+			KeyId bobsKey;
+			Sealed alicesValue;
+			try ( EventStorage schema = PostgresEventStorage.newBuilder()
+					.name("reporting-schema").prefix(PREFIX).dataSource(application).initializeDatabase().build();
+				  ShreddingKeyStore applicationKeys = PostgresShreddingKeyStore.on(application, PREFIX);
+				  ShreddingCodec applicationCodec = AesGcmShreddingCodec.over(applicationKeys) ) {
+				alicesValue = applicationCodec.seal("\"Alice Martin\"", ALICE);
+				alicesKey = alicesValue.key();
+				bobsKey = applicationCodec.seal("\"Bob Jansen\"", BOB_MARKETING).key();
+				applicationCodec.shred(BOB_MARKETING, ErasureReason.of("marketing consent withdrawn"));
+			}
+
+			// the reporting role, granted as the README says
+			PostgresContainer.createRole(image, ROLE, PASSWORD);
+			PostgresContainer.asSuperuser(image, statement -> statement.execute(
+					"GRANT SELECT (key_id, subject_type, subject_id, subject_category, created_at, shredded_at, shredded_reason) ON "
+							+ PREFIX + "shredding_keys TO " + ROLE));
+
+			try ( HikariDataSource reporting = PostgresContainer.dataSource(image, "integration-tests-db", ROLE, PASSWORD);
+				  ShreddingKeyStore reportingKeys = new PostgresShreddingKeyStore(reporting, PREFIX, Duration.ZERO);
+				  ShreddingCodec reportingCodec = AesGcmShreddingCodec.over(reportingKeys) ) {
+
+				// the denial: not an outage, and not an erasure -- a live key and a destroyed one read the
+				// same to a role that may not see the column that tells them apart
+				assertInstanceOf(KeyResolution.Denied.class, reportingKeys.resolveKey(alicesKey));
+				assertInstanceOf(KeyResolution.Denied.class, reportingKeys.resolveKey(bobsKey));
+				assertInstanceOf(Unsealed.Withheld.class, reportingCodec.open(alicesValue));
+				// the two-answer method cannot say "denied" and must not say "erased"
+				assertThrows(ShreddingException.class, () -> reportingKeys.resolve(alicesKey));
+
+				// the audit, every statement of it
+				ShreddingAudit audit = reportingKeys.audit().orElseThrow();
+				assertEquals(new ShreddingAudit.ShreddingTotals(1, 1, 1), audit.totals());
+				assertEquals(List.of(
+						new ShreddingAudit.CategoryTotals("default", 1, 1, 0),
+						new ShreddingAudit.CategoryTotals("marketing", 0, 0, 1)),
+						audit.categories());
+
+				assertEquals(2, audit.keys(KeyAuditQuery.all()).size());
+
+				List<ShreddingAudit.KeyRecord> erasures = audit.keys(KeyAuditQuery.all().onlyShredded());
+				assertEquals(1, erasures.size());
+				assertEquals(bobsKey, erasures.getFirst().id());
+				assertEquals(Optional.of(ErasureReason.of("marketing consent withdrawn")), erasures.getFirst().reason());
+
+				List<ShreddingAudit.KeyRecord> byKey = audit.keys(KeyAuditQuery.forKeys(Set.of(alicesKey, bobsKey)));
+				assertEquals(2, byKey.size());
+				assertEquals(List.of(bobsKey),
+						byKey.stream().filter(ShreddingAudit.KeyRecord::isShredded).map(ShreddingAudit.KeyRecord::id).toList());
+
+				assertEquals(1, audit.keys(KeyAuditQuery.forSubject(ALICE)).size());
+				assertEquals(1, audit.keys(KeyAuditQuery.all().withCategory("marketing")).size());
+			}
+		}
+	}
+
+	@Nested
+	class OnPostgres16 extends Tests {
+
+		OnPostgres16 ( ) { super(PostgresContainer.IMAGE_PG16); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG16);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG16);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG16);
+		}
+	}
+
+	@Nested
+	class OnPostgres17 extends Tests {
+
+		OnPostgres17 ( ) { super(PostgresContainer.IMAGE_PG17); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG17);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG17);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG17);
+		}
+	}
+
+	@Nested
+	class OnPostgres18 extends Tests {
+
+		OnPostgres18 ( ) { super(PostgresContainer.IMAGE_PG18); }
+
+		@BeforeAll
+		public static void setUpBeforeAll ( ) {
+			PostgresContainer.start(PostgresContainer.IMAGE_PG18);
+		}
+
+		@AfterAll
+		public static void tearDownAfterAll ( ) {
+			PostgresContainer.stop(PostgresContainer.IMAGE_PG18);
+			PostgresContainer.cleanup(PostgresContainer.IMAGE_PG18);
+		}
+	}
+
+}

--- a/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/ShreddableEventDataTest.java
+++ b/sliceworkz-eventstore-testing/src/main/java/org/sliceworkz/eventstore/testing/tck/stream/ShreddableEventDataTest.java
@@ -365,6 +365,84 @@ public class ShreddableEventDataTest extends AbstractEventStoreTest {
 		assertEquals(2, audit(store).keys(KeyAuditQuery.all().withLimit(2)).size());
 	}
 
+	/**
+	 * The category inventory: which categories of personal data the store holds, and how much under
+	 * each. A category is what an erasure takes and what a reader is granted, and only the key store
+	 * knows which ones exist -- the events carry them inside sealed envelopes -- so this is what an
+	 * operator reads before deciding which categories a service may open.
+	 */
+	@ForEachBackend
+	void theAuditBreaksItsTotalsDownByCategory ( ) {
+		EventStore store = eventStoreWithShredding();
+		EventStream<PaymentEvent> payments = store.getEventStream(STREAM, PaymentEvent.class);
+
+		DataSubject marketing = ALICE.withCategory("marketing");
+		payments.append(AppendCriteria.none(), Event.of(
+				new StrictlyValidated("v-1", Shreddable.of("alice@example.org", marketing)), Tags.none()));
+		payments.append(AppendCriteria.none(), Event.of(transfer(), Tags.none()));
+
+		// default: Alice and Bob; marketing: Alice only. Most live subjects first.
+		assertEquals(List.of(
+				new ShreddingAudit.CategoryTotals("default", 2, 2, 0),
+				new ShreddingAudit.CategoryTotals("marketing", 1, 1, 0)),
+				audit(store).categories());
+
+		store.erase(marketing, ErasureReason.of("marketing consent withdrawn"));
+
+		// an erased category stays in the inventory with its erasure counted, rather than vanishing --
+		// "we held marketing data and destroyed it" is exactly what the inventory is for
+		assertEquals(List.of(
+				new ShreddingAudit.CategoryTotals("default", 2, 2, 0),
+				new ShreddingAudit.CategoryTotals("marketing", 0, 0, 1)),
+				audit(store).categories());
+
+		// and the breakdown sums to the totals
+		ShreddingAudit.ShreddingTotals totals = audit(store).totals();
+		assertEquals(totals.liveKeys(), audit(store).categories().stream().mapToLong(ShreddingAudit.CategoryTotals::liveKeys).sum());
+		assertEquals(totals.shreddedKeys(), audit(store).categories().stream().mapToLong(ShreddingAudit.CategoryTotals::shreddedKeys).sum());
+	}
+
+	/**
+	 * The join back from an event to the key store. An event says which keys it was sealed under and
+	 * nothing else; a reader holding one -- a dashboard rendering it, a support tool -- asks the audit
+	 * for exactly those keys to tell "protected" from "erased", without a key of its own.
+	 */
+	@ForEachBackend
+	void theKeysAnEventCarriesCanBeLookedUpToTellProtectedFromErased ( ) {
+		EventStore store = eventStoreWithShredding();
+		EventStream<PaymentEvent> payments = store.getEventStream(STREAM, PaymentEvent.class);
+
+		Event<PaymentEvent> stored = payments.append(AppendCriteria.none(), Event.of(transfer(), Tags.none())).getFirst();
+		Set<KeyId> keysOnTheEvent = stored.tags().tags().stream()
+				.filter(tag -> KeyId.TAG_KEY.equals(tag.key()))
+				.map(tag -> KeyId.of(tag.value()))
+				.collect(java.util.stream.Collectors.toSet());
+		assertEquals(2, keysOnTheEvent.size(), "two subjects, two keys");
+
+		List<ShreddingAudit.KeyRecord> records = audit(store).keys(KeyAuditQuery.forKeys(keysOnTheEvent));
+		assertEquals(keysOnTheEvent, records.stream().map(ShreddingAudit.KeyRecord::id).collect(java.util.stream.Collectors.toSet()));
+		assertTrue(records.stream().noneMatch(ShreddingAudit.KeyRecord::isShredded));
+
+		store.erase(ALICE, ErasureReason.of("GDPR art.17 request #4711"));
+
+		// the same lookup now says which of the two is gone, and whose it was
+		records = audit(store).keys(KeyAuditQuery.forKeys(keysOnTheEvent));
+		assertEquals(2, records.size());
+		List<ShreddingAudit.KeyRecord> erased = records.stream().filter(ShreddingAudit.KeyRecord::isShredded).toList();
+		assertEquals(1, erased.size());
+		assertEquals(ALICE, erased.getFirst().subject());
+		assertEquals(Optional.of(ErasureReason.of("GDPR art.17 request #4711")), erased.getFirst().reason());
+
+		// the key filter composes with the others rather than replacing them
+		assertEquals(1, audit(store).keys(KeyAuditQuery.forKeys(keysOnTheEvent).onlyShredded()).size());
+		assertEquals(1, audit(store).keys(KeyAuditQuery.forSubject(BOB).withKeys(keysOnTheEvent)).size());
+		assertEquals(0, audit(store).keys(KeyAuditQuery.forSubject(BOB).withKeys(keysOnTheEvent).onlyShredded()).size());
+
+		// a key this store never held answers nothing, rather than failing: an envelope from another
+		// store is a miswiring the caller can see from an empty answer
+		assertEquals(List.of(), audit(store).keys(KeyAuditQuery.forKey(KeyId.of("k-never-minted-here"))));
+	}
+
 	// ---- who may read what: withheld is a third state, decided on the key seams -------------------------
 
 	/**


### PR DESCRIPTION
## Summary

Extends the shredding audit API to support two new query patterns: looking up specific keys by their IDs (the join back from an event to the key store), and breaking down audit totals by retention category (the inventory of what personal data the store holds).

## Key Changes

- **`KeyAuditQuery` now supports filtering by key ID**: Added `forKeys(Set<KeyId>)` and `forKey(KeyId)` factory methods to query the audit for specific keys — typically the `dek:` tags an event carries. The key filter composes with other filters (subject, category, shredded-only) rather than replacing them. Defaults the limit to the number of keys requested, since a key ID names at most one record.

- **`ShreddingAudit` now reports category inventory**: Added `categories()` method returning `List<CategoryTotals>`, breaking down the totals by `DataSubject.category()`. This is the only way to learn which categories exist without already knowing them, since events carry categories only inside sealed envelopes. Sorted by live subjects descending, then category name.

- **PostgreSQL audit statements no longer reference `key_material`**: Changed shredding state judgment from `key_material IS NULL` to `shredded_at IS NOT NULL` in both `keys()` and `totals()` queries. This is essential for the reporting role the README recommends (granted every column *except* `key_material`): PostgreSQL checks `SELECT` privilege on every column a statement references, including `WHERE` and `FILTER` clauses, so a predicate on `key_material` would fail the entire audit for that role with `insufficient_privilege`. The two columns are always stamped together by `shred()`, so the change is semantically equivalent.

- **Added `PostgresShreddingReportingRoleTest`**: Comprehensive test verifying that the reporting role (granted `SELECT` on all columns except `key_material`) correctly denies every key lookup while still supporting the full audit API, including the new category inventory and key-by-id queries. Runs against PostgreSQL 16, 17, and 18.

- **Updated in-memory and API implementations**: `InMemoryShreddingKeyStore` now implements `categories()`, and `KeyAuditQuery` record signature updated to include the optional `keys` field (with a backward-compatible constructor for the five-parameter form).

## Notable Implementation Details

- The key filter is stored as an immutable copy of the input set, validated to reject null or empty sets (which would match nothing, never the intent).
- Category totals count distinct `(subject_type, subject_id)` pairs per category, so a subject holding data in two categories counts once in each.
- The `categories()` method is a `default` on the interface that throws `UnsupportedOperationException`, allowing older audit implementations to keep compiling while signaling they cannot answer the query.
- All audit statements under the reporting role are pinned by `PostgresShreddingReportingRoleTest`, ensuring the implementation cannot regress into referencing `key_material`.

https://claude.ai/code/session_01NMhfpMjYvRkRzQ6DVoiqKT